### PR TITLE
TAJO-1145: Add 'bin/tajo --help' command

### DIFF
--- a/tajo-dist/src/main/bin/tajo
+++ b/tajo-dist/src/main/bin/tajo
@@ -58,8 +58,7 @@ case "`uname`" in
 CYGWIN*) cygwin=true;;
 esac
 
-# if no args specified, show usage
-if [ $# = 0 ]; then
+function print_usage() {
   echo "Usage: tajo [--config confdir] COMMAND"
   echo "where COMMAND is one of:"
   echo "  master               run the Master Server"
@@ -76,12 +75,22 @@ if [ $# = 0 ]; then
   echo " or"
   echo "  CLASSNAME            run the class named CLASSNAME"
   echo "Most commands print help when invoked w/o parameters."
+}
+
+# if no args specified, show usage
+if [ $# = 0 ]; then
+  print_usage
   exit 1
 fi
 
 # get arguments
 COMMAND=$1
 shift
+
+if [ "$COMMAND" == "--help" ] || [ "$COMMAND" == "-help" ] || [ "$COMMAND" == "-h" ] ; then
+  print_usage
+  exit
+fi
 
 if [ -f "${TAJO_CONF_DIR}/tajo-env.sh" ]; then
   . "${TAJO_CONF_DIR}/tajo-env.sh"


### PR DESCRIPTION
It can be shown the help directive by using these options.
`bin/tajo --help` , `bin/tajo -help` or `bin/tajo -h`
