### PR TITLE
TAJO-1126: Join condition including functions throws IllegalArgumentExce...

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/OverridableConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/OverridableConf.java
@@ -51,7 +51,7 @@ import static org.apache.tajo.rpc.protocolrecords.PrimitiveProtos.KeyValueSetPro
 public class OverridableConf extends KeyValueSet {
   private static final Log LOG = LogFactory.getLog(OverridableConf.class);
   private ConfigType [] configTypes;
-  private TajoConf conf;
+  protected TajoConf conf;
 
   public OverridableConf(final TajoConf conf, ConfigType...configTypes) {
     this.conf = conf;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/query/QueryUnitRequest.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/query/QueryUnitRequest.java
@@ -24,6 +24,7 @@ package org.apache.tajo.engine.query;
 import org.apache.tajo.QueryUnitAttemptId;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.ProtoObject;
+import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.engine.planner.enforce.Enforcer;
 import org.apache.tajo.engine.planner.global.DataChannel;
 import org.apache.tajo.ipc.TajoWorkerProtocol;
@@ -44,7 +45,7 @@ public interface QueryUnitRequest extends ProtoObject<TajoWorkerProtocol.QueryUn
 	public List<FetchImpl> getFetches();
   public boolean shouldDie();
   public void setShouldDie();
-  public QueryContext getQueryContext();
+  public QueryContext getQueryContext(TajoConf conf);
   public DataChannel getDataChannel();
   public Enforcer getEnforcer();
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/query/QueryUnitRequestImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/query/QueryUnitRequestImpl.java
@@ -186,7 +186,7 @@ public class QueryUnitRequestImpl implements QueryUnitRequest {
     fetches.add(fetch);
   }
 
-  public QueryContext getQueryContext() {
+  public QueryContext getQueryContext(TajoConf conf) {
     QueryUnitRequestProtoOrBuilder p = viaProto ? proto : builder;
     if (queryContext != null) {
       return queryContext;
@@ -194,7 +194,7 @@ public class QueryUnitRequestImpl implements QueryUnitRequest {
     if (!p.hasQueryContext()) {
       return null;
     }
-    this.queryContext = new QueryContext(new TajoConf(), p.getQueryContext());
+    this.queryContext = new QueryContext(conf, p.getQueryContext());
     return this.queryContext;
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/worker/Task.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/Task.java
@@ -149,7 +149,7 @@ public class Task {
     this.taskId = taskId;
 
     this.systemConf = executionBlockContext.getConf();
-    this.queryContext = request.getQueryContext();
+    this.queryContext = request.getQueryContext(systemConf);
     this.executionBlockContext = executionBlockContext;
     this.taskDir = StorageUtil.concatPath(baseDir,
         taskId.getQueryUnitId().getId() + "_" + taskId.getId());

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinGraph.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinGraph.java
@@ -123,7 +123,10 @@ public class JoinGraph extends SimpleUndirectedGraph<String, JoinEdge> {
       Set<EvalNode> cnf = Sets.newHashSet(AlgebraicUtil.toConjunctiveNormalFormArray(joinNode.getJoinQual()));
 
       for (EvalNode singleQual : cnf) {
-        if (EvalTreeUtil.isJoinQual(block, singleQual, true)) {
+        if (EvalTreeUtil.isJoinQual(block,
+            joinNode.getLeftChild().getOutSchema(),
+            joinNode.getRightChild().getOutSchema(),
+            singleQual, true)) {
           String[] relations = guessRelationsFromJoinQual(block, (BinaryEval) singleQual);
           String leftExprRelName = relations[0];
           String rightExprRelName = relations[1];

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/FilterPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/FilterPushDownRule.java
@@ -154,7 +154,8 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
   }
 
   @Override
-  public LogicalNode visitJoin(FilterPushDownContext context, LogicalPlan plan, LogicalPlan.QueryBlock block, JoinNode joinNode,
+  public LogicalNode visitJoin(FilterPushDownContext context, LogicalPlan plan, LogicalPlan.QueryBlock block,
+                               JoinNode joinNode,
                                Stack<LogicalNode> stack) throws PlanningException {
     // here we should stop selection pushdown on the null supplying side(s) of an outer join
     // get the two operands of the join operation as well as the join type
@@ -238,7 +239,10 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
 
       List<EvalNode> removedFromFilter = new ArrayList<EvalNode>();
       for (EvalNode eachEval: context.pushingDownFilters) {
-        if (EvalTreeUtil.isJoinQual(block, eachEval, true)) {
+        if (EvalTreeUtil.isJoinQual(block,
+            joinNode.getLeftChild().getOutSchema(),
+            joinNode.getRightChild().getOutSchema(),
+            eachEval, true)) {
           outerJoinPredicationEvals.add(eachEval);
           removedFromFilter.add(eachEval);
         } else {
@@ -584,7 +588,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
     BiMap<EvalNode, EvalNode> matched = HashBiMap.create();
 
     for (EvalNode eval : context.pushingDownFilters) {
-      if (ignoreJoin && EvalTreeUtil.isJoinQual(block, eval, true)) {
+      if (ignoreJoin && EvalTreeUtil.isJoinQual(block, null, null, eval, true)) {
         notMatched.add(eval);
         continue;
       }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
@@ -597,7 +597,7 @@ public class PlannerUtil {
 
     @Override
     public void visit(EvalNode node) {
-      if (EvalTreeUtil.isJoinQual(node, includeThetaJoin)) {
+      if (EvalTreeUtil.isJoinQual(null, schemas[0], schemas[1], node, includeThetaJoin)) {
         BinaryEval binaryEval = (BinaryEval) node;
         Column[] pair = new Column[2];
 


### PR DESCRIPTION
...ption.

See https://issues.apache.org/jira/browse/TAJO-1126.

Thank you for enclosing the reproducible query and detailed bug reports.

In addition to above description, I discussed this problem with Hyoungjun in offline chat. He informed me the bug where the parameterized unit tests in TestJoin does not work. The fact that QueryUnitRequesttImpl newly creates TajoConf instance instead of taking existing TajoConf causes this bug. So, given parameters were lost during unit tests. This problem is hiding the unit test failures. As he mentioned, I could find about 20 test failures in TestJoin when I fixed this parameters loss problem.

I found the bug from PlannerUtil::isJoinQual. I improved this method to take two schemas of both relations for join, and I also enabled the method to ensure  by checking schemas if both expressions composes a join condition. As a result, all the failures in TestJoin are passed.
