### PR TITLE
TAJO-1220: Implement JDBC function for 'createStatement' and 'setEscapeP...

### DIFF
--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/JdbcConnection.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/JdbcConnection.java
@@ -183,7 +183,17 @@ public class JdbcConnection implements Connection {
   @Override
   public Statement createStatement(int resultSetType, int resultSetConcurrency)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException("createStatement");
+	  		//Just support 'CONCUR_READ_ONLY' only.
+            if (resultSetConcurrency != ResultSet.CONCUR_READ_ONLY) {
+              throw new SQLException("Statement with resultset concurrency " +
+                  resultSetConcurrency + " is not supported");      
+            }
+            //Not support 'TYPE_SCROLL_SENSITIVE'.
+            if (resultSetType == ResultSet.TYPE_SCROLL_SENSITIVE) {
+              throw new SQLException("Statement with resultset type " + 
+            	  resultSetType + " is not supported");
+            }
+            return new TajoStatement(this, tajoClient);
   }
 
   @Override

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoStatement.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoStatement.java
@@ -311,10 +311,11 @@ public class TajoStatement implements Statement {
     throw new SQLFeatureNotSupportedException("setCursorName not supported");
   }
 
+  /**
+   * Not necessary.
+   */
   @Override
-  public void setEscapeProcessing(boolean enable) throws SQLException {
-    throw new SQLFeatureNotSupportedException("setEscapeProcessing not supported");
-  }
+  public void setEscapeProcessing(boolean enable) throws SQLException {}
 
   @Override
   public void setFetchDirection(int direction) throws SQLException {


### PR DESCRIPTION
Hi guys!
- Statement createStatement(int resultSetType, int resultSetConcurrency)
  - The resultSetType is not supported 'TYPE_SCROLL_SENSITIVE'.
  - The resultSetConcurrency is supported only 'CONCUR_READ_ONLY'. 
- void setEscapeProcessing(boolean enable)
  - Tajo is not necessary the function. So do nothing.

Thanks.
