### PR TITLE
TAJO-1226: add json and parquet validator

### DIFF
--- a/tajo-plan/src/main/java/org/apache/tajo/plan/DataTypeValidatorFactory.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/DataTypeValidatorFactory.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.plan;
+
+import org.apache.tajo.catalog.Schema;
+import org.apache.tajo.catalog.proto.CatalogProtos;
+import org.apache.tajo.plan.validator.DataTypeValidator;
+import org.apache.tajo.plan.validator.JsonDataTypeValidator;
+import org.apache.tajo.plan.validator.ParquetDataTypeValidator;
+import org.apache.tajo.plan.verifier.VerificationState;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataTypeValidatorFactory {
+  static final Map<CatalogProtos.StoreType, DataTypeValidator> validatorMap = new HashMap<CatalogProtos.StoreType, DataTypeValidator>();
+
+  static {
+    validatorMap.put(CatalogProtos.StoreType.PARQUET, new ParquetDataTypeValidator());
+    validatorMap.put(CatalogProtos.StoreType.JSON, new JsonDataTypeValidator());
+  };
+
+  public static void validate(VerificationState state, CatalogProtos.StoreType storeType, Schema scheme) {
+    DataTypeValidator validator = validatorMap.get(storeType);
+
+    if (validator != null) {
+      validator.validate(state, scheme);
+    }
+  }
+}

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/validator/DataTypeValidator.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/validator/DataTypeValidator.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.plan.validator;
+
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.catalog.Schema;
+import org.apache.tajo.catalog.proto.CatalogProtos;
+import org.apache.tajo.common.TajoDataTypes;
+import org.apache.tajo.plan.verifier.VerificationState;
+
+import java.util.Set;
+
+
+public abstract class DataTypeValidator {
+
+  public abstract CatalogProtos.StoreType getStoreType();
+  public abstract Set<TajoDataTypes.Type> getValidTypeSet();
+
+  public void validate(VerificationState state, Schema schema) {
+    int size = schema.size();
+    Set<TajoDataTypes.Type> validTypes = getValidTypeSet();
+
+    for (int i = 0; i < size; i++) {
+      Column column = schema.getColumn(i);
+      TajoDataTypes.Type type = column.getDataType().getType();
+
+      if (validTypes.contains(type) == false) {
+        String error = getStoreType().name() + " doesn't support " + column.getQualifiedName() + ":" + type.toString();
+        state.addVerification(error);
+      }
+    }
+  }
+}

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/validator/JsonDataTypeValidator.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/validator/JsonDataTypeValidator.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.plan.validator;
+
+import org.apache.tajo.catalog.proto.CatalogProtos;
+import org.apache.tajo.common.TajoDataTypes;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.tajo.catalog.proto.CatalogProtos.StoreType.JSON;
+
+public class JsonDataTypeValidator extends DataTypeValidator {
+    private static Set<TajoDataTypes.Type> validTypes = new HashSet<TajoDataTypes.Type>(
+            Arrays.asList(
+                    TajoDataTypes.Type.BOOLEAN,
+                    TajoDataTypes.Type.INT1,
+                    TajoDataTypes.Type.INT2,
+                    TajoDataTypes.Type.INT4,
+                    TajoDataTypes.Type.INT8,
+                    TajoDataTypes.Type.FLOAT4,
+                    TajoDataTypes.Type.FLOAT8,
+                    TajoDataTypes.Type.CHAR,
+                    TajoDataTypes.Type.TEXT,
+                    TajoDataTypes.Type.VARCHAR,
+                    TajoDataTypes.Type.INET4,
+                    TajoDataTypes.Type.TIMESTAMP,
+                    TajoDataTypes.Type.DATE,
+                    TajoDataTypes.Type.TIME,
+                    TajoDataTypes.Type.INTERVAL,
+                    TajoDataTypes.Type.BIT,
+                    TajoDataTypes.Type.BINARY,
+                    TajoDataTypes.Type.BLOB,
+                    TajoDataTypes.Type.VARBINARY,
+                    TajoDataTypes.Type.NULL_TYPE
+            )
+    );
+
+    @Override
+    public CatalogProtos.StoreType getStoreType() {
+        return JSON;
+    }
+
+    @Override
+    public Set<TajoDataTypes.Type> getValidTypeSet() {
+        return validTypes;
+    }
+}

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/validator/ParquetDataTypeValidator.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/validator/ParquetDataTypeValidator.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.plan.validator;
+
+import org.apache.tajo.catalog.proto.CatalogProtos;
+import org.apache.tajo.common.TajoDataTypes;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.tajo.catalog.proto.CatalogProtos.StoreType.PARQUET;
+
+public class ParquetDataTypeValidator extends DataTypeValidator {
+  private static Set<TajoDataTypes.Type> validTypes = new HashSet<TajoDataTypes.Type>(
+          Arrays.asList(
+                  TajoDataTypes.Type.BOOLEAN,
+                  TajoDataTypes.Type.BIT,
+                  TajoDataTypes.Type.INT2,
+                  TajoDataTypes.Type.INT4,
+                  TajoDataTypes.Type.INT8,
+                  TajoDataTypes.Type.FLOAT4,
+                  TajoDataTypes.Type.FLOAT8,
+                  TajoDataTypes.Type.CHAR,
+                  TajoDataTypes.Type.TEXT,
+                  TajoDataTypes.Type.PROTOBUF,
+                  TajoDataTypes.Type.BLOB,
+                  TajoDataTypes.Type.INET4,
+                  TajoDataTypes.Type.INET6
+                  )
+  );
+
+  @Override
+  public CatalogProtos.StoreType getStoreType() {
+    return PARQUET;
+  }
+
+  @Override
+  public Set<TajoDataTypes.Type> getValidTypeSet() {
+    return validTypes;
+  }
+}

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/LogicalPlanVerifier.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/LogicalPlanVerifier.java
@@ -25,11 +25,12 @@ import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.plan.LogicalPlan;
-import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.plan.PlanningException;
 import org.apache.tajo.plan.Target;
 import org.apache.tajo.plan.logical.*;
+import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
+import org.apache.tajo.plan.DataTypeValidatorFactory;
 
 import java.util.Stack;
 
@@ -255,8 +256,8 @@ public class LogicalPlanVerifier extends BasicLogicalPlanVisitor<LogicalPlanVeri
   @Override
   public LogicalNode visitCreateTable(Context context, LogicalPlan plan, LogicalPlan.QueryBlock block,
                                       CreateTableNode node, Stack<LogicalNode> stack) throws PlanningException {
-    super.visitCreateTable(context, plan, block, node, stack);
     // here, we don't need check table existence because this check is performed in PreLogicalPlanVerifier.
+    DataTypeValidatorFactory.validate(context.state, node.getStorageType(), node.getTableSchema());
     return node;
   }
 

--- a/tajo-plan/src/test/java/org/apache/tajo/plan/TestDataTypeValidator.java
+++ b/tajo-plan/src/test/java/org/apache/tajo/plan/TestDataTypeValidator.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.plan;
+
+import org.apache.tajo.catalog.Schema;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.plan.verifier.VerificationState;
+import org.junit.Test;
+
+import static org.apache.tajo.catalog.proto.CatalogProtos.StoreType.JSON;
+import static org.apache.tajo.catalog.proto.CatalogProtos.StoreType.PARQUET;
+import static org.junit.Assert.assertEquals;
+
+public class TestDataTypeValidator {
+  @Test
+  public void testParquetExpectOk() throws Exception{
+    VerificationState state = new VerificationState();
+    Schema schema = new Schema();
+    schema.addColumn("id", Type.INT4);
+    schema.addColumn("name", Type.TEXT);
+    schema.addColumn("age", Type.INT2);
+
+    DataTypeValidatorFactory.validate(state, PARQUET, schema);
+    assertEquals(state.getErrorMessages().size(), 0);
+  }
+
+  @Test
+  public void testParquetExpectException() {
+    VerificationState state = new VerificationState();
+
+    Schema schema = new Schema();
+    schema.addColumn("id", Type.INT4);
+    schema.addColumn("name", Type.TEXT);
+    schema.addColumn("age", Type.INT2);
+    schema.addColumn("mytime", Type.DATE);
+
+    DataTypeValidatorFactory.validate(state, PARQUET, schema);
+    assertEquals(state.getErrorMessages().size(), 1);
+  }
+
+  @Test
+  public void testJsonExpectOk() throws Exception{
+    VerificationState state = new VerificationState();
+
+    Schema schema = new Schema();
+    schema.addColumn("id", Type.INT4);
+    schema.addColumn("name", Type.TEXT);
+    schema.addColumn("age", Type.INT2);
+
+    DataTypeValidatorFactory.validate(state, JSON, schema);
+    assertEquals(state.getErrorMessages().size(), 0);
+  }
+
+  @Test
+  public void testJsonExpectException() {
+    VerificationState state = new VerificationState();
+
+    Schema schema = new Schema();
+    schema.addColumn("id", Type.INT4);
+    schema.addColumn("name", Type.TEXT);
+    schema.addColumn("age", Type.INT2);
+    schema.addColumn("myproto", Type.PROTOBUF);
+
+    DataTypeValidatorFactory.validate(state, JSON, schema);
+    assertEquals(state.getErrorMessages().size(), 1);
+  }
+
+  @Test
+  public void testJsonExpectException2() {
+    VerificationState state = new VerificationState();
+
+    Schema schema = new Schema();
+    schema.addColumn("id", Type.INT4);
+    schema.addColumn("name", Type.TEXT);
+    schema.addColumn("age", Type.INT2);
+    schema.addColumn("myproto", Type.PROTOBUF);
+    schema.addColumn("myproto2", Type.PROTOBUF);
+
+    DataTypeValidatorFactory.validate(state, JSON, schema);
+    assertEquals(state.getErrorMessages().size(), 2);
+  }
+}


### PR DESCRIPTION
Result of this patch.

```c
default> create external table table1 (       id int,       name text,       score float,       type text, mytime date)       using parquet location 'file:/Users/charsyam/tajo/table';
ERROR: PARQUET doesn't support mytime:DATE
```