### PR TITLE
TAJO-1276: Link to tsql guide 404s in tajo cli

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ Documents
 * Configuration Guide (http://tajo.apache.org/docs/current/configuration.html)
 * Backup and Restore Guide (http://tajo.apache.org/docs/current/backup_and_restore.html)
 * Functions (http://tajo.apache.org/docs/current/functions.html)
-* Tajo Interactive Shell (http://tajo.apache.org/docs/current/cli.html)
+* Tajo Interactive Shell (http://tajo.apache.org/docs/current/tsql.html)
 
 Requirements
 ============

--- a/tajo-client/src/main/java/org/apache/tajo/cli/tsql/commands/HelpCommand.java
+++ b/tajo-client/src/main/java/org/apache/tajo/cli/tsql/commands/HelpCommand.java
@@ -85,7 +85,7 @@ public class HelpCommand extends TajoShellCommand {
       sout.println();
 
       sout.println("Documentations");
-      sout.println("  tsql guide        http://tajo.apache.org/docs/" + targetDocVersion + "/cli.html");
+      sout.println("  tsql guide        http://tajo.apache.org/docs/" + targetDocVersion + "/tsql.html");
       sout.println("  Query language    http://tajo.apache.org/docs/" + targetDocVersion + "/sql_language.html");
       sout.println("  Functions         http://tajo.apache.org/docs/" + targetDocVersion + "/functions.html");
       sout.println("  Backup & restore  http://tajo.apache.org/docs/" + targetDocVersion + "/backup_and_restore.html");

--- a/tajo-docs/src/main/sphinx/tsql/meta_command.rst
+++ b/tajo-docs/src/main/sphinx/tsql/meta_command.rst
@@ -41,7 +41,7 @@ In the current implementation, there are meta commands as follows: ::
 
 
   Documentations
-    tsql guide        http://tajo.apache.org/docs/current/cli.html
+    tsql guide        http://tajo.apache.org/docs/current/tsql.html
     Query language    http://tajo.apache.org/docs/current/sql_language.html
     Functions         http://tajo.apache.org/docs/current/functions.html
     Backup & restore  http://tajo.apache.org/docs/current/backup_and_restore.html

--- a/tajo-project/src/site/markdown/mailing-lists.md
+++ b/tajo-project/src/site/markdown/mailing-lists.md
@@ -31,7 +31,7 @@ The Tajo user mailing list is : user@tajo.apache.org.
 * [Unsubscribe from List] (mailto:user-unsubscribe@tajo.apache.org)
 * [Archives] (http://mail-archives.apache.org/mod_mbox/tajo-user/)
 
-### Devlopers
+### Developers
 
 If you'd like to contribute to Tajo, please subscribe to the Tajo developer mailing list.
 


### PR DESCRIPTION
Ended up being a big hassle repushing the 0.9.0 docs, so I just went ahead and wrote up a quick page to redirect from cli.html and added it to the website.  Going forward, I've fixed all the references to the cli.html in the website and code to tsql.html (a more correct name anyway).  Also, fixed typo in mailing list page.  Once this is committed, I'll re-generated and re-publish the website.