### PR TITLE
TAJO-882: CLI hangs when a error occurs in the GlobalPlanner.

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/utils/test/ErrorInjectionRewriter.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/utils/test/ErrorInjectionRewriter.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.engine.utils.test;
+
+import org.apache.tajo.engine.planner.LogicalPlan;
+import org.apache.tajo.engine.planner.PlanningException;
+import org.apache.tajo.engine.planner.rewrite.RewriteRule;
+
+public class ErrorInjectionRewriter implements RewriteRule {
+  @Override
+  public String getName() {
+    return "ErrorInjectionRewriter";
+  }
+
+  @Override
+  public boolean isEligible(LogicalPlan plan) {
+    return true;
+  }
+
+  @Override
+  public LogicalPlan rewrite(LogicalPlan plan) throws PlanningException {
+    throw new NullPointerException();
+  }
+}

--- a/tajo-core/src/main/java/org/apache/tajo/master/querymaster/QueryMasterTask.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/querymaster/QueryMasterTask.java
@@ -496,6 +496,10 @@ public class QueryMasterTask extends CompositeService {
     }
   }
 
+  public Throwable getInitError() {
+    return initError;
+  }
+
   public String getErrorMessage() {
     if (isInitError()) {
       return StringUtils.stringifyException(initError);

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorkerClientService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorkerClientService.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.AbstractService;
+import org.apache.hadoop.util.StringUtils;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.QueryIdFactory;
 import org.apache.tajo.TajoIdProtos;
@@ -209,6 +210,14 @@ public class TajoWorkerClientService extends AbstractService {
           TajoWorkerProtocol.TaskFatalErrorReport firstError = diagnostics.iterator().next();
           builder.setErrorMessage(firstError.getErrorMessage());
           builder.setErrorTrace(firstError.getErrorTrace());
+        }
+
+        if (queryMasterTask.isInitError()) {
+          Throwable initError = queryMasterTask.getInitError();
+          builder.setErrorMessage(
+              initError.getMessage() == null ? initError.getClass().getName() : initError.getMessage());
+          builder.setErrorTrace(StringUtils.stringifyException(initError));
+          builder.setState(queryMasterTask.getState());
         }
       }
       return builder.build();

--- a/tajo-core/src/test/java/org/apache/tajo/TajoTestingCluster.java
+++ b/tajo-core/src/test/java/org/apache/tajo/TajoTestingCluster.java
@@ -617,6 +617,10 @@ public class TajoTestingCluster {
 
   public void setAllTajoDaemonConfValue(String key, String value) {
     tajoMaster.getContext().getConf().set(key, value);
+    setAllWorkersConfValue(key, value);
+  }
+
+  public void setAllWorkersConfValue(String key, String value) {
     for (TajoWorker eachWorker: tajoWorkers) {
       eachWorker.getConfig().set(key, value);
     }


### PR DESCRIPTION
I added a ErrorInjectionRewriter which throws NullPointerException.
You can inject a error status using the following code.

```
try {
  // Inject in LogicalPlanner
  //testingCluster.setAllTajoDaemonConfValue(("tajo.plan.rewriter.classes",
  //      ErrorInjectionRewriter.class.getCanonicalName());

  //  Inject in PhysicalPlanner
  testingCluster.setAllWorkersConfValue("tajo.plan.rewriter.classes",
        ErrorInjectionRewriter.class.getCanonicalName());
} finally {
  // testingCluster.setAllTajoDaemonConfValue("tajo.plan.rewriter.classes", "");
  testingCluster.setAllWorkersConfValue("tajo.plan.rewriter.classes", "");
}
```
