### PR TITLE
TAJO-1053: ADD PARTITIONS for HCatalogStore.

### DIFF
--- a/tajo-docs/src/main/sphinx/hcatalog_integration.rst
+++ b/tajo-docs/src/main/sphinx/hcatalog_integration.rst
@@ -45,8 +45,8 @@ Finally, you should specify HCatalogStore as Tajo catalog driver class in ``conf
   ``ALTER TABLE table_name ADD PARTITION`` commands on each of the newly added partitions or
   ``MSCK REPAIR TABLE  table_name`` command.
 
-  But current tajo doesn't provide ``ADD PARTITION`` command and hive doesn't provide a api for
+  But current tajo doesn't provide ``ADD PARTITION`` command and hive doesn't provide an api for
   responding to ``MSK REPAIR TABLE`` command. Thus, if you insert data to hive partitioned
-  table and you want to scan it on hive, you must run following command on hive ::
+  table and you want to scan the updated partitions through Tajo, you must run following command on hive ::
 
   $ MSCK REPAIR TABLE [table_name];


### PR DESCRIPTION
I tried to resolve this issue. But unfortunately, current tajo doesn't provide ALTER PARTITION command. In addition, hive doesn't support a api for repair all partitions at a time. So, there is a one way which scan all directories of a tajo and run ALTER PARITION api for each all partitions. But it is very inefficient way and it will be a cause of HiveMetaStore low performance. Thus, we need to guide our users to run msck command on hive. 
