### PR TITLE
TAJO-1177: Reduce the use of Sun proprietary API

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/datum/TextDatum.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/TextDatum.java
@@ -20,11 +20,12 @@ package org.apache.tajo.datum;
 
 import com.google.common.primitives.UnsignedBytes;
 import com.google.gson.annotations.Expose;
-import com.sun.tools.javac.util.Convert;
+
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.exception.InvalidCastException;
 import org.apache.tajo.exception.InvalidOperationException;
 import org.apache.tajo.util.MurmurHash;
+import org.apache.tajo.util.StringUtils;
 
 import java.nio.charset.Charset;
 import java.util.Comparator;
@@ -97,7 +98,7 @@ public class TextDatum extends Datum {
 
   @Override
   public char[] asUnicodeChars() {
-    return Convert.utf2chars(this.bytes);
+    return StringUtils.convertBytesToChars(bytes, DEFAULT_CHARSET);
   }
 
   @Override

--- a/tajo-common/src/main/java/org/apache/tajo/util/KeyValueSet.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/KeyValueSet.java
@@ -24,7 +24,6 @@ import com.google.gson.annotations.Expose;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.json.CommonGsonHelper;
 import org.apache.tajo.json.GsonObject;
-import sun.misc.FloatingDecimal;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -173,11 +172,10 @@ public class KeyValueSet implements ProtoObject<KeyValueSetProto>, Cloneable, Gs
     if (containsKey(key)) {
       String strVal = get(key, null);
       try {
-        sun.misc.FloatingDecimal fd = FloatingDecimal.readJavaFormatString(strVal);
-        if (Float.MAX_VALUE < fd.doubleValue()) {
+        if (Float.MAX_VALUE < Double.parseDouble(strVal)) {
           throw new IllegalStateException("Parsed value is overflow in float type");
         }
-        return fd.floatValue();
+        return Float.parseFloat(strVal);
       } catch (NumberFormatException nfe) {
         throw new IllegalArgumentException("No such a config key: "  + key);
       }

--- a/tajo-common/src/main/java/org/apache/tajo/util/UnsafeUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/UnsafeUtil.java
@@ -95,7 +95,7 @@ public class UnsafeUtil {
   }
 
   public static long getAddress(ByteBuffer buffer) {
-    Preconditions.checkArgument(buffer instanceof DirectBuffer, "ByteBuffer must be DirectBuffer");
+    Preconditions.checkArgument(buffer.isDirect(), "ByteBuffer must be DirectBuffer");
     return ((DirectBuffer)buffer).address();
   }
 
@@ -105,7 +105,7 @@ public class UnsafeUtil {
 
   public static void free(ByteBuffer bb) {
     Preconditions.checkNotNull(bb);
-    Preconditions.checkState(bb instanceof DirectBuffer);
+    Preconditions.checkState(bb.isDirect());
 
     Cleaner cleaner = ((DirectBuffer) bb).cleaner();
     if (cleaner != null) {

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestTextDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestTextDatum.java
@@ -96,4 +96,18 @@ public class TestTextDatum {
     Whitebox.setInternalState(Charset.class, "defaultCharset", systemCharSet);
     assertEquals(systemCharSet, Charset.defaultCharset());
   }
+  
+  @Test
+  public void testAsUnicodeChars() {
+    byte[] testStringArray = new byte[] {0x74, 0x61, 0x6A, 0x6F};
+    TextDatum test = new TextDatum(testStringArray);
+    
+    assertArrayEquals(new char[] {'t', 'a', 'j', 'o'}, test.asUnicodeChars());
+    
+    testStringArray = new byte[] {(byte) 0xED, (byte) 0x83, (byte) 0x80, (byte) 0xEC, 
+        (byte) 0xA1, (byte) 0xB0};
+    test = new TextDatum(testStringArray);
+    
+    assertArrayEquals(new char[] {'\ud0c0', '\uc870'}, test.asUnicodeChars());
+  }
 }

--- a/tajo-common/src/test/java/org/apache/tajo/util/TestStringUtil.java
+++ b/tajo-common/src/test/java/org/apache/tajo/util/TestStringUtil.java
@@ -18,6 +18,8 @@
 
 package org.apache.tajo.util;
 
+import java.nio.charset.Charset;
+
 import org.apache.commons.lang.CharUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.junit.Test;
@@ -124,5 +126,27 @@ public class TestStringUtil {
     assertNotNull(bytesArray[1]);
     assertArrayEquals(textArray[1].getBytes(), bytesArray[1]);
     assertNull(bytesArray[2]);
+  }
+  
+  @Test
+  public void testConvertBytesToChars() {
+    byte[] testStringArray = new byte[] { 0x74, 0x61, 0x6A, 0x6F };
+    assertArrayEquals(new char[] { 't', 'a', 'j', 'o' },
+        StringUtils.convertBytesToChars(testStringArray, Charset.forName("UTF-8")));
+
+    testStringArray = new byte[] { (byte) 0xED, (byte) 0x83, (byte) 0x80, (byte) 0xEC, (byte) 0xA1, (byte) 0xB0 };
+    assertArrayEquals(new char[] { '\ud0c0', '\uc870' },
+        StringUtils.convertBytesToChars(testStringArray, Charset.forName("UTF-8")));
+  }
+  
+  @Test
+  public void testConvertCharsToBytes() {
+    char[] testStringArray = new char[] { 't', 'a', 'j', 'o' };
+    assertArrayEquals(new byte[] { 0x74, 0x61, 0x6A, 0x6F },
+        StringUtils.convertCharsToBytes(testStringArray, Charset.forName("UTF-8")));
+
+    testStringArray = new char[] { '\ud0c0', '\uc870' };
+    assertArrayEquals(new byte[] { (byte) 0xED, (byte) 0x83, (byte) 0x80, (byte) 0xEC, (byte) 0xA1, (byte) 0xB0 },
+        StringUtils.convertCharsToBytes(testStringArray, Charset.forName("UTF-8")));
   }
 }

--- a/tajo-core/src/test/java/org/apache/tajo/client/TestTajoClient.java
+++ b/tajo-core/src/test/java/org/apache/tajo/client/TestTajoClient.java
@@ -22,8 +22,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ServiceException;
-import com.sun.org.apache.commons.logging.Log;
-import com.sun.org.apache.commons.logging.LogFactory;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -39,12 +40,9 @@ import org.apache.tajo.ipc.ClientProtos.QueryHistoryProto;
 import org.apache.tajo.ipc.ClientProtos.QueryInfoProto;
 import org.apache.tajo.ipc.ClientProtos.SubQueryHistoryProto;
 import org.apache.tajo.jdbc.TajoResultSet;
-import org.apache.tajo.master.querymaster.QueryInfo;
 import org.apache.tajo.storage.StorageConstants;
 import org.apache.tajo.storage.StorageUtil;
 import org.apache.tajo.util.CommonTestingUtil;
-import org.apache.tajo.util.history.QueryUnitHistory;
-import org.apache.tajo.util.history.SubQueryHistory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -57,7 +55,6 @@ import java.sql.SQLException;
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 @Category(IntegrationTest.class)
 public class TestTajoClient {

--- a/tajo-storage/src/main/java/org/apache/tajo/tuple/offheap/HeapTuple.java
+++ b/tajo-storage/src/main/java/org/apache/tajo/tuple/offheap/HeapTuple.java
@@ -20,16 +20,19 @@ package org.apache.tajo.tuple.offheap;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import com.sun.tools.javac.util.Convert;
+
 import org.apache.tajo.datum.*;
 import org.apache.tajo.exception.UnsupportedException;
 import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.storage.VTuple;
 import org.apache.tajo.util.SizeOf;
+import org.apache.tajo.util.StringUtils;
 import org.apache.tajo.util.UnsafeUtil;
+
 import sun.misc.Unsafe;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import static org.apache.tajo.common.TajoDataTypes.DataType;
 
@@ -241,7 +244,7 @@ public class HeapTuple implements Tuple {
 
     byte [] bytes = new byte[len];
     UNSAFE.copyMemory(data, BASE_OFFSET + pos, bytes, UnsafeUtil.ARRAY_BYTE_BASE_OFFSET, len);
-    return Convert.utf2chars(bytes);
+    return StringUtils.convertBytesToChars(bytes, Charset.forName("UTF-8"));
   }
 
   @Override

--- a/tajo-storage/src/main/java/org/apache/tajo/tuple/offheap/UnSafeTuple.java
+++ b/tajo-storage/src/main/java/org/apache/tajo/tuple/offheap/UnSafeTuple.java
@@ -21,18 +21,21 @@ package org.apache.tajo.tuple.offheap;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import com.sun.tools.javac.util.Convert;
+
 import org.apache.tajo.datum.*;
 import org.apache.tajo.exception.UnsupportedException;
 import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.storage.VTuple;
 import org.apache.tajo.util.SizeOf;
+import org.apache.tajo.util.StringUtils;
 import org.apache.tajo.util.UnsafeUtil;
+
 import sun.misc.Unsafe;
 import sun.nio.ch.DirectBuffer;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
 
 import static org.apache.tajo.common.TajoDataTypes.DataType;
 
@@ -278,7 +281,7 @@ public abstract class UnSafeTuple implements Tuple {
 
     byte [] bytes = new byte[len];
     UNSAFE.copyMemory(null, pos, bytes, UnsafeUtil.ARRAY_BYTE_BASE_OFFSET, len);
-    return Convert.utf2chars(bytes);
+    return StringUtils.convertBytesToChars(bytes, Charset.forName("UTF-8"));
   }
 
   @Override


### PR DESCRIPTION
It has been passed test cases using JDK 1.6.0_45.
