### PR TITLE
TAJO-1169: Some older version of OpenJDK 1.6 does not get default timezone id

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -360,7 +360,7 @@ public class TajoConf extends Configuration {
     $CLI_ERROR_STOP("tajo.cli.error.stop", false),
 
     // Timezone & Date ----------------------------------------------------------
-    $TIMEZONE("tajo.timezone", System.getProperty("user.timezone")),
+    $TIMEZONE("tajo.timezone", TimeZone.getDefault().getID()),
     $DATE_ORDER("tajo.date.order", "YMD"),
 
     // FILE FORMAT


### PR DESCRIPTION
It has been tested by getting default timezone id.

```
[root@oracle-db1 tajo-0.9.1]# ./bin/tajo getconf tajo.timezone
Asia/Seoul
```
