### PR TITLE
TAJO-1308: QueryInprogress can not release when query is QUERY_ERROR.

### DIFF
--- a/tajo-client/src/main/java/org/apache/tajo/client/QueryClientImpl.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/QueryClientImpl.java
@@ -376,7 +376,7 @@ public class QueryClientImpl implements QueryClient {
       throws ServiceException {
 
     try {
-      ServerCallable<ClientProtos.SerializedResultSet> callable =
+      final ServerCallable<ClientProtos.SerializedResultSet> callable =
           new ServerCallable<ClientProtos.SerializedResultSet>(connection.connPool, connection.getTajoMasterAddr(),
               TajoMasterClientProtocol.class, false, true) {
 
@@ -392,7 +392,8 @@ public class QueryClientImpl implements QueryClient {
               try {
                 GetQueryResultDataResponse response = tajoMasterService.getQueryResultData(null, builder.build());
                 if (response.getResultCode() == ClientProtos.ResultCode.ERROR) {
-                  throw new ServiceException(response.getErrorTrace());
+                  abort();
+                  throw new ServiceException(response.getErrorMessage());
                 }
 
                 return response.getResultSet();
@@ -412,7 +413,9 @@ public class QueryClientImpl implements QueryClient {
           serializedResultSet.getSerializedTuplesList(),
           serializedResultSet.getSerializedTuplesCount(),
           getClientSideSessionVars());
-    } catch (Exception e) {
+    } catch (ServiceException e) {
+      throw e;
+    } catch (Throwable e) {
       throw new ServiceException(e.getMessage(), e);
     }
   }

--- a/tajo-core/src/main/java/org/apache/tajo/master/QueryInProgress.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/QueryInProgress.java
@@ -222,6 +222,7 @@ public class QueryInProgress {
 
   private boolean isFinishState(TajoProtos.QueryState state) {
     return state == TajoProtos.QueryState.QUERY_FAILED ||
+        state == TajoProtos.QueryState.QUERY_ERROR ||
         state == TajoProtos.QueryState.QUERY_KILLED ||
         state == TajoProtos.QueryState.QUERY_SUCCEEDED;
   }

--- a/tajo-core/src/main/java/org/apache/tajo/master/QueryManager.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/QueryManager.java
@@ -170,7 +170,8 @@ public class QueryManager extends CompositeService {
       dispatcher.getEventHandler().handle(new QueryJobEvent(QueryJobEvent.Type.QUERY_MASTER_START,
           queryInProgress.getQueryInfo()));
     } else {
-      stopQuery(queryId);
+      dispatcher.getEventHandler().handle(new QueryJobEvent(QueryJobEvent.Type.QUERY_JOB_STOP,
+          queryInProgress.getQueryInfo()));
     }
 
     return queryInProgress.getQueryInfo();

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterClientService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterClientService.java
@@ -512,6 +512,7 @@ public class TajoMasterClientService extends AbstractService {
     public GetQueryResultDataResponse getQueryResultData(RpcController controller, GetQueryResultDataRequest request)
         throws ServiceException {
       GetQueryResultDataResponse.Builder builder = GetQueryResultDataResponse.newBuilder();
+      SerializedResultSet.Builder resultSetBuilder = SerializedResultSet.newBuilder();
 
       try {
         context.getSessionManager().touch(request.getSessionId().getId());
@@ -524,7 +525,7 @@ public class TajoMasterClientService extends AbstractService {
         }
 
         List<ByteString> rows = queryResultScanner.getNextRows(request.getFetchRowNum());
-        SerializedResultSet.Builder resultSetBuilder = SerializedResultSet.newBuilder();
+
         resultSetBuilder.setSchema(queryResultScanner.getLogicalSchema().getProto());
         resultSetBuilder.addAllSerializedTuples(rows);
 
@@ -536,6 +537,7 @@ public class TajoMasterClientService extends AbstractService {
 
       } catch (Throwable t) {
         LOG.error(t.getMessage(), t);
+        builder.setResultSet(resultSetBuilder.build()); // required field
         builder.setResultCode(ResultCode.ERROR);
         String errorMessage = t.getMessage() == null ? t.getClass().getName() : t.getMessage();
         builder.setErrorMessage(errorMessage);


### PR DESCRIPTION
Additionally, I’ve fix the error message issue when query is failed.
```
RROR: org.apache.tajo.rpc.TajoServiceException: Message missing required fields: resultSet
java.sql.SQLException: org.apache.tajo.rpc.TajoServiceException: Message missing required fields: resultSet
        at org.apache.tajo.jdbc.TajoResultSetBase.next(TajoResultSetBase.java:786)
        at org.apache.tajo.cli.tsql.DefaultTajoCliOutputFormatter.printResult(DefaultTajoCliOutputFormatter.java:104)
        at org.apache.tajo.cli.tsql.TajoCli.localQueryCompleted(TajoCli.java:571)
        at org.apache.tajo.cli.tsql.TajoCli.executeQuery(TajoCli.java:545)
        at org.apache.tajo.cli.tsql.TajoCli.executeParsedResults(TajoCli.java:447)
        at org.apache.tajo.cli.tsql.TajoCli.runShell(TajoCli.java:419)
        at org.apache.tajo.cli.tsql.TajoCli.main(TajoCli.java:699)
Caused by: java.io.IOException: org.apache.tajo.rpc.TajoServiceException: Message missing required fields: resultSet
        at org.apache.tajo.jdbc.FetchResultSet.nextTuple(FetchResultSet.java:81)
        at org.apache.tajo.jdbc.TajoResultSetBase.next(TajoResultSetBase.java:780)
        ... 6 more
```