### PR TITLE
TAJO-1024: RpcConnectionPool::getConnection can cause NPE at initialization

### DIFF
--- a/tajo-rpc/src/main/java/org/apache/tajo/rpc/RpcConnectionPool.java
+++ b/tajo-rpc/src/main/java/org/apache/tajo/rpc/RpcConnectionPool.java
@@ -75,8 +75,12 @@ public class RpcConnectionPool {
     NettyClientBase client = connections.get(key);
 
     if (client == null) {
-      client = makeConnection(key);
-      boolean added = connections.putIfAbsent(key, client) == null;
+      boolean added;
+      synchronized (connections){
+        client = makeConnection(key);
+        connections.put(key, client);
+        added = true;
+      }
 
       if (!added) {
         client.close();


### PR DESCRIPTION
It's concurrency bug. So, it is hard to reproduce the case. So, I omitted the unit tests. But, it definitely fixes the bug. After I apply it, I couldn't see the bug again. @jinossy helped this work.
