### PR TITLE
TAJO-1173: Add size 8 instead of 4 For ServerName

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/master/cluster/ServerName.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/cluster/ServerName.java
@@ -93,7 +93,7 @@ public class ServerName implements Comparable<ServerName> {
   }
 
   public static String getServerName(String hostName, int port) {
-    final StringBuilder name = new StringBuilder(hostName.length() + 4);
+    final StringBuilder name = new StringBuilder(hostName.length() + 8);
     name.append(hostName);
     name.append(SERVERNAME_SEPARATOR);
     name.append(port);


### PR DESCRIPTION
In tajo-core/src/main/java/org/apache/tajo/master/cluster/ServerName.java.
In getServerName, Creating StringBuilder With (hostName.length() + 4)

but like below, it is short, so it call internally newCapacity() if port size is larger than 3 

``` java
     name.append(hostName); //+hostName.length()
     name.append(SERVERNAME_SEPARATOR); //+1
     name.append(port); //port range is 0 <= port range <= 65535
```

so this patch. prevent newCapacity() internally doing allocating proper size.

but. It just change value from 4 to 8(to cover port range 65535)
It passed testcases.
