### PR TITLE
TAJO-953: RawFile should release a DirectBuffer immediately

### DIFF
--- a/tajo-storage/src/main/java/org/apache/tajo/storage/RawFile.java
+++ b/tajo-storage/src/main/java/org/apache/tajo/storage/RawFile.java
@@ -33,7 +33,6 @@ import org.apache.tajo.datum.NullDatum;
 import org.apache.tajo.datum.ProtobufDatumFactory;
 import org.apache.tajo.storage.fragment.FileFragment;
 import org.apache.tajo.util.BitArray;
-import sun.nio.ch.DirectBuffer;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -381,11 +380,7 @@ public class RawFile {
         tableStats.setNumRows(recordCount);
       }
 
-      if(buffer.isDirect()){
-        ((DirectBuffer) buffer).cleaner().clean();
-      } else {
-        buffer.clear();
-      }
+      StorageUtil.closeBuffer(buffer);
       IOUtils.cleanup(LOG, channel, fis);
     }
 
@@ -727,11 +722,7 @@ public class RawFile {
         LOG.debug("RawFileAppender written: " + getOffset() + " bytes, path: " + path);
       }
 
-      if(buffer.isDirect()){
-        ((DirectBuffer) buffer).cleaner().clean();
-      } else {
-        buffer.clear();
-      }
+      StorageUtil.closeBuffer(buffer);
       IOUtils.cleanup(LOG, channel, randomAccessFile);
     }
 

--- a/tajo-storage/src/main/java/org/apache/tajo/storage/StorageUtil.java
+++ b/tajo-storage/src/main/java/org/apache/tajo/storage/StorageUtil.java
@@ -23,17 +23,21 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.tajo.catalog.*;
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.catalog.Schema;
+import org.apache.tajo.catalog.TableMeta;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.util.FileUtil;
 import org.apache.tajo.util.KeyValueSet;
 import parquet.hadoop.ParquetOutputFormat;
+import sun.nio.ch.DirectBuffer;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-public class StorageUtil extends StorageConstants{
+public class StorageUtil extends StorageConstants {
   public static int getRowByteSize(Schema schema) {
     int sum = 0;
     for(Column col : schema.getColumns()) {
@@ -183,6 +187,16 @@ public class StorageUtil extends StorageConstants{
       return Integer.parseInt(pathTokens[3]);
     } else {
       return -1;
+    }
+  }
+
+  public static void closeBuffer(ByteBuffer buffer) {
+    if (buffer != null) {
+      if (buffer.isDirect()) {
+        ((DirectBuffer) buffer).cleaner().clean();
+      } else {
+        buffer.clear();
+      }
     }
   }
 }


### PR DESCRIPTION
RawFile allocated memory is a native DirectBuffer. This memory will be freed when the finalize method is called by gc
