### PR TITLE
TAJO-1174: remove unnessary codes for blobdatum

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/datum/BlobDatum.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/BlobDatum.java
@@ -140,8 +140,6 @@ public class BlobDatum extends Datum {
   public Datum equalsTo(Datum datum) {
     switch (datum.type()) {
     case BLOB:
-    	initFromBytes();
-    	((BlobDatum)datum).initFromBytes();
       return DatumFactory.createBool(Arrays.equals(this.val, ((BlobDatum)datum).val));
     case NULL_TYPE:
       return datum;


### PR DESCRIPTION
in blobdatum
we don't need to call initFromBytes() in equals() 
because it just compare Byte array, not ByteBuffer.
so it is better to remove unnessary codes.
