### PR TITLE
TAJO-948: 'INSERT INTO' statement to non existence table casuses NPE

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/PreLogicalPlanVerifier.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/PreLogicalPlanVerifier.java
@@ -255,7 +255,7 @@ public class PreLogicalPlanVerifier extends BaseAlgebraVisitor <PreLogicalPlanVe
 
           TableDesc table = catalog.getTableDesc(qualifiedName);
           if (table == null) {
-            context.state.addVerification("It seems target table doesn't exist");
+            context.state.addVerification(String.format("relation \"%s\" does not exist", qualifiedName));
             return null;
           }
           if (table.hasPartition()) {


### PR DESCRIPTION
The cause is there is no part to check if the table instance is null before it's used.

Please review if the changeset is appropriate.

Thanks.
