### PR TITLE
TAJO-936: TestStorages::testSplitable is failed occasionally.

### DIFF
--- a/tajo-storage/src/main/java/org/apache/tajo/storage/rcfile/RCFile.java
+++ b/tajo-storage/src/main/java/org/apache/tajo/storage/rcfile/RCFile.java
@@ -1380,6 +1380,7 @@ public class RCFile {
 
       in.readFully(sync); // read sync bytes
       headerEnd = in.getPos();
+      lastSeenSyncPos = headerEnd; //initial sync position
       readBytes += headerEnd;
     }
 


### PR DESCRIPTION
if a split end position is less than the header size, it read twice
