### PR TITLE
TAJO-1112: Implement histogram interface and a candidate histogram

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
@@ -39,6 +39,7 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
   @Expose private Long numNulls = null; // optional
   @Expose private Datum minValue = null; // optional
   @Expose private Datum maxValue = null; // optional
+  @Expose private Histogram histogram = null; // optional
 
   public ColumnStats(Column column) {
     this.column = column;
@@ -60,6 +61,9 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
     }
     if (proto.hasMaxValue()) {
       this.maxValue = DatumFactory.createFromBytes(getColumn().getDataType(), proto.getMaxValue().toByteArray());
+    }
+    if (proto.hasHistogram()) {
+      this.histogram = new Histogram(proto.getHistogram());
     }
   }
 
@@ -110,6 +114,14 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
   public boolean hasNullValue() {
     return numNulls > 0;
   }
+  
+  public void setHistogram(Histogram histogram) {
+    this.histogram = histogram;
+  }
+
+  public Histogram getHistogram() {
+    return this.histogram;
+  }
 
   public boolean equals(Object obj) {
     if (obj instanceof ColumnStats) {
@@ -118,7 +130,8 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
           && getNumDistValues().equals(other.getNumDistValues())
           && getNumNulls().equals(other.getNumNulls())
           && TUtil.checkEquals(getMinValue(), other.getMinValue())
-          && TUtil.checkEquals(getMaxValue(), other.getMaxValue());
+          && TUtil.checkEquals(getMaxValue(), other.getMaxValue())
+          && getHistogram().equals(other.getHistogram());
     } else {
       return false;
     }
@@ -135,6 +148,7 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
     stat.numNulls = numNulls;
     stat.minValue = minValue;
     stat.maxValue = maxValue;
+    stat.histogram = this.histogram.clone();
 
     return stat;
   }
@@ -167,6 +181,9 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
     }
     if (this.maxValue != null) {
       builder.setMaxValue(ByteString.copyFrom(this.maxValue.asByteArray()));
+    }
+    if (this.histogram != null) {
+      builder.setHistogram(this.histogram.getProto());
     }
 
     return builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
@@ -131,7 +131,7 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
           && getNumNulls().equals(other.getNumNulls())
           && TUtil.checkEquals(getMinValue(), other.getMinValue())
           && TUtil.checkEquals(getMaxValue(), other.getMaxValue())
-          && getHistogram().equals(other.getHistogram());
+          && TUtil.checkEquals(getHistogram(), other.getHistogram());
     } else {
       return false;
     }
@@ -148,7 +148,7 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
     stat.numNulls = numNulls;
     stat.minValue = minValue;
     stat.maxValue = maxValue;
-    stat.histogram = this.histogram.clone();
+    stat.histogram = this.histogram;
 
     return stat;
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiDepthHistogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiDepthHistogram.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.catalog.statistics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.tajo.catalog.proto.CatalogProtos.HistogramProto;
+import org.apache.tajo.util.TUtil;
+
+public class EquiDepthHistogram extends Histogram {
+
+  public EquiDepthHistogram() {
+    super();
+  }
+
+  public EquiDepthHistogram(HistogramProto proto) {
+    super(proto);
+  }
+
+  @Override
+  public boolean construct(List<Double> samples) {
+    int numBuckets = samples.size() > DEFAULT_MAX_BUCKETS ? DEFAULT_MAX_BUCKETS : samples.size();
+    return construct(samples, numBuckets);
+  }
+
+  /**
+   * An EquiDepth histogram is constructed by dividing the data points into buckets of equal frequencies (as equal as
+   * possible).
+   * 
+   * Note that, this function, which allows the specification of the (maximum) number of buckets, should be called
+   * directly only in the unit tests. In non-test cases, the construct(samples) version above should be used.
+   */
+  public boolean construct(List<Double> srcSamples, int numBuckets) {
+    isReady = false;
+    buckets = TUtil.newList();
+
+    ArrayList<Double> samples = new ArrayList<Double>(srcSamples); // sorted samples
+    Collections.sort(samples);
+
+    int averageFrequency = Math.round((float) samples.size() / numBuckets);
+    int bFrequency;
+    int bMinIndex = 0, bMaxIndex;
+    Double bMin, bMax;
+
+    for (int i = 0; i < numBuckets && bMinIndex < samples.size(); i++) {
+      bMin = samples.get(bMinIndex);
+      bFrequency = averageFrequency;
+      bMaxIndex = bMinIndex + averageFrequency - 1;
+
+      if (bMaxIndex > samples.size() - 1) {
+	bMaxIndex = samples.size() - 1;
+	bFrequency = bMaxIndex - bMinIndex + 1;
+      }
+
+      while (bMaxIndex + 1 < samples.size() && samples.get(bMaxIndex).equals(samples.get(bMaxIndex + 1))) {
+	bMaxIndex++;
+	bFrequency++;
+      }
+      bMax = samples.get(bMaxIndex);
+      bMinIndex = bMaxIndex + 1;
+      buckets.add(new HistogramBucket(bMin, bMax, bFrequency));
+    }
+
+    if (bMinIndex < samples.size()) {
+      int lastBucket = buckets.size() - 1;
+      int additionalFrequency = samples.size() - bMinIndex;
+      buckets.get(lastBucket).setFrequency(buckets.get(lastBucket).getFrequency() + additionalFrequency);
+      buckets.get(lastBucket).setMax(samples.get(samples.size() - 1));
+    }
+
+    samples.clear();
+    isReady = true;
+    lastAnalyzed = System.currentTimeMillis();
+
+    return true;
+  }
+}

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiDepthHistogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiDepthHistogram.java
@@ -25,6 +25,8 @@ import java.util.List;
 import org.apache.tajo.catalog.proto.CatalogProtos.HistogramProto;
 import org.apache.tajo.util.TUtil;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public class EquiDepthHistogram extends Histogram {
 
   public EquiDepthHistogram() {
@@ -48,6 +50,7 @@ public class EquiDepthHistogram extends Histogram {
    * Note that, this function, which allows the specification of the (maximum) number of buckets, should be called
    * directly only in the unit tests. In non-test cases, the construct(samples) version above should be used.
    */
+  @VisibleForTesting
   public boolean construct(List<Double> srcSamples, int numBuckets) {
     isReady = false;
     buckets = TUtil.newList();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiDepthHistogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiDepthHistogram.java
@@ -23,14 +23,16 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.tajo.catalog.proto.CatalogProtos.HistogramProto;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.datum.Datum;
 import org.apache.tajo.util.TUtil;
 
 import com.google.common.annotations.VisibleForTesting;
 
 public class EquiDepthHistogram extends Histogram {
 
-  public EquiDepthHistogram() {
-    super();
+  public EquiDepthHistogram(Type dataType) {
+    super(dataType);
   }
 
   public EquiDepthHistogram(HistogramProto proto) {
@@ -38,7 +40,7 @@ public class EquiDepthHistogram extends Histogram {
   }
 
   @Override
-  public boolean construct(List<Double> samples) {
+  public boolean construct(List<Datum> samples) {
     int numBuckets = samples.size() > DEFAULT_MAX_BUCKETS ? DEFAULT_MAX_BUCKETS : samples.size();
     return construct(samples, numBuckets);
   }
@@ -51,17 +53,17 @@ public class EquiDepthHistogram extends Histogram {
    * directly only in the unit tests. In non-test cases, the construct(samples) version above should be used.
    */
   @VisibleForTesting
-  public boolean construct(List<Double> srcSamples, int numBuckets) {
+  public boolean construct(List<Datum> srcSamples, int numBuckets) {
     isReady = false;
     buckets = TUtil.newList();
 
-    ArrayList<Double> samples = new ArrayList<Double>(srcSamples); // sorted samples
+    ArrayList<Datum> samples = new ArrayList<Datum>(srcSamples); // sorted samples
     Collections.sort(samples);
 
     int averageFrequency = Math.round((float) samples.size() / numBuckets);
     int bFrequency;
     int bMinIndex = 0, bMaxIndex;
-    Double bMin, bMax;
+    Datum bMin, bMax;
 
     for (int i = 0; i < numBuckets && bMinIndex < samples.size(); i++) {
       bMin = samples.get(bMinIndex);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiWidthHistogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiWidthHistogram.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.apache.tajo.catalog.proto.CatalogProtos.HistogramProto;
 import org.apache.tajo.util.TUtil;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public class EquiWidthHistogram extends Histogram {
 
   public EquiWidthHistogram() {
@@ -48,6 +50,7 @@ public class EquiWidthHistogram extends Histogram {
    * Note that, this function, which allows the specification of the (maximum) number of buckets, should be called
    * directly only in the unit tests. In non-test cases, the construct(samples) version above should be used.
    */
+  @VisibleForTesting
   public boolean construct(List<Double> samples, int numBuckets) {
     isReady = false;
     buckets = TUtil.newList();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiWidthHistogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/EquiWidthHistogram.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.catalog.statistics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.tajo.catalog.proto.CatalogProtos.HistogramProto;
+import org.apache.tajo.util.TUtil;
+
+public class EquiWidthHistogram extends Histogram {
+
+  public EquiWidthHistogram() {
+    super();
+  }
+
+  public EquiWidthHistogram(HistogramProto proto) {
+    super(proto);
+  }
+
+  @Override
+  public boolean construct(List<Double> samples) {
+    int numBuckets = samples.size() > DEFAULT_MAX_BUCKETS ? DEFAULT_MAX_BUCKETS : samples.size();
+    return construct(samples, numBuckets);
+  }
+  
+  /**
+   * Originally, an EquiWidth histogram is constructed by dividing the entire value range of the data points into
+   * buckets of equal sizes. Here, we construct it similarly, then improve it by removing empty buckets, to save disk
+   * space and processing time, and by compacting the buckets' boundaries, to increase selectivity estimation accuracy.
+   * 
+   * Note that, this function, which allows the specification of the (maximum) number of buckets, should be called
+   * directly only in the unit tests. In non-test cases, the construct(samples) version above should be used.
+   */
+  public boolean construct(List<Double> samples, int numBuckets) {
+    isReady = false;
+    buckets = TUtil.newList();
+    Double globalMin = Double.MAX_VALUE;
+    Double globalMax = -Double.MAX_VALUE;
+    List<Double> bMinValues = new ArrayList<Double>(numBuckets);
+    List<Double> bMaxValues = new ArrayList<Double>(numBuckets);
+    List<Long> bFrequencies = new ArrayList<Long>(numBuckets);
+
+    for (Double p : samples) {
+      if (p < globalMin) globalMin = p;
+      if (p > globalMax) globalMax = p;
+    }
+    double bWidth = (globalMax - globalMin) / numBuckets;
+
+    for (int i = 0; i < numBuckets; i++) {
+      bMinValues.add(Double.MAX_VALUE);
+      bMaxValues.add(-Double.MAX_VALUE);
+      bFrequencies.add(0l);
+    }
+
+    for (Double p : samples) {
+      int bIndex = (int) Math.round(Math.floor((p - globalMin) / bWidth));
+      if (bIndex > numBuckets - 1) bIndex = numBuckets - 1;
+      bFrequencies.set(bIndex, bFrequencies.get(bIndex) + 1);
+
+      if (p < bMinValues.get(bIndex)) bMinValues.set(bIndex, p);
+      if (p > bMaxValues.get(bIndex)) bMaxValues.set(bIndex, p);
+    }
+
+    for (int i = 0; i < numBuckets; i++) {
+      if (bFrequencies.get(i).longValue() > 0) {
+	buckets.add(new HistogramBucket(bMinValues.get(i), bMaxValues.get(i), bFrequencies.get(i)));
+      }
+    }
+
+    isReady = true;
+    lastAnalyzed = System.currentTimeMillis();
+
+    return true;
+  }
+}

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/Histogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/Histogram.java
@@ -1,0 +1,238 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.catalog.statistics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.tajo.catalog.json.CatalogGsonHelper;
+import org.apache.tajo.catalog.proto.CatalogProtos;
+import org.apache.tajo.common.ProtoObject;
+import org.apache.tajo.json.GsonObject;
+import org.apache.tajo.util.TUtil;
+
+import com.google.common.base.Objects;
+import com.google.gson.annotations.Expose;
+
+public class Histogram implements ProtoObject<CatalogProtos.HistogramProto>, Cloneable, GsonObject {
+  
+  @Expose protected Long lastAnalyzed = null; // optional
+  @Expose protected List<HistogramBucket> buckets = null; // repeated
+  @Expose protected boolean isReady; // whether this histogram is ready to be used for selectivity estimation
+  protected int DEFAULT_MAX_BUCKETS = 100; // Same as PostgreSQL
+
+  public Histogram() {
+    buckets = TUtil.newList();
+    isReady = false;
+  }
+  
+  public Histogram(CatalogProtos.HistogramProto proto) {
+    if (proto.hasLastAnalyzed()) {
+      this.lastAnalyzed = proto.getLastAnalyzed();
+    }    
+    buckets = TUtil.newList();
+    for (CatalogProtos.HistogramBucketProto bucketProto : proto.getBucketsList()) {
+      this.buckets.add(new HistogramBucket(bucketProto));
+    }
+    isReady = true;
+  }
+  
+  public Long getLastAnalyzed() {
+    return this.lastAnalyzed;
+  }
+  
+  public void setLastAnalyzed(Long lastAnalyzed) {
+    this.lastAnalyzed = lastAnalyzed;
+  }
+  
+  public List<HistogramBucket> getBuckets() {
+    return this.buckets;
+  }
+
+  public void setBuckets(List<HistogramBucket> buckets) {
+    this.buckets = new ArrayList<HistogramBucket>(buckets);
+  }
+
+  public void addBucket(HistogramBucket bucket) {
+    this.buckets.add(bucket);
+  }
+
+  public int getBucketsCount() {
+    return this.buckets.size();
+  }
+
+  public boolean getIsReady() {
+    return this.isReady;
+  }
+  
+  public void setIsReady(boolean isReady) {
+    this.isReady = isReady;
+  }
+  
+  public boolean equals(Object obj) {
+    if (obj instanceof Histogram) {
+      Histogram other = (Histogram) obj;
+      return getLastAnalyzed().equals(other.getLastAnalyzed())
+          && TUtil.checkEquals(this.buckets, other.buckets);
+    } else {
+      return false;
+    }
+  }
+
+  public int hashCode() {
+    return Objects.hashCode(this.lastAnalyzed, this.buckets);
+  }
+
+  public Histogram clone() throws CloneNotSupportedException {
+    Histogram hist = (Histogram) super.clone();
+    hist.lastAnalyzed = this.lastAnalyzed;
+    hist.buckets = new ArrayList<HistogramBucket>(this.buckets);
+    hist.isReady = this.isReady;
+    return hist;
+  }
+
+  public String toString() {
+    return CatalogGsonHelper.getPrettyInstance().toJson(this, Histogram.class);
+  }
+
+  @Override
+  public String toJson() {
+    return CatalogGsonHelper.toJson(this, Histogram.class);
+  }
+
+
+  @Override
+  public CatalogProtos.HistogramProto getProto() {
+    CatalogProtos.HistogramProto.Builder builder = CatalogProtos.HistogramProto.newBuilder();
+    if (this.lastAnalyzed != null) {
+      builder.setLastAnalyzed(this.lastAnalyzed);
+    }
+    if (this.buckets != null) {
+      for (HistogramBucket bucket : buckets) {
+        builder.addBuckets(bucket.getProto());
+      }
+    }
+    return builder.build();
+  }
+
+  /**
+   * Construct a histogram. Compute the number of buckets and the min, max, frequency values for each of them. This
+   * method must be overridden by specific sub-classes. The number of buckets should be less than or equal to the
+   * sample size.
+   * 
+   * @param samples
+   *          Sample data points to construct the histogram. This collection should fit in the memory and Null values
+   *          should never appear in it.
+   * @return Return true if the computation is done without any problem. Otherwise, return false
+   */
+  public boolean construct(List<Double> samples) {
+    // When overridden in sub-classes, remember to update lastAnalyzed and isReady before returning
+    return false;
+  }
+
+  /**
+   * Estimate the selectivity. "from" must be less than or equal to "to". For example, in the query
+   * "SELECT * from Employee WHERE age >= 20 and age <= 30", "from" is 20 and "to" is 30. If "from" is not specified in
+   * the predicate, (-Double.MAX_VALUE) should be used. Similarly, if "to" is not specified in the predicate,
+   * Double.MAX_VALUE should be used. "from" and "to" are inclusive, which means that an epsilon value should be added
+   * to "from", or subtracted from "to", if the comparison in the predicate is exclusive. For example, if the selection
+   * condition in the above query is "age > 20", "from" should be 20 + E where E is any number that satisfies
+   * "0 < E < 1".
+   * 
+   * @param from
+   *          The inclusive lower bound
+   * @param to
+   *          The inclusive upper bound
+   * @return The selectivity in range [0..1]. If the histogram is not ready (i.e., being constructed), return -1
+   */
+  public double estimateSelectivity(Double from, Double to) {
+    if(from > to) return 0;
+    if(!isReady) return -1;
+    Double freq = estimateFrequency(from, to);
+    Double totalFreq = 0.0;
+    for(HistogramBucket bucket : buckets) {
+      totalFreq += bucket.getFrequency();
+    }
+    double selectivity = freq / totalFreq;
+    return selectivity;
+  }
+  
+  public double estimateSelectivity(Float from, Float to) {
+    return estimateSelectivity(from.doubleValue(), to.doubleValue());
+  }
+  
+  public double estimateSelectivity(Long from, Long to) {
+    return estimateSelectivity(from.doubleValue(), to.doubleValue());
+  }
+  
+  public double estimateSelectivity(Integer from, Integer to) {
+    return estimateSelectivity(from.doubleValue(), to.doubleValue());
+  }
+  
+  /**
+   * Based on the histogram's buckets, estimate the number of rows whose values (of the corresponding column) are
+   * between "from" and "to".
+   * 
+   * @param from
+   * @param to
+   * @return 
+   */
+  private Double estimateFrequency(Double from, Double to) {
+    Double estimate = 0.0;
+    for(HistogramBucket bucket : buckets) {
+      estimate += estimateFrequency(bucket, from, to);
+    }
+    return estimate;
+  }
+  
+  private Double estimateFrequency(HistogramBucket bucket, Double from, Double to) {
+    Double min = bucket.getMin();
+    Double max = bucket.getMax();
+    Double width = max - min;
+    Double overlap = 0.0;
+    
+    if (min < max) {
+      if (from < min) {
+	if (to < min) {
+	  overlap = 0.0;
+	} else if (to >= min && to <= max) {
+	  overlap = (to - min) / width;
+	} else {
+	  overlap = 1.0;
+	}
+      } else if (from >= min && from <= max) {
+	if (to <= max) {
+	  overlap = (to - from) / width;
+	} else {
+	  overlap = (max - from) / width;
+	}
+      } else {
+	overlap = 0.0;
+      }
+    } else { // min == max
+      if(min >= from && min <= to) {
+	overlap = 1.0;
+      } else {
+	overlap = 0.0;
+      }
+    }
+    
+    return overlap * bucket.getFrequency();
+  }
+}

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/Histogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/Histogram.java
@@ -32,7 +32,10 @@ import com.google.gson.annotations.Expose;
 
 public class Histogram implements ProtoObject<CatalogProtos.HistogramProto>, Cloneable, GsonObject {
   
-  @Expose protected Long lastAnalyzed = null; // optional
+  @Expose
+  protected Long lastAnalyzed = null; // optional, store the last time point that this histogram is constructed,
+				      // will be used together with the "last-updated time" of the column data
+				      // to decide whether this histogram needs to be reconstructed or not
   @Expose protected List<HistogramBucket> buckets = null; // repeated
   @Expose protected boolean isReady; // whether this histogram is ready to be used for selectivity estimation
   protected int DEFAULT_MAX_BUCKETS = 100; // Same as PostgreSQL

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/HistogramBucket.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/HistogramBucket.java
@@ -22,46 +22,54 @@ import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.HistogramBucketProto;
 import org.apache.tajo.common.ProtoObject;
+import org.apache.tajo.common.TajoDataTypes.DataType;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.datum.Datum;
+import org.apache.tajo.datum.DatumFactory;
 import org.apache.tajo.json.GsonObject;
+import org.apache.tajo.util.TUtil;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import com.google.protobuf.ByteString;
 
 public class HistogramBucket implements ProtoObject<CatalogProtos.HistogramBucketProto>, Cloneable, GsonObject {
   
-  @Expose private Double min = null; // required
-  @Expose private Double max = null; // required
-  @Expose private Long frequency = null; // required
+  @Expose private Datum min = null; // required
+  @Expose private Datum max = null; // required
+  @Expose private Long frequency = null; // required 
 
-  public HistogramBucket(double min, double max) {
+  public HistogramBucket(Datum min, Datum max) {
     this.min = min;
     this.max = max;
     this.frequency = 0l;
   }
   
-  public HistogramBucket(double min, double max, long frequency) {
-    this.min = min;
-    this.max = max;
+  public HistogramBucket(Datum min, Datum max, long frequency) {
+    this(min, max);
     this.frequency = frequency;
   }
 
-  public HistogramBucket(CatalogProtos.HistogramBucketProto proto) {
+  public HistogramBucket(CatalogProtos.HistogramBucketProto proto, Type dataType) {
+    DataType.Builder typeBuilder = DataType.newBuilder();
+    typeBuilder.setType(dataType);
+    
     if (proto.hasMin()) {
-      this.min = proto.getMin();
+      this.min = DatumFactory.createFromBytes(typeBuilder.build(), proto.getMin().toByteArray());
     }
     if (proto.hasMax()) {
-      this.max = proto.getMax();
+      this.max = DatumFactory.createFromBytes(typeBuilder.build(), proto.getMax().toByteArray());
     }
     if (proto.hasFrequency()) {
       this.frequency = proto.getFrequency();
     }
   }
 
-  public Double getMin() {
+  public Datum getMin() {
     return this.min;
   }
 
-  public Double getMax() {
+  public Datum getMax() {
     return this.max;
   }
 
@@ -69,11 +77,11 @@ public class HistogramBucket implements ProtoObject<CatalogProtos.HistogramBucke
     return this.frequency;
   }
 
-  public void setMin(Double minVal) {
+  public void setMin(Datum minVal) {
     this.min = minVal;
   }
   
-  public void setMax(Double maxVal) {
+  public void setMax(Datum maxVal) {
     this.max = maxVal;
   }
   
@@ -88,8 +96,8 @@ public class HistogramBucket implements ProtoObject<CatalogProtos.HistogramBucke
   public boolean equals(Object obj) {
     if (obj instanceof HistogramBucket) {
       HistogramBucket other = (HistogramBucket) obj;
-      return getMin().equals(other.getMin())
-          && getMax().equals(other.getMax())
+      return TUtil.checkEquals(getMin(), other.getMin())
+          && TUtil.checkEquals(getMax(), other.getMax())
           && getFrequency().equals(other.getFrequency());
     } else {
       return false;
@@ -123,10 +131,10 @@ public class HistogramBucket implements ProtoObject<CatalogProtos.HistogramBucke
   public HistogramBucketProto getProto() {
     CatalogProtos.HistogramBucketProto.Builder builder = CatalogProtos.HistogramBucketProto.newBuilder();
     if (this.min != null) {
-      builder.setMin(this.min);
+      builder.setMin(ByteString.copyFrom(this.min.asByteArray()));
     }
     if (this.max != null) {
-      builder.setMax(this.max);
+      builder.setMax(ByteString.copyFrom(this.max.asByteArray()));
     }
     if (this.frequency != null) {
       builder.setFrequency(this.frequency);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/HistogramBucket.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/HistogramBucket.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.catalog.statistics;
+
+import org.apache.tajo.catalog.json.CatalogGsonHelper;
+import org.apache.tajo.catalog.proto.CatalogProtos;
+import org.apache.tajo.catalog.proto.CatalogProtos.HistogramBucketProto;
+import org.apache.tajo.common.ProtoObject;
+import org.apache.tajo.json.GsonObject;
+
+import com.google.common.base.Objects;
+import com.google.gson.annotations.Expose;
+
+public class HistogramBucket implements ProtoObject<CatalogProtos.HistogramBucketProto>, Cloneable, GsonObject {
+  
+  @Expose private Double min = null; // required
+  @Expose private Double max = null; // required
+  @Expose private Long frequency = null; // required
+
+  public HistogramBucket(double min, double max) {
+    this.min = min;
+    this.max = max;
+    this.frequency = 0l;
+  }
+  
+  public HistogramBucket(double min, double max, long frequency) {
+    this.min = min;
+    this.max = max;
+    this.frequency = frequency;
+  }
+
+  public HistogramBucket(CatalogProtos.HistogramBucketProto proto) {
+    if (proto.hasMin()) {
+      this.min = proto.getMin();
+    }
+    if (proto.hasMax()) {
+      this.max = proto.getMax();
+    }
+    if (proto.hasFrequency()) {
+      this.frequency = proto.getFrequency();
+    }
+  }
+
+  public Double getMin() {
+    return this.min;
+  }
+
+  public Double getMax() {
+    return this.max;
+  }
+
+  public Long getFrequency() {
+    return this.frequency;
+  }
+
+  public void setMin(Double minVal) {
+    this.min = minVal;
+  }
+  
+  public void setMax(Double maxVal) {
+    this.max = maxVal;
+  }
+  
+  public void setFrequency(Long freqVal) {
+    if(freqVal < 0) {
+      this.frequency = 0l;
+    } else {
+      this.frequency = freqVal;
+    }
+  }
+
+  public boolean equals(Object obj) {
+    if (obj instanceof HistogramBucket) {
+      HistogramBucket other = (HistogramBucket) obj;
+      return getMin().equals(other.getMin())
+          && getMax().equals(other.getMax())
+          && getFrequency().equals(other.getFrequency());
+    } else {
+      return false;
+    }
+  }
+
+  public int hashCode() {
+    return Objects.hashCode(getMin(), getMax(), getFrequency());
+  }
+
+  public Object clone() throws CloneNotSupportedException {
+    HistogramBucket buk = (HistogramBucket) super.clone();
+    buk.min = this.min;
+    buk.max = this.max;
+    buk.frequency = this.frequency;
+
+    return buk;
+  }
+
+  public String toString() {
+    return CatalogGsonHelper.getPrettyInstance().toJson(this, HistogramBucket.class);
+  }
+
+  @Override
+  public String toJson() {
+    return CatalogGsonHelper.toJson(this, HistogramBucket.class);
+  }
+
+
+  @Override
+  public HistogramBucketProto getProto() {
+    CatalogProtos.HistogramBucketProto.Builder builder = CatalogProtos.HistogramBucketProto.newBuilder();
+    if (this.min != null) {
+      builder.setMin(this.min);
+    }
+    if (this.max != null) {
+      builder.setMax(this.max);
+    }
+    if (this.frequency != null) {
+      builder.setFrequency(this.frequency);
+    }
+    return builder.build();
+  }
+}

--- a/tajo-catalog/tajo-catalog-common/src/main/proto/CatalogProtos.proto
+++ b/tajo-catalog/tajo-catalog-common/src/main/proto/CatalogProtos.proto
@@ -210,12 +210,13 @@ message ColumnStatsProto {
 
 message HistogramProto {
   optional int64 lastAnalyzed = 1;
-  repeated HistogramBucketProto buckets = 2;
+  required Type dataType = 2;
+  repeated HistogramBucketProto buckets = 3;
 }
 
 message HistogramBucketProto {
-  required double min = 1;
-  required double max = 2;
+  required bytes min = 1;
+  required bytes max = 2;
   required uint64 frequency = 3;
 }
 

--- a/tajo-catalog/tajo-catalog-common/src/main/proto/CatalogProtos.proto
+++ b/tajo-catalog/tajo-catalog-common/src/main/proto/CatalogProtos.proto
@@ -205,6 +205,18 @@ message ColumnStatsProto {
   optional int64 numNulls = 3;
   optional bytes minValue = 4;
   optional bytes maxValue = 5;
+  optional HistogramProto histogram = 6;
+}
+
+message HistogramProto {
+  optional int64 lastAnalyzed = 1;
+  repeated HistogramBucketProto buckets = 2;
+}
+
+message HistogramBucketProto {
+  required double min = 1;
+  required double max = 2;
+  required uint64 frequency = 3;
 }
 
 enum StatType {

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestHistogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestHistogram.java
@@ -1,0 +1,402 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.catalog.statistics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Random;
+
+import org.apache.tajo.catalog.json.CatalogGsonHelper;
+import org.apache.tajo.util.TUtil;
+import org.junit.Test;
+
+public class TestHistogram {
+
+  private List<Double> generateRandomData(int numPoints, int maxBound) {
+    List<Double> dataSet = TUtil.newList();
+    Random rnd = new Random(System.currentTimeMillis());
+    for (int i = 0; i < numPoints; i++) {
+      double p = rnd.nextDouble() * rnd.nextInt(maxBound);
+      if(rnd.nextDouble() < 0.5) p = -p;
+      dataSet.add(p);
+    }
+    return dataSet;
+  }
+
+  private List<Double> generateGaussianData(int numPoints, int scaleFactor, int numClusters) {
+    List<Double> dataSet = TUtil.newList();
+    Random rnd = new Random(System.currentTimeMillis());
+    int shiftStep = scaleFactor / (numClusters * 2);
+    int clusterCount = 0;
+    int i = -((int) Math.floor(numClusters / 2));
+    
+    while(clusterCount < numClusters) {
+      int shiftAmount = i * shiftStep;
+      for (int j = 0; j < numPoints; j++) {
+	dataSet.add(rnd.nextGaussian() * scaleFactor + shiftAmount);
+      }
+      i++;
+      clusterCount++;
+    }
+    return dataSet;
+  }
+
+  // samplingRatio must be in the range [0..1]
+  private List<Double> getRandomSamples(List<Double> dataSet, double samplingRatio) {
+    int dataSetSize = dataSet.size();
+    List<Double> samples = TUtil.newList();
+    Random rnd = new Random(System.currentTimeMillis());
+    for (int i = 0; i < dataSetSize; i++) {
+      if (rnd.nextDouble() <= samplingRatio) {
+	samples.add(dataSet.get(i));
+      }
+    }
+    return samples;
+  }
+
+  private Double computeRealSelectivity(List<Double> points, Double from, Double to) {
+    int numSatisfy = 0;
+    for (Double p : points) {
+      if (p >= from && p <= to) {
+	numSatisfy++;
+      }
+    }
+    return ((double) numSatisfy) / points.size();
+  }
+
+  private double computeListAverage(List<Double> values) {
+    double sum = 0.0;
+    for (Double v : values) {
+      sum += v;
+    }
+    double avg = sum / values.size();
+    return avg;
+  }
+
+  @Test
+  public final void testHistogramAccuracy() {
+    testHistogramAccuracy(0);
+    testHistogramAccuracy(1);
+    testHistogramAccuracy(3);
+    testHistogramAccuracy(5);
+  }
+
+  private void testHistogramAccuracy(int dataType) {
+    int valueBound = 100;
+    int dataSize = 100000;
+    double samplingRatio = 0.1;
+    List<Double> dataSet;
+
+    if (dataType == 0) {
+      dataSet = generateRandomData(dataSize, valueBound);
+      System.out.println("Random data\n");
+    } else {
+      dataSet = generateGaussianData(dataSize, valueBound, 1);
+      System.out.println("\nGaussian data (" + dataType + " clusters)\n");
+    }
+    List<Double> samples = getRandomSamples(dataSet, samplingRatio);
+
+    System.out.println("+ Big test ranges");
+    testHistogramAccuracy(0, dataSet, samples, valueBound, 20);
+    testHistogramAccuracy(1, dataSet, samples, valueBound, 20);
+
+    System.out.println("+ Small test ranges");
+    testHistogramAccuracy(0, dataSet, samples, valueBound, 5);
+    testHistogramAccuracy(1, dataSet, samples, valueBound, 5);
+  }
+
+  private double testHistogramAccuracy(int histogramType, List<Double> dataSet, List<Double> samples, int valueBound,
+      int maxTestRange) {
+    Histogram h;
+    Double from, to, estimate, real, error;
+    Random r = new Random(System.currentTimeMillis());
+    long startTime, elapsedTime;
+    List<Double> relativeErrors = TUtil.newList();
+
+    if (histogramType == 0) {
+      h = new EquiWidthHistogram();
+      System.out.println("  EquiWidthHistogram");
+    } else {
+      h = new EquiDepthHistogram();
+      System.out.println("  EquiDepthHistogram");
+    }
+
+    startTime = System.nanoTime();
+    h.construct(samples);
+    elapsedTime = (System.nanoTime() - startTime) / 1000000;
+    assertTrue(h.getIsReady() == true);
+
+    for (int i = 0; i < 1000; i++) {
+      from = r.nextDouble() + r.nextInt(valueBound) * 1.2;
+      if (r.nextDouble() < 0.5) from = -from;
+      to = from + r.nextDouble() * maxTestRange;
+
+      estimate = h.estimateSelectivity(from, to);
+      real = computeRealSelectivity(dataSet, from, to);
+      if (real.doubleValue() == 0) {
+	if (estimate.doubleValue() == 0) {
+	  error = 0.0;
+	} else {
+	  error = 1.0;
+	}
+      } else {
+	error = Math.abs(real - estimate) / real;
+      }
+      relativeErrors.add(error);
+    }
+    double avgAccuracy = (1.0 - computeListAverage(relativeErrors)) * 100.0;
+    System.out.format("    Construction time: %d ms; average accuracy: %.3f %%\n", elapsedTime, avgAccuracy);
+    return avgAccuracy;
+  }
+
+  @Test
+  public final void testEquiWidthCase1() {
+    List<Double> samples = TUtil.newList(0.6, 1.1, 1.25, 1.7, 1.9, 5.0, 5.0, 8.0, 9.0, 9.7);
+    EquiWidthHistogram h = new EquiWidthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 5);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() <= 5);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 5);
+    assertTrue(h.getBuckets().get(0).getMin() == 0.6);
+    assertTrue(h.getBuckets().get(0).getMax() == 1.9);
+    assertTrue(h.getBuckets().get(1).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(1).getMin() == 5);
+    assertTrue(h.getBuckets().get(1).getMax() == 5);
+  }
+
+  @Test
+  public final void testEquiWidthCase2() {
+    List<Double> samples = TUtil.newList(-6.0, -5.1, -1.25, -1.17, 0.0, 3.2, 5.0, 8.0, 9.0, 9.7);
+    EquiWidthHistogram h = new EquiWidthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 5);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() <= 5);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(0).getMin() == -6.0);
+    assertTrue(h.getBuckets().get(0).getMax() == -5.1);
+    assertTrue(h.getBuckets().get(1).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(1).getMin() == -1.25);
+    assertTrue(h.getBuckets().get(1).getMax() == 0.0);
+    assertTrue(h.getBuckets().get(2).getFrequency() == 1);
+    assertTrue(h.getBuckets().get(2).getMin() == 3.2);
+    assertTrue(h.getBuckets().get(2).getMax() == 3.2);
+    assertTrue(h.getBuckets().get(4).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(4).getMin() == 8.0);
+    assertTrue(h.getBuckets().get(4).getMax() == 9.7);
+  }
+
+  @Test
+  public final void testEquiWidthCase3() {
+    List<Double> samples = TUtil.newList(-6.0, -5.1, -1.25, -1.17, 0.0, -3.2, -5.0, -8.0, -9.0, -9.7);
+    EquiWidthHistogram h = new EquiWidthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 5);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() <= 5);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(0).getMin() == -9.7);
+    assertTrue(h.getBuckets().get(0).getMax() == -8.0);
+    assertTrue(h.getBuckets().get(4).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(4).getMin() == -1.25);
+    assertTrue(h.getBuckets().get(4).getMax() == 0.0);
+  }
+
+  @Test
+  public final void testEquiDepthCase1() {
+    List<Double> samples = TUtil.newList(0.6, 1.1, 1.25, 1.7, 1.9, 5.0, 5.0, 8.0, 9.0, 9.7);
+    EquiDepthHistogram h = new EquiDepthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 5);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() <= 5);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(0).getMin() == 0.6);
+    assertTrue(h.getBuckets().get(0).getMax() == 1.1);
+    assertTrue(h.getBuckets().get(1).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(1).getMin() == 1.25);
+    assertTrue(h.getBuckets().get(1).getMax() == 1.7);
+    assertTrue(h.getBuckets().get(2).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(2).getMin() == 1.9);
+    assertTrue(h.getBuckets().get(2).getMax() == 5.0);
+    assertTrue(h.getBuckets().get(4).getFrequency() == 1);
+    assertTrue(h.getBuckets().get(4).getMin() == 9.7);
+    assertTrue(h.getBuckets().get(4).getMax() == 9.7);
+  }
+
+  @Test
+  public final void testEquiDepthCase2() {
+    List<Double> samples = TUtil.newList(0.6, 1.1, 1.25, 1.7, 1.9, 5.0, 5.0, 8.0, 9.0, 9.7, 9.8);
+    EquiDepthHistogram h = new EquiDepthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 3);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() <= 5);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 4);
+    assertTrue(h.getBuckets().get(0).getMin() == 0.6);
+    assertTrue(h.getBuckets().get(0).getMax() == 1.7);
+    assertTrue(h.getBuckets().get(1).getFrequency() == 4);
+    assertTrue(h.getBuckets().get(1).getMin() == 1.9);
+    assertTrue(h.getBuckets().get(1).getMax() == 8.0);
+    assertTrue(h.getBuckets().get(2).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(2).getMin() == 9.0);
+    assertTrue(h.getBuckets().get(2).getMax() == 9.8);
+  }
+
+  @Test
+  public final void testEquiDepthCase3() {
+    List<Double> samples = TUtil.newList(0.6, 1.1, 1.25, 1.7, 1.9, 5.0, 5.6, 8.0, 9.0, 9.7, 9.8);
+    EquiDepthHistogram h = new EquiDepthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 2);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() <= 5);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 6);
+    assertTrue(h.getBuckets().get(0).getMin() == 0.6);
+    assertTrue(h.getBuckets().get(0).getMax() == 5.0);
+    assertTrue(h.getBuckets().get(1).getFrequency() == 5);
+    assertTrue(h.getBuckets().get(1).getMin() == 5.6);
+    assertTrue(h.getBuckets().get(1).getMax() == 9.8);
+  }
+
+  @Test
+  public final void testEquiDepthCase4() {
+    List<Double> samples = TUtil.newList(-6.0, -5.1, -1.25, -1.17, 0.0, 3.2, 5.0, 8.0, 9.0, 9.7);
+    EquiDepthHistogram h = new EquiDepthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 5);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() == 5);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(0).getMin() == -6.0);
+    assertTrue(h.getBuckets().get(0).getMax() == -5.1);
+    assertTrue(h.getBuckets().get(1).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(1).getMin() == -1.25);
+    assertTrue(h.getBuckets().get(1).getMax() == -1.17);
+    assertTrue(h.getBuckets().get(2).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(2).getMin() == 0.0);
+    assertTrue(h.getBuckets().get(2).getMax() == 3.2);
+    assertTrue(h.getBuckets().get(3).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(3).getMin() == 5.0);
+    assertTrue(h.getBuckets().get(3).getMax() == 8.0);
+    assertTrue(h.getBuckets().get(4).getFrequency() == 2);
+    assertTrue(h.getBuckets().get(4).getMin() == 9.0);
+    assertTrue(h.getBuckets().get(4).getMax() == 9.7);
+  }
+
+  @Test
+  public final void testEquiDepthCase5() {
+    List<Double> samples = TUtil.newList(-6.0, -5.1, -1.25, -1.17, 0.0, 3.2, 5.0, 8.0, 9.0, 9.7);
+    EquiDepthHistogram h = new EquiDepthHistogram();
+    assertTrue(h.getIsReady() == false);
+    assertTrue(h.getBucketsCount() == 0);
+    h.construct(samples, 3);
+
+    assertTrue(h.getIsReady() == true);
+    assertTrue(h.getBucketsCount() == 3);
+    assertTrue(h.getBuckets().get(0).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(0).getMin() == -6.0);
+    assertTrue(h.getBuckets().get(0).getMax() == -1.25);
+    assertTrue(h.getBuckets().get(1).getFrequency() == 3);
+    assertTrue(h.getBuckets().get(1).getMin() == -1.17);
+    assertTrue(h.getBuckets().get(1).getMax() == 3.2);
+    assertTrue(h.getBuckets().get(2).getFrequency() == 4);
+    assertTrue(h.getBuckets().get(2).getMin() == 5.0);
+    assertTrue(h.getBuckets().get(2).getMax() == 9.7);
+  }
+
+  @Test
+  public final void testEqualsObjectEquiWidth() {
+    List<Double> samples = generateRandomData(1000, 100);
+    Histogram h1 = new EquiWidthHistogram();
+    h1.construct(samples);
+
+    Histogram h2 = new Histogram(h1.getProto());
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  public final void testEqualsObjectEquiDepth() {
+    List<Double> samples = generateRandomData(1000, 100);
+    Histogram h1 = new EquiDepthHistogram();
+    h1.construct(samples);
+
+    Histogram h2 = new Histogram(h1.getProto());
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  public final void testJsonEquiWidth() throws CloneNotSupportedException {
+    List<Double> samples = generateRandomData(1000, 100);
+    Histogram h1 = new EquiWidthHistogram();
+    h1.construct(samples);
+
+    String json = h1.toJson();
+    Histogram h2 = CatalogGsonHelper.fromJson(json, Histogram.class);
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  public final void testJsonEquiDepth() throws CloneNotSupportedException {
+    List<Double> samples = generateRandomData(1000, 100);
+    Histogram h1 = new EquiDepthHistogram();
+    h1.construct(samples);
+
+    String json = h1.toJson();
+    Histogram h2 = CatalogGsonHelper.fromJson(json, Histogram.class);
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  public final void testCloneEquiWidth() throws CloneNotSupportedException {
+    List<Double> samples = generateRandomData(1000, 100);
+    Histogram h1 = new EquiWidthHistogram();
+    h1.construct(samples);
+
+    Histogram h2 = h1.clone();
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  public final void testCloneEquiDepth() throws CloneNotSupportedException {
+    List<Double> samples = generateRandomData(1000, 100);
+    Histogram h1 = new EquiDepthHistogram();
+    h1.construct(samples);
+
+    Histogram h2 = h1.clone();
+    assertEquals(h1, h2);
+  }
+}

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestHistogram.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestHistogram.java
@@ -109,7 +109,7 @@ public class TestHistogram {
       dataSet = generateRandomData(dataSize, valueBound);
       System.out.println("Random data\n");
     } else {
-      dataSet = generateGaussianData(dataSize, valueBound, 1);
+      dataSet = generateGaussianData(dataSize, valueBound, dataType);
       System.out.println("\nGaussian data (" + dataType + " clusters)\n");
     }
     List<Double> samples = getRandomSamples(dataSet, samplingRatio);

--- a/tajo-common/src/main/java/org/apache/tajo/datum/Datum.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/Datum.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.datum;
 
 import com.google.gson.annotations.Expose;
+
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.conf.TajoConf.ConfVars;
 import org.apache.tajo.exception.InvalidCastException;
@@ -267,6 +268,40 @@ public abstract class Datum implements Comparable<Datum>, GsonObject {
       }
     } else {
       return true;
+    }
+  }
+  
+  public static Datum getRangeMax(Type type) {
+    switch (type) {
+    case INT2:
+      return DatumFactory.createInt2(Short.MAX_VALUE);
+    case INT4:
+      return DatumFactory.createInt4(Integer.MAX_VALUE);
+    case INT8:
+      return DatumFactory.createInt8(Long.MAX_VALUE);
+    case FLOAT4:
+      return DatumFactory.createFloat4(Float.MAX_VALUE);
+    case FLOAT8:
+      return DatumFactory.createFloat8(Double.MAX_VALUE);
+    default:
+      throw new InvalidOperationException(type);
+    }
+  }
+  
+  public static Datum getRangeMin(Type type) {
+    switch (type) {
+    case INT2:
+      return DatumFactory.createInt2(Short.MIN_VALUE);
+    case INT4:
+      return DatumFactory.createInt4(Integer.MIN_VALUE);
+    case INT8:
+      return DatumFactory.createInt8(Long.MIN_VALUE);
+    case FLOAT4:
+      return DatumFactory.createFloat4(-Float.MAX_VALUE);
+    case FLOAT8:
+      return DatumFactory.createFloat8(-Double.MAX_VALUE);
+    default:
+      throw new InvalidOperationException(type);
     }
   }
 }


### PR DESCRIPTION
Hi everyone,
This patch contains:
+ a histogram interface with utility functions, including selectivity estimation
+ 2 candidate histograms: equi-width and equi-depth
+ some unit tests for integrity and accuracy of the histograms

In the accuracy tests, given a 100k data set and a 10k random sample (10% of the data set), the estimation accuracy is about 80% - 95%, for both random data of uniform and Gaussian distributions. Histogram construction time (just consider the first construction time, without cache effect) is about 15 ms.

Please review and advice me if anything should be improved. Sincerely!