### PR TITLE
TAJO-1207: Remove redundant code in Bytes.java in tajo-common

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/util/Bytes.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/Bytes.java
@@ -1439,9 +1439,6 @@ public class Bytes {
    */
   public static byte [] padHead(final byte [] a, final int length) {
     byte [] padding = new byte[length];
-    for (int i = 0; i < length; i++) {
-      padding[i] = 0;
-    }
     return add(padding,a);
   }
 
@@ -1452,9 +1449,6 @@ public class Bytes {
    */
   public static byte [] padTail(final byte [] a, final int length) {
     byte [] padding = new byte[length];
-    for (int i = 0; i < length; i++) {
-      padding[i] = 0;
-    }
     return add(a,padding);
   }
 


### PR DESCRIPTION
in Bytes.java
padHead and padTail
Don't need to set array to 0.
because java alloc byte array and initialize them as 0.

``` java
byte [] padding = new byte[length];
//so below is redundant block
for (int i = 0; i < length; i++)
{ padding[i] = 0; }
return add(padding,a);
```
