### PR TITLE
TAJO-1258: Close() for classes derived from FileAppender should be robust

### DIFF
--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/CSVFile.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/CSVFile.java
@@ -225,10 +225,8 @@ public class CSVFile {
           deflateFilter.resetState();
           deflateFilter = null;
         }
-
-        os.close();
       } finally {
-        IOUtils.cleanup(LOG, fos);
+        IOUtils.cleanup(LOG, os, fos, outputStream);
         if (compressor != null) {
           CodecPool.returnCompressor(compressor);
           compressor = null;

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/RowFile.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/RowFile.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.Schema;
@@ -468,7 +469,7 @@ public class RowFile {
         }
         sync();
         out.flush();
-        out.close();
+        IOUtils.cleanup(LOG, out);
       }
     }
 

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/avro/AvroAppender.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/avro/AvroAppender.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.TableMeta;
@@ -201,7 +202,7 @@ public class AvroAppender extends FileAppender {
    */
   @Override
   public void close() throws IOException {
-    dataFileWriter.close();
+    IOUtils.cleanup(null, dataFileWriter);
   }
 
   /**

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/parquet/ParquetAppender.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/parquet/ParquetAppender.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.storage.parquet;
 
+import org.apache.hadoop.io.IOUtils;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.storage.StorageConstants;
 import parquet.hadoop.ParquetOutputFormat;
@@ -128,7 +129,7 @@ public class ParquetAppender extends FileAppender {
    */
   @Override
   public void close() throws IOException {
-    writer.close();
+    IOUtils.cleanup(null, writer);
   }
 
   public long getEstimatedOutputSize() throws IOException {

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/sequencefile/SequenceFileAppender.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/sequencefile/SequenceFileAppender.java
@@ -248,7 +248,6 @@ public class SequenceFileAppender extends FileAppender {
   @Override
   public void flush() throws IOException {
     os.flush();
-    writer.close();
   }
 
   @Override
@@ -258,8 +257,7 @@ public class SequenceFileAppender extends FileAppender {
       stats.setNumBytes(getOffset());
     }
 
-    os.close();
-    writer.close();
+    IOUtils.cleanup(LOG, os, writer);
   }
 
   @Override

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/text/DelimitedTextFile.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/text/DelimitedTextFile.java
@@ -241,10 +241,8 @@ public class DelimitedTextFile {
           deflateFilter.resetState();
           deflateFilter = null;
         }
-
-        os.close();
       } finally {
-        IOUtils.cleanup(LOG, fos);
+        IOUtils.cleanup(LOG, fos, os, outputStream);
         if (compressor != null) {
           CodecPool.returnCompressor(compressor);
           compressor = null;


### PR DESCRIPTION
TAJO-1258 branch is newly created and PR is re-created.

I modified it using IOUtils.cleanup.