### PR TITLE
TAJO-1099: LogicalPlanner::convertDataType causes NPE in some cases.

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/eval/SimpleEvalNodeVisitor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/eval/SimpleEvalNodeVisitor.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.engine.eval;
 
+import com.google.common.base.Preconditions;
 import org.apache.tajo.exception.UnsupportedException;
 
 import java.util.Stack;
@@ -29,6 +30,8 @@ import java.util.Stack;
 public abstract class SimpleEvalNodeVisitor<CONTEXT> {
 
   public EvalNode visit(CONTEXT context, EvalNode evalNode, Stack<EvalNode> stack) {
+    Preconditions.checkNotNull(evalNode);
+
     EvalNode result;
 
     if (evalNode instanceof UnaryEval) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/optimizer/eval/EvalTreeOptimizer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/optimizer/eval/EvalTreeOptimizer.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.engine.optimizer.eval;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -65,6 +66,7 @@ public class EvalTreeOptimizer {
   }
 
   public EvalNode optimize(LogicalPlanner.PlanContext context, EvalNode node) {
+    Preconditions.checkNotNull(node);
 
     EvalNode optimized = node;
     for (EvalTreeOptimizationRule rule : rules) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/TypeDeterminant.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/TypeDeterminant.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.engine.planner;
 
+import com.google.common.base.Preconditions;
 import org.apache.tajo.algebra.*;
 import org.apache.tajo.catalog.CatalogService;
 import org.apache.tajo.catalog.CatalogUtil;
@@ -77,6 +78,10 @@ public class TypeDeterminant extends SimpleAlgebraVisitor<LogicalPlanner.PlanCon
   }
 
   public DataType computeBinaryType(OpType type, DataType lhsDataType, DataType rhsDataType) throws PlanningException {
+    Preconditions.checkNotNull(type);
+    Preconditions.checkNotNull(lhsDataType);
+    Preconditions.checkNotNull(rhsDataType);
+
     if(OpType.isLogicalType(type) || OpType.isComparisonType(type)) {
       return BOOL_TYPE;
     } else if (OpType.isArithmeticType(type)) {
@@ -300,5 +305,17 @@ public class TypeDeterminant extends SimpleAlgebraVisitor<LogicalPlanner.PlanCon
   public DataType visitTimeLiteral(LogicalPlanner.PlanContext ctx, Stack<Expr> stack, TimeLiteral expr)
       throws PlanningException {
     return CatalogUtil.newSimpleDataType(TajoDataTypes.Type.TIME);
+  }
+
+  @Override
+  public DataType visitDateLiteral(LogicalPlanner.PlanContext ctx, Stack<Expr> stack, DateLiteral expr)
+      throws PlanningException {
+    return CatalogUtil.newSimpleDataType(TajoDataTypes.Type.DATE);
+  }
+
+  @Override
+  public DataType visitIntervalLiteral(LogicalPlanner.PlanContext ctx, Stack<Expr> stack, IntervalLiteral expr)
+      throws PlanningException {
+    return CatalogUtil.newSimpleDataType(TajoDataTypes.Type.INTERVAL);
   }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/logical/EvalExprNode.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/logical/EvalExprNode.java
@@ -23,6 +23,7 @@ package org.apache.tajo.engine.planner.logical;
 
 import com.google.gson.annotations.Expose;
 import org.apache.tajo.engine.planner.PlanString;
+import org.apache.tajo.engine.planner.PlannerUtil;
 import org.apache.tajo.engine.planner.Target;
 import org.apache.tajo.util.TUtil;
 
@@ -41,6 +42,7 @@ public class EvalExprNode extends LogicalNode implements Projectable {
   @Override
   public void setTargets(Target[] targets) {
     this.exprs = targets;
+    setOutSchema(PlannerUtil.targetToSchema(targets));
   }
 
   @Override


### PR DESCRIPTION
So far, ExprTestBase has not passed through TypeDeterminant in LogicalPlanPreprocessor. So, unit tests haven't caused this problems. 

I fixed the bug and modified LogicalPlanPreprocessor to pass TypeDeterminant in LogicalPlanPreprocessor. As a result, even though this patch does not include any unit tests, it is same as all ExprTestBase tests verify this problem.
