### PR TITLE
TAJO-1249: Tajo Should Check File Format is allowed.

### DIFF
--- a/tajo-core/src/test/java/org/apache/tajo/engine/eval/TestPredicates.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/eval/TestPredicates.java
@@ -407,7 +407,7 @@ public class TestPredicates extends ExprTestBase {
   @Test
   public void testCreateTableWithUnsupportedStoreType() throws IOException {
     testSimpleEval("create table table1 (name text, age int) using RAW;",
-        new String[] {"Wrong query statement or query plan: create table table1 (name text, age int) using RAW"},
+        new String[] {"Unsupported store type :raw"},
         false);
   }
 }


### PR DESCRIPTION
Currently Tajo just show NullPointException when can't understand file format

``` c
default> create external table table1 ( id int, name text, score float, type text, mytime int, mytime2 date) using TEXT1 location 'file:/Users/charsyam/tajo/table';
ERROR: java.lang.NullPointerException
```

It is better to return using verficationstate
