### PR TITLE
TAJO-1188: Fix testcase testTimestampConstructor in TestTimestampDatum

### DIFF
--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestTimestampDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestTimestampDatum.java
@@ -151,7 +151,8 @@ public class TestTimestampDatum {
     assertEquals(datum2, datum);
 
     for (int i = 0; i < 100; i++) {
-      Calendar cal = Calendar.getInstance();
+      TimeZone timeZone = TimeZone.getTimeZone("UTC");
+      Calendar cal = Calendar.getInstance(timeZone);
       long jTime = System.currentTimeMillis();
       int uTime = (int)(jTime / 1000);
       cal.setTimeInMillis(jTime);


### PR DESCRIPTION
This is also timezone bug.
but, before adding timezone info into tajo.
I think it is better to fix testcase for this case.
testTimestampConstructor in TestTimestampDatum will break the test because of timezone.
it compares UTC date and jvm timezone date.
so it needs to set timezone as UTC for Calendar.
