### PR TITLE
TAJO-1021: Remove the member variable Builder from all classes inherited...

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/AlterTableDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/AlterTableDesc.java
@@ -25,11 +25,10 @@ import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.json.GsonObject;
 
+import static org.apache.tajo.catalog.proto.CatalogProtos.AlterTableDescProto;
 
-public class AlterTableDesc implements ProtoObject<CatalogProtos.AlterTableDescProto>, GsonObject, Cloneable {
 
-  protected CatalogProtos.AlterTableDescProto.Builder builder = null;
-
+public class AlterTableDesc implements ProtoObject<AlterTableDescProto>, GsonObject, Cloneable {
   @Expose
   protected AlterTableType alterTableType; //required
   @Expose
@@ -44,7 +43,6 @@ public class AlterTableDesc implements ProtoObject<CatalogProtos.AlterTableDescP
   protected Column addColumn = null; //optiona
 
   public AlterTableDesc() {
-    builder = CatalogProtos.AlterTableDescProto.newBuilder();
   }
 
 
@@ -106,7 +104,6 @@ public class AlterTableDesc implements ProtoObject<CatalogProtos.AlterTableDescP
   @Override
   public AlterTableDesc clone() throws CloneNotSupportedException {
     AlterTableDesc newAlter = (AlterTableDesc) super.clone();
-    newAlter.builder = CatalogProtos.AlterTableDescProto.newBuilder();
     newAlter.alterTableType = alterTableType;
     newAlter.tableName = tableName;
     newAlter.newTableName = newTableName;
@@ -121,10 +118,9 @@ public class AlterTableDesc implements ProtoObject<CatalogProtos.AlterTableDescP
   }
 
   @Override
-  public CatalogProtos.AlterTableDescProto getProto() {
-    if (null == builder) {
-      builder = CatalogProtos.AlterTableDescProto.newBuilder();
-    }
+  public AlterTableDescProto getProto() {
+    AlterTableDescProto.Builder builder = AlterTableDescProto.newBuilder();
+
     if (null != this.tableName) {
       builder.setTableName(this.tableName);
     }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/IndexDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/IndexDesc.java
@@ -27,8 +27,6 @@ import org.apache.tajo.catalog.proto.CatalogProtos.IndexMethod;
 import org.apache.tajo.common.ProtoObject;
 
 public class IndexDesc implements ProtoObject<IndexDescProto>, Cloneable {
-  private IndexDescProto.Builder builder;
-  
   private String indexName;            // required
   private String databaseName;         // required
   private String tableName;            // required
@@ -39,7 +37,6 @@ public class IndexDesc implements ProtoObject<IndexDescProto>, Cloneable {
   private boolean isAscending = false; // optional [default = false]
   
   public IndexDesc() {
-    this.builder = IndexDescProto.newBuilder();
   }
   
   public IndexDesc(String idxName, String databaseName, String tableName, Column column,
@@ -93,9 +90,7 @@ public class IndexDesc implements ProtoObject<IndexDescProto>, Cloneable {
 
   @Override
   public IndexDescProto getProto() {
-    if (builder == null) {
-      builder = IndexDescProto.newBuilder();
-    }
+    IndexDescProto.Builder builder = IndexDescProto.newBuilder();
 
     CatalogProtos.TableIdentifierProto.Builder tableIdentifierBuilder = CatalogProtos.TableIdentifierProto.newBuilder();
     if (databaseName != null) {

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableDesc.java
@@ -38,7 +38,6 @@ import org.apache.tajo.util.TUtil;
 public class TableDesc implements ProtoObject<TableDescProto>, GsonObject, Cloneable {
   private final Log LOG = LogFactory.getLog(TableDesc.class);
 
-  protected TableDescProto.Builder builder = null;
 	@Expose protected String tableName;                        // required
   @Expose protected Schema schema;
   @Expose protected TableMeta meta;                          // required
@@ -51,7 +50,6 @@ public class TableDesc implements ProtoObject<TableDescProto>, GsonObject, Clone
   @Expose protected Boolean external;                        // optional
 
 	public TableDesc() {
-		builder = TableDescProto.newBuilder();
 	}
 
   public TableDesc(String tableName, Schema schema, TableMeta meta,
@@ -180,7 +178,6 @@ public class TableDesc implements ProtoObject<TableDescProto>, GsonObject, Clone
 	
 	public Object clone() throws CloneNotSupportedException {
 	  TableDesc desc = (TableDesc) super.clone();
-	  desc.builder = TableDescProto.newBuilder();
 	  desc.tableName = tableName;
     desc.schema = (Schema) schema.clone();
     desc.meta = (TableMeta) meta.clone();
@@ -202,9 +199,7 @@ public class TableDesc implements ProtoObject<TableDescProto>, GsonObject, Clone
 	}
 
   public TableDescProto getProto() {
-    if (builder == null) {
-      builder = TableDescProto.newBuilder();
-    }
+    TableDescProto.Builder builder = TableDescProto.newBuilder();
 
     if (this.tableName != null) {
       builder.setTableName(this.tableName);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionMethodDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionMethodDesc.java
@@ -36,8 +36,6 @@ import static org.apache.tajo.catalog.proto.CatalogProtos.TableIdentifierProto;
  * <code>PartitionMethodDesc</code> presents a table description, including partition type, and partition keys.
  */
 public class PartitionMethodDesc implements ProtoObject<CatalogProtos.PartitionMethodProto>, Cloneable, GsonObject {
-  private CatalogProtos.PartitionMethodProto.Builder builder;
-
   @Expose private String databaseName;                         // required
   @Expose private String tableName;                            // required
   @Expose private PartitionType partitionType;                 // required
@@ -45,7 +43,6 @@ public class PartitionMethodDesc implements ProtoObject<CatalogProtos.PartitionM
   @Expose private Schema expressionSchema;                     // required
 
   public PartitionMethodDesc() {
-    builder = CatalogProtos.PartitionMethodProto.newBuilder();
   }
 
   public PartitionMethodDesc(String databaseName, String tableName,
@@ -118,10 +115,6 @@ public class PartitionMethodDesc implements ProtoObject<CatalogProtos.PartitionM
 
   @Override
   public CatalogProtos.PartitionMethodProto getProto() {
-    if(builder == null) {
-      builder = CatalogProtos.PartitionMethodProto.newBuilder();
-    }
-
     TableIdentifierProto.Builder tableIdentifierBuilder = TableIdentifierProto.newBuilder();
     if (databaseName != null) {
       tableIdentifierBuilder.setDatabaseName(databaseName);
@@ -141,7 +134,6 @@ public class PartitionMethodDesc implements ProtoObject<CatalogProtos.PartitionM
 
   public Object clone() throws CloneNotSupportedException {
     PartitionMethodDesc desc = (PartitionMethodDesc) super.clone();
-    desc.builder = builder;
     desc.tableName = tableName;
     desc.partitionType = partitionType;
     desc.expression = expression;

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
@@ -34,8 +34,6 @@ import org.apache.tajo.json.GsonObject;
 import org.apache.tajo.util.TUtil;
 
 public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>, Cloneable, GsonObject {
-  private CatalogProtos.ColumnStatsProto.Builder builder = CatalogProtos.ColumnStatsProto.newBuilder();
-
   @Expose private Column column = null; // required
   @Expose private Long numDistVals = null; // optional
   @Expose private Long numNulls = null; // optional
@@ -132,7 +130,6 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
 
   public Object clone() throws CloneNotSupportedException {
     ColumnStats stat = (ColumnStats) super.clone();
-    stat.builder = CatalogProtos.ColumnStatsProto.newBuilder();
     stat.column = this.column;
     stat.numDistVals = numDistVals;
     stat.numNulls = numNulls;
@@ -154,9 +151,8 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
 
   @Override
   public CatalogProtos.ColumnStatsProto getProto() {
-    if (builder == null) {
-      builder = CatalogProtos.ColumnStatsProto.newBuilder();
-    }
+    CatalogProtos.ColumnStatsProto.Builder builder = CatalogProtos.ColumnStatsProto.newBuilder();
+
     if (this.column != null) {
       builder.setColumn(this.column.getProto());
     }


### PR DESCRIPTION
... from ProtoObject.

This patch does not all uses of Builder. A few of classes which are frequently updated during query processing still require proto instance reuses.
