### PR TITLE
TAJO-1221: HA TajoClient should not connect TajoMaster at the first.

### DIFF
--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/CatalogServer.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/CatalogServer.java
@@ -173,6 +173,11 @@ public class CatalogServer extends AbstractService {
   public void start() {
     String serverAddr = conf.getVar(ConfVars.CATALOG_ADDRESS);
     InetSocketAddress initIsa = NetUtils.createSocketAddr(serverAddr);
+
+    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      initIsa = NetUtils.createLocalSocketAddr(initIsa);
+    }
+
     int workerNum = conf.getIntVar(ConfVars.CATALOG_RPC_SERVER_WORKER_THREAD_NUM);
     try {
       this.rpcServer = new BlockingRpcServer(CatalogProtocol.class, handler, initIsa, workerNum);
@@ -185,6 +190,7 @@ public class CatalogServer extends AbstractService {
       LOG.error("CatalogServer startup failed", e);
       throw new CatalogException(e);
     }
+
 
     LOG.info("Catalog Server startup (" + bindAddressStr + ")");
     super.start();

--- a/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
@@ -64,22 +64,17 @@ public class TajoHAClientUtil {
       TajoCliContext context) throws IOException, ServiceException {
 
     if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
-      if (!HAServiceUtil.isMasterAlive(conf.getVar(
-          TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS), conf)) {
-        TajoClient tajoClient = null;
-        String baseDatabase = client.getBaseDatabase();
-        conf.setVar(TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS,
-            HAServiceUtil.getMasterClientName(conf));
-        client.close();
-        tajoClient = new TajoClientImpl(conf, baseDatabase);
+      TajoClient tajoClient = null;
+      String baseDatabase = client.getBaseDatabase();
+      conf.setVar(TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS,
+          HAServiceUtil.getMasterClientName(conf));
+      client.close();
+      tajoClient = new TajoClientImpl(conf, baseDatabase);
 
-        if (context != null && context.getCurrentDatabase() != null) {
-          tajoClient.selectDatabase(context.getCurrentDatabase());
-        }
-        return tajoClient;
-      } else {
-        return client;
+      if (context != null && context.getCurrentDatabase() != null) {
+        tajoClient.selectDatabase(context.getCurrentDatabase());
       }
+      return tajoClient;
     } else {
       return client;
     }

--- a/tajo-common/src/main/java/org/apache/tajo/util/HAServiceUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/HAServiceUtil.java
@@ -30,12 +30,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class HAServiceUtil {
-
-  private final static int MASTER_UMBILICAL_RPC_ADDRESS = 1;
-  private final static int MASTER_CLIENT_RPC_ADDRESS = 2;
-  private final static int RESOURCE_TRACKER_RPC_ADDRESS = 3;
-  private final static int CATALOG_ADDRESS = 4;
-  private final static int MASTER_INFO_ADDRESS = 5;
+  public final static int MASTER_UMBILICAL_RPC_ADDRESS = 1;
+  public final static int MASTER_CLIENT_RPC_ADDRESS = 2;
+  public final static int RESOURCE_TRACKER_RPC_ADDRESS = 3;
+  public final static int CATALOG_ADDRESS = 4;
+  public final static int MASTER_INFO_ADDRESS = 5;
 
   public static InetSocketAddress getMasterUmbilicalAddress(TajoConf conf) {
     return getMasterAddress(conf, MASTER_UMBILICAL_RPC_ADDRESS);
@@ -91,6 +90,7 @@ public class HAServiceUtil {
           if (files.length == 1) {
             Path file = files[0].getPath();
             String hostAddress = file.getName().replaceAll("_", ":");
+
             FSDataInputStream stream = fs.open(file);
             String data = stream.readUTF();
             stream.close();

--- a/tajo-common/src/main/java/org/apache/tajo/util/NetUtils.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/NetUtils.java
@@ -18,9 +18,14 @@
 
 package org.apache.tajo.util;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import java.net.*;
 
 public class NetUtils {
+  private static Log LOG = LogFactory.getLog(NetUtils.class);
+
   public static String normalizeInetSocketAddress(InetSocketAddress addr) {
     return addr.getAddress().getHostAddress() + ":" + addr.getPort();
   }
@@ -28,6 +33,16 @@ public class NetUtils {
   public static InetSocketAddress createSocketAddr(String addr) {
     String [] splitted = addr.split(":");
     return new InetSocketAddress(splitted[0], Integer.parseInt(splitted[1]));
+  }
+
+  public static InetSocketAddress createLocalSocketAddr(InetSocketAddress addr) {
+    try {
+      String hostAddress = InetAddress.getLocalHost().getHostAddress();
+      int port = addr.getPort();
+      return  NetUtils.createSocketAddr(hostAddress + ":" + port);
+    } catch (UnknownHostException e) {
+    }
+    return addr;
   }
 
   /**

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterClientService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterClientService.java
@@ -97,6 +97,11 @@ public class TajoMasterClientService extends AbstractService {
     // start the rpc server
     String confClientServiceAddr = conf.getVar(ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS);
     InetSocketAddress initIsa = NetUtils.createSocketAddr(confClientServiceAddr);
+
+    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      initIsa = NetUtils.createLocalSocketAddr(initIsa);
+    }
+
     int workerNum = conf.getIntVar(ConfVars.MASTER_SERVICE_RPC_SERVER_WORKER_THREAD_NUM);
     try {
       server = new BlockingRpcServer(TajoMasterClientProtocol.class, clientHandler, initIsa, workerNum);

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterService.java
@@ -65,6 +65,11 @@ public class TajoMasterService extends AbstractService {
   public void start() {
     String confMasterServiceAddr = conf.getVar(TajoConf.ConfVars.TAJO_MASTER_UMBILICAL_RPC_ADDRESS);
     InetSocketAddress initIsa = NetUtils.createSocketAddr(confMasterServiceAddr);
+
+    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      initIsa = NetUtils.createLocalSocketAddr(initIsa);
+    }
+
     int workerNum = conf.getIntVar(TajoConf.ConfVars.MASTER_RPC_SERVER_WORKER_THREAD_NUM);
     try {
       server = new AsyncRpcServer(TajoMasterProtocol.class, masterHandler, initIsa, workerNum);

--- a/tajo-core/src/main/java/org/apache/tajo/master/querymaster/QueryMasterManagerService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/querymaster/QueryMasterManagerService.java
@@ -76,6 +76,10 @@ public class QueryMasterManagerService extends CompositeService
         throw new IllegalArgumentException("Failed resolve of " + initIsa);
       }
 
+      if (tajoConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+        initIsa = NetUtils.createLocalSocketAddr(initIsa);
+      }
+
       int workerNum = tajoConf.getIntVar(TajoConf.ConfVars.QUERY_MASTER_RPC_SERVER_WORKER_THREAD_NUM);
       this.rpcServer = new AsyncRpcServer(QueryMasterProtocol.class, this, initIsa, workerNum);
       this.rpcServer.start();

--- a/tajo-core/src/main/java/org/apache/tajo/master/rm/TajoResourceTracker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/rm/TajoResourceTracker.java
@@ -83,6 +83,10 @@ public class TajoResourceTracker extends AbstractService implements TajoResource
     String confMasterServiceAddr = systemConf.getVar(TajoConf.ConfVars.RESOURCE_TRACKER_RPC_ADDRESS);
     InetSocketAddress initIsa = NetUtils.createSocketAddr(confMasterServiceAddr);
 
+    if (systemConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      initIsa = NetUtils.createLocalSocketAddr(initIsa);
+    }
+
     try {
       server = new AsyncRpcServer(TajoResourceTrackerProtocol.class, this, initIsa, 3);
     } catch (Exception e) {


### PR DESCRIPTION
We TajoClient is opened, TajoClient initially tries to connect TajoMaster. This manner does not guarantee high availability. A known TajoMaster host may be not work anymore. So, this manner still has some failure point.
Also, this manner prohibits a Tajo cluster to run on some dynamic cluster environments like Yarn.

Solution

Tajo HA client should get directly TajoMaster addresses and others from HA component without contacting TajoMaster.
