### PR TITLE
TAJO-905: When to_date() parses some date without day, the result will b...

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -74,6 +74,9 @@ Release 0.9.0 - unreleased
 
   BUG FIXES
 
+    TAJO-905: When to_date() parses some date without day, the result will be 
+    wrong. (hyunsik)
+
     TAJO-891: Complex join conditions with UNION or inline should be supported.
     (hyunsik)
     

--- a/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeFormat.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeFormat.java
@@ -596,6 +596,11 @@ public class DateTimeFormat {
     //TODO consider TimeZone
     doToTimestamp(dateText, formatText, tm);
 
+    // when we parse some date without day like '2014-04', we should set day to 1.
+    if (tm.dayOfMonth == 0) {
+      tm.dayOfMonth = 1;
+    }
+
     if (tm.dayOfYear > 0 && tm.dayOfMonth > 0) {
       tm.dayOfYear = 0;
     }

--- a/tajo-core/src/test/java/org/apache/tajo/engine/function/TestDateTimeFunctions.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/function/TestDateTimeFunctions.java
@@ -312,6 +312,8 @@ public class TestDateTimeFunctions extends ExprTestBase {
     testSimpleEval("select to_date('2014-01-04', 'YYYY-MM-DD')", new String[]{"2014-01-04"});
     testSimpleEval("select to_date('2014-01-04', 'YYYY-MM-DD') + interval '1 day'",
         new String[]{"2014-01-05 00:00:00" + getUserTimeZoneDisplay()});
+
+    testSimpleEval("SELECT to_date('201404', 'yyyymm');", new String[]{"2014-04-01"});
   }
 
   @Test


### PR DESCRIPTION
...e wrong.
