### PR TITLE
TAJO-1093: DateTimeFormat.to_char() is slower than SimpleDateFormat.form...

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeFormat.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeFormat.java
@@ -1686,7 +1686,7 @@ public class DateTimeFormat {
     tempArray = Integer.toString(tempValue).toCharArray();
     targetArraySize = Math.max(tempArray.length, size + (isPositive?0:1));
     targetArray = new char[targetArraySize];
-    if (size > 0) {
+    if (size > tempArray.length) {
       System.arraycopy(zeroStrings[size], 0, targetArray, (targetArraySize-size), size);
     }
     System.arraycopy(tempArray, 0, targetArray, (targetArraySize-tempArray.length), tempArray.length);
@@ -1718,6 +1718,7 @@ public class DateTimeFormat {
       Arrays.fill(targetArray, ' ');
       System.arraycopy(tempArray, 0, targetArray, 
           isLeftJustified?0:(targetArraySize-tempArray.length), tempArray.length);
+      result = new String(targetArray);
     }
     
     return result;


### PR DESCRIPTION
Details can be found on this line note.
https://github.com/ykrips/tajo/commit/127b2026b8b3cc010cce738706543f606dc69d18#tajo-common-src-main-java-org-apache-tajo-util-datetime-datetimeformat-java-P30
In addition, I found a defect on my patch. When specifying the minimal width on formatString function, it could not be applied.
