### PR TITLE
TAJO-1133: Add 'bin/tajo version' command

### DIFF
--- a/tajo-dist/src/main/bin/tajo
+++ b/tajo-dist/src/main/bin/tajo
@@ -73,6 +73,7 @@ if [ $# = 0 ]; then
   echo "  getconf              print tajo configuration"
   echo "  jar <jar>            run a jar file"
   echo "  benchmark            run the benchmark driver"
+  echo "  version              print the version"
   echo " or"
   echo "  CLASSNAME            run the class named CLASSNAME"
   echo "Most commands print help when invoked w/o parameters."
@@ -372,6 +373,10 @@ elif [ "$COMMAND" = "dump" ] ; then
   CLASS='org.apache.tajo.client.TajoDump'
   TAJO_ROOT_LOGGER_APPENDER="${TAJO_ROOT_LOGGER_APPENDER:-NullAppender}"
   TAJO_OPTS="$TAJO_OPTS $TAJO_DUMP_OPTS"
+elif [ "$COMMAND" = "version" ] ; then
+  CLASS='org.apache.tajo.util.VersionInfo'
+  TAJO_ROOT_LOGGER_APPENDER="${TAJO_ROOT_LOGGER_APPENDER:-NullAppender}"
+  TAJO_OPTS="$TAJO_OPTS $TAJO_CLI_OPTS"
 else
   CLASS=$COMMAND
 fi


### PR DESCRIPTION
It will print out like this.

```
Tajo 0.9.1-SNAPSHOT
Git https://github.com/ykrips/tajo -r f728413fe36918a9b5e2381af951c05361900099
Compiled by ykrips on 2014-10-30T01:29Z
Compiled with protoc 2.5.0
From source with checksum fa37715d8a9ac5b225f7f1a481d5f12
This command was run using /opt/tajo-0.9.1/tajo-common-0.9.1-SNAPSHOT.jar
```
