### PR TITLE
TAJO-1009: A binary eval for column references of the same tables should...

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/eval/EvalTreeUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/eval/EvalTreeUtil.java
@@ -20,6 +20,8 @@ package org.apache.tajo.engine.eval;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.sun.org.apache.xml.internal.resolver.Catalog;
+import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.common.TajoDataTypes.DataType;
@@ -233,12 +235,23 @@ public class EvalTreeUtil {
   /**
    * If a given expression is join condition, it returns TRUE. Otherwise, it returns FALSE.
    *
+   * If three conditions are satisfied, we can recognize the expression as a equi join condition.
+   * <ol>
+   *   <li>An expression is an equal comparison expression.</li>
+   *   <li>Both terms in an expression are column references.</li>
+   *   <li>Both column references point come from different tables</li>
+   * </ol>
+   *
+   * For theta join condition, we will use "an expression is a predicate including column references which come
+   * from different two tables" instead of the first rule.
+   *
    * @param expr EvalNode to be evaluated
    * @param includeThetaJoin If true, it will return equi as well as non-equi join conditions.
    *                         Otherwise, it only returns equi-join conditions.
    * @return True if it is join condition.
    */
   public static boolean isJoinQual(EvalNode expr, boolean includeThetaJoin) {
+
     if (expr instanceof BinaryEval) {
       boolean joinComparator;
       if (includeThetaJoin) {
@@ -250,7 +263,16 @@ public class EvalTreeUtil {
       BinaryEval binaryEval = (BinaryEval) expr;
       boolean isBothTermFields = isSingleColumn(binaryEval.getLeftExpr()) && isSingleColumn(binaryEval.getRightExpr());
 
-      return joinComparator && isBothTermFields;
+
+      String leftQualifier =
+          EvalTreeUtil.findUniqueColumns(binaryEval.getLeftExpr()).iterator().next().getQualifiedName();
+      String rightQualifier =
+          EvalTreeUtil.findUniqueColumns(binaryEval.getRightExpr()).iterator().next().getQualifiedName();
+
+      boolean isDifferentTables =
+          !(CatalogUtil.extractQualifier(leftQualifier).equals(CatalogUtil.extractQualifier(rightQualifier)));
+
+      return joinComparator && isBothTermFields && isDifferentTables;
     } else {
       return false;
     }

--- a/tajo-core/src/test/java/org/apache/tajo/engine/eval/TestEvalTreeUtil.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/eval/TestEvalTreeUtil.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import static org.apache.tajo.TajoConstants.DEFAULT_TABLESPACE_NAME;
 import static org.apache.tajo.common.TajoDataTypes.Type.INT4;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestEvalTreeUtil {
@@ -364,5 +365,11 @@ public class TestEvalTreeUtil {
     for (AggregationFunctionCallEval eval : list) {
       assertTrue(result.contains(eval.getName()));
     }
+  }
+
+  @Test
+  public final void testIsJoinQual() throws PlanningException {
+    EvalNode evalNode = getRootSelection("select score from people where people.score > people.age");
+    assertFalse(EvalTreeUtil.isJoinQual(evalNode, true));
   }
 }


### PR DESCRIPTION
... not be recognized as a join condition.
