### PR TITLE
TAJO-1306: HAServiceUtil should not directly use HDFS.

### DIFF
--- a/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
+++ b/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
@@ -64,7 +64,7 @@ public abstract class AbstractCatalogClient implements CatalogService {
     if (catalogServerAddr == null) {
       return null;
     } else {
-      if (!conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      if (!conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
         return catalogServerAddr;
       } else {
         if (!HAServiceUtil.isMasterAlive(catalogServerAddr, conf)) {

--- a/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
+++ b/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
@@ -35,6 +35,8 @@ import org.apache.tajo.rpc.RpcConnectionPool;
 import org.apache.tajo.rpc.ServerCallable;
 import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos;
 import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos.NullProto;
+import org.apache.tajo.service.ServiceTracker;
+import org.apache.tajo.service.ServiceTrackerFactory;
 import org.apache.tajo.util.ProtoUtil;
 
 import java.net.InetSocketAddress;
@@ -48,6 +50,7 @@ import java.util.List;
 public abstract class AbstractCatalogClient implements CatalogService {
   private final Log LOG = LogFactory.getLog(AbstractCatalogClient.class);
 
+  protected ServiceTracker serviceTracker;
   protected RpcConnectionPool pool;
   protected InetSocketAddress catalogServerAddr;
   protected TajoConf conf;
@@ -57,6 +60,7 @@ public abstract class AbstractCatalogClient implements CatalogService {
   public AbstractCatalogClient(TajoConf conf, InetSocketAddress catalogServerAddr) {
     this.pool = RpcConnectionPool.getPool();
     this.catalogServerAddr = catalogServerAddr;
+    this.serviceTracker = ServiceTrackerFactory.get(conf);
     this.conf = conf;
   }
 
@@ -64,14 +68,11 @@ public abstract class AbstractCatalogClient implements CatalogService {
     if (catalogServerAddr == null) {
       return null;
     } else {
+
       if (!conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
         return catalogServerAddr;
       } else {
-        if (!HAServiceUtil.isMasterAlive(catalogServerAddr, conf)) {
-          return HAServiceUtil.getCatalogAddress(conf);
-        } else {
-          return catalogServerAddr;
-        }
+        return serviceTracker.getCatalogAddress();
       }
     }
   }

--- a/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
+++ b/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
@@ -29,7 +29,6 @@ import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.*;
 import org.apache.tajo.common.TajoDataTypes.DataType;
 import org.apache.tajo.conf.TajoConf;
-import org.apache.tajo.ha.HAServiceUtil;
 import org.apache.tajo.rpc.NettyClientBase;
 import org.apache.tajo.rpc.RpcConnectionPool;
 import org.apache.tajo.rpc.ServerCallable;
@@ -69,7 +68,7 @@ public abstract class AbstractCatalogClient implements CatalogService {
       return null;
     } else {
 
-      if (!conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+      if (!conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
         return catalogServerAddr;
       } else {
         return serviceTracker.getCatalogAddress();

--- a/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoAdmin.java
+++ b/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoAdmin.java
@@ -422,7 +422,7 @@ public class TajoAdmin {
   private void processMasters(Writer writer) throws ParseException, IOException,
       ServiceException, SQLException {
     tajoClient = TajoHAClientUtil.getTajoClient(tajoConf, tajoClient);
-    if (tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+    if (tajoConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
 
       List<String> list = HAServiceUtil.getMasters(tajoConf);
       int i = 0;

--- a/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoAdmin.java
+++ b/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoAdmin.java
@@ -422,7 +422,7 @@ public class TajoAdmin {
   private void processMasters(Writer writer) throws ParseException, IOException,
       ServiceException, SQLException {
     tajoClient = TajoHAClientUtil.getTajoClient(tajoConf, tajoClient);
-    if (tajoConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+    if (tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
 
       List<String> list = HAServiceUtil.getMasters(tajoConf);
       int i = 0;

--- a/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoHAAdmin.java
+++ b/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoHAAdmin.java
@@ -132,7 +132,7 @@ public class TajoHAAdmin {
       tajoClient = new TajoClientImpl(tajoConf);
     }
 
-    if (!tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+    if (!tajoConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
       writer.write("HA is not enabled for this tajo cluster.");
     } else {
       switch (cmdType) {

--- a/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoHAAdmin.java
+++ b/tajo-client/src/main/java/org/apache/tajo/cli/tools/TajoHAAdmin.java
@@ -132,7 +132,7 @@ public class TajoHAAdmin {
       tajoClient = new TajoClientImpl(tajoConf);
     }
 
-    if (!tajoConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+    if (!tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
       writer.write("HA is not enabled for this tajo cluster.");
     } else {
       switch (cmdType) {

--- a/tajo-client/src/main/java/org/apache/tajo/client/DummyServiceTracker.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/DummyServiceTracker.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.client;
+
+import org.apache.tajo.exception.UnsupportedException;
+import org.apache.tajo.service.ServiceTracker;
+import org.apache.tajo.service.ServiceTrackerException;
+import org.apache.tajo.service.TajoMasterInfo;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public class DummyServiceTracker implements ServiceTracker {
+  private InetSocketAddress address;
+
+  public DummyServiceTracker(InetSocketAddress address) {
+    this.address = address;
+  }
+
+  @Override
+  public boolean isHighAvailable() {
+    return false;
+  }
+
+  @Override
+  public InetSocketAddress getUmbilicalAddress() {
+    throw new UnsupportedException();
+  }
+
+  @Override
+  public InetSocketAddress getClientServiceAddress() {
+    return address;
+  }
+
+  @Override
+  public InetSocketAddress getResourceTrackerAddress() {
+    throw new UnsupportedException();
+  }
+
+  @Override
+  public InetSocketAddress getCatalogAddress() {
+    throw new UnsupportedException();
+  }
+
+  @Override
+  public InetSocketAddress getMasterHttpInfo() throws ServiceTrackerException {
+    throw new UnsupportedException();
+  }
+
+  @Override
+  public void register() throws IOException {
+  }
+
+  @Override
+  public void delete() throws IOException {
+  }
+
+  @Override
+  public boolean isActiveStatus() {
+    return true;
+  }
+
+  @Override
+  public List<TajoMasterInfo> getMasters() throws IOException {
+    throw new UnsupportedException();
+  }
+}

--- a/tajo-client/src/main/java/org/apache/tajo/client/QueryClientImpl.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/QueryClientImpl.java
@@ -376,7 +376,7 @@ public class QueryClientImpl implements QueryClient {
       throws ServiceException {
 
     try {
-      ServerCallable<ClientProtos.SerializedResultSet> callable =
+      final ServerCallable<ClientProtos.SerializedResultSet> callable =
           new ServerCallable<ClientProtos.SerializedResultSet>(connection.connPool, connection.getTajoMasterAddr(),
               TajoMasterClientProtocol.class, false, true) {
 
@@ -392,7 +392,8 @@ public class QueryClientImpl implements QueryClient {
               try {
                 GetQueryResultDataResponse response = tajoMasterService.getQueryResultData(null, builder.build());
                 if (response.getResultCode() == ClientProtos.ResultCode.ERROR) {
-                  throw new ServiceException(response.getErrorTrace());
+                  abort();
+                  throw new ServiceException(response.getErrorMessage());
                 }
 
                 return response.getResultSet();
@@ -412,7 +413,9 @@ public class QueryClientImpl implements QueryClient {
           serializedResultSet.getSerializedTuplesList(),
           serializedResultSet.getSerializedTuplesCount(),
           getClientSideSessionVars());
-    } catch (Exception e) {
+    } catch (ServiceException e) {
+      throw e;
+    } catch (Throwable e) {
       throw new ServiceException(e.getMessage(), e);
     }
   }

--- a/tajo-client/src/main/java/org/apache/tajo/client/SessionConnection.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/SessionConnection.java
@@ -21,7 +21,6 @@ package org.apache.tajo.client;
 import com.google.protobuf.ServiceException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.tajo.TajoIdProtos;
 import org.apache.tajo.annotation.Nullable;
 import org.apache.tajo.auth.UserRoleInfo;
@@ -309,7 +308,7 @@ public class SessionConnection implements Closeable {
   }
 
   protected InetSocketAddress getTajoMasterAddr() {
-    if (!conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+    if (!conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
       return tajoMasterAddr;
     } else {
       if (!HAServiceUtil.isMasterAlive(tajoMasterAddr, conf)) {

--- a/tajo-client/src/main/java/org/apache/tajo/client/SessionConnection.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/SessionConnection.java
@@ -25,7 +25,6 @@ import org.apache.tajo.TajoIdProtos;
 import org.apache.tajo.annotation.Nullable;
 import org.apache.tajo.auth.UserRoleInfo;
 import org.apache.tajo.conf.TajoConf;
-import org.apache.tajo.ha.HAServiceUtil;
 import org.apache.tajo.ipc.ClientProtos;
 import org.apache.tajo.ipc.ClientProtos.ResultCode;
 import org.apache.tajo.ipc.ClientProtos.SessionUpdateResponse;
@@ -33,6 +32,7 @@ import org.apache.tajo.ipc.TajoMasterClientProtocol;
 import org.apache.tajo.rpc.NettyClientBase;
 import org.apache.tajo.rpc.RpcConnectionPool;
 import org.apache.tajo.rpc.ServerCallable;
+import org.apache.tajo.service.ServiceTracker;
 import org.apache.tajo.util.KeyValueSet;
 import org.apache.tajo.util.NetUtils;
 import org.apache.tajo.util.ProtoUtil;
@@ -57,8 +57,6 @@ public class SessionConnection implements Closeable {
 
   private final TajoConf conf;
 
-  final InetSocketAddress tajoMasterAddr;
-
   final RpcConnectionPool connPool;
 
   private final String baseDatabase;
@@ -72,41 +70,29 @@ public class SessionConnection implements Closeable {
   /** session variable cache */
   private final Map<String, String> sessionVarsCache = new HashMap<String, String>();
 
-
-  public SessionConnection(TajoConf conf) throws IOException {
-    this(conf, NetUtils.createSocketAddr(conf.getVar(TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS)), null);
-  }
-
-  public SessionConnection(TajoConf conf, @Nullable String baseDatabase) throws IOException {
-    this(conf, NetUtils.createSocketAddr(conf.getVar(TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS)), baseDatabase);
-  }
-
-  public SessionConnection(InetSocketAddress addr) throws IOException {
-    this(new TajoConf(), addr, null);
-  }
-
-  public SessionConnection(String hostname, int port, String baseDatabase) throws IOException {
-    this(new TajoConf(), NetUtils.createSocketAddr(hostname, port), baseDatabase);
-  }
+  private ServiceTracker serviceTracker;
 
   /**
    * Connect to TajoMaster
    *
    * @param conf TajoConf
-   * @param addr TajoMaster address
+   * @param tracker TajoMaster address
    * @param baseDatabase The base database name. It is case sensitive. If it is null,
    *                     the 'default' database will be used.
    * @throws java.io.IOException
    */
-  public SessionConnection(TajoConf conf, InetSocketAddress addr, @Nullable String baseDatabase) throws IOException {
+  public SessionConnection(TajoConf conf, ServiceTracker tracker, @Nullable String baseDatabase)
+      throws IOException {
+
     this.conf = conf;
     this.conf.set("tajo.disk.scheduler.report.interval", "0");
-    this.tajoMasterAddr = addr;
     int workerNum = conf.getIntVar(TajoConf.ConfVars.RPC_CLIENT_WORKER_THREAD_NUM);
     // Don't share connection pool per client
     connPool = RpcConnectionPool.newPool(getClass().getSimpleName(), workerNum);
     userInfo = UserRoleInfo.getCurrentUser();
     this.baseDatabase = baseDatabase != null ? baseDatabase : null;
+
+    this.serviceTracker = tracker;
   }
 
   public Map<String, String> getClientSideSessionVars() {
@@ -139,7 +125,8 @@ public class SessionConnection implements Closeable {
   public boolean isConnected() {
     if(!closed.get()){
       try {
-        return connPool.getConnection(tajoMasterAddr, TajoMasterClientProtocol.class, false).isConnected();
+        return connPool.getConnection(serviceTracker.getClientServiceAddress(),
+            TajoMasterClientProtocol.class, false).isConnected();
       } catch (Throwable e) {
         return false;
       }
@@ -308,15 +295,7 @@ public class SessionConnection implements Closeable {
   }
 
   protected InetSocketAddress getTajoMasterAddr() {
-    if (!conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-      return tajoMasterAddr;
-    } else {
-      if (!HAServiceUtil.isMasterAlive(tajoMasterAddr, conf)) {
-        return HAServiceUtil.getMasterClientAddress(conf);
-      } else {
-        return tajoMasterAddr;
-      }
-    }
+    return serviceTracker.getClientServiceAddress();
   }
 
   protected void checkSessionAndGet(NettyClientBase client) throws ServiceException {

--- a/tajo-client/src/main/java/org/apache/tajo/client/TajoClientImpl.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/TajoClientImpl.java
@@ -32,8 +32,6 @@ import org.apache.tajo.catalog.TableMeta;
 import org.apache.tajo.catalog.partition.PartitionMethodDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.conf.TajoConf;
-import org.apache.tajo.conf.TajoConf.ConfVars;
-import org.apache.tajo.ha.HAServiceUtil;
 import org.apache.tajo.ipc.ClientProtos.*;
 import org.apache.tajo.jdbc.TajoMemoryResultSet;
 import org.apache.tajo.jdbc.TajoResultSet;
@@ -41,6 +39,8 @@ import org.apache.tajo.rule.EvaluationContext;
 import org.apache.tajo.rule.EvaluationFailedException;
 import org.apache.tajo.rule.SelfDiagnosisRuleEngine;
 import org.apache.tajo.rule.SelfDiagnosisRuleSession;
+import org.apache.tajo.service.ServiceTracker;
+import org.apache.tajo.service.ServiceTrackerFactory;
 import org.apache.tajo.util.NetUtils;
 
 import java.io.IOException;
@@ -56,41 +56,30 @@ public class TajoClientImpl extends SessionConnection implements TajoClient, Que
   QueryClient queryClient;
   CatalogAdminClient catalogClient;
 
-  public TajoClientImpl(TajoConf conf) throws IOException {
-    this(conf, TajoHAClientUtil.getRpcClientAddress(conf), null);
-  }
-
-  public TajoClientImpl(TajoConf conf, @Nullable String baseDatabase) throws IOException {
-    this(conf, TajoHAClientUtil.getRpcClientAddress(conf), baseDatabase);
-  }
-
-  public TajoClientImpl(InetSocketAddress addr) throws IOException {
-    this(new TajoConf(), addr, null);
-  }
-
   /**
    * Connect to TajoMaster
    *
    * @param conf TajoConf
-   * @param addr TajoMaster address
+   * @param tracker ServiceTracker to discovery Tajo Client RPC
    * @param baseDatabase The base database name. It is case sensitive. If it is null,
    *                     the 'default' database will be used.
    * @throws java.io.IOException
    */
-  public TajoClientImpl(TajoConf conf, InetSocketAddress addr, @Nullable String baseDatabase) throws IOException {
-    super(conf, addr, baseDatabase);
+  public TajoClientImpl(TajoConf conf, ServiceTracker tracker, @Nullable String baseDatabase) throws IOException {
+    super(conf, tracker, baseDatabase);
+
     this.queryClient = new QueryClientImpl(this);
     this.catalogClient = new CatalogAdminClientImpl(this);
-    
+
     diagnoseTajoClient();
   }
 
-  public TajoClientImpl(String hostName, int port, @Nullable String baseDatabase) throws IOException {
-    super(hostName, port, baseDatabase);
-    this.queryClient = new QueryClientImpl(this);
-    this.catalogClient = new CatalogAdminClientImpl(this);
-    
-    diagnoseTajoClient();
+  public TajoClientImpl(TajoConf conf) throws IOException {
+    this(conf, ServiceTrackerFactory.get(conf), null);
+  }
+
+  public TajoClientImpl(TajoConf conf, @Nullable String baseDatabase) throws IOException {
+    this(conf, ServiceTrackerFactory.get(conf), baseDatabase);
   }
   
   private void diagnoseTajoClient() throws EvaluationFailedException {

--- a/tajo-client/src/main/java/org/apache/tajo/client/TajoClientImpl.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/TajoClientImpl.java
@@ -41,7 +41,6 @@ import org.apache.tajo.rule.SelfDiagnosisRuleEngine;
 import org.apache.tajo.rule.SelfDiagnosisRuleSession;
 import org.apache.tajo.service.ServiceTracker;
 import org.apache.tajo.service.ServiceTrackerFactory;
-import org.apache.tajo.util.NetUtils;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
@@ -65,6 +65,7 @@ public class TajoHAClientUtil {
       TajoCliContext context) throws IOException, ServiceException {
 
     if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+
       if (!HAServiceUtil.isMasterAlive(conf.getVar(
         TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS), conf)) {
         TajoClient tajoClient = null;
@@ -85,15 +86,4 @@ public class TajoHAClientUtil {
       return client;
     }
   }
-
-
-  public static InetSocketAddress getRpcClientAddress(TajoConf conf) {
-    if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-      return NetUtils.createSocketAddr(HAServiceUtil.getMasterClientName(conf));
-    } else {
-      return NetUtils.createSocketAddr(conf.getVar(TajoConf.ConfVars
-        .TAJO_MASTER_CLIENT_RPC_ADDRESS));
-    }
-  }
-
 }

--- a/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
@@ -40,10 +40,8 @@ import com.google.protobuf.ServiceException;
 import org.apache.tajo.cli.tsql.TajoCli.TajoCliContext;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.ha.HAServiceUtil;
-import org.apache.tajo.util.NetUtils;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 
 public class TajoHAClientUtil {
   /**
@@ -64,7 +62,7 @@ public class TajoHAClientUtil {
   public static TajoClient getTajoClient(TajoConf conf, TajoClient client,
       TajoCliContext context) throws IOException, ServiceException {
 
-    if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
 
       if (!HAServiceUtil.isMasterAlive(conf.getVar(
         TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS), conf)) {

--- a/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/TajoHAClientUtil.java
@@ -64,7 +64,7 @@ public class TajoHAClientUtil {
   public static TajoClient getTajoClient(TajoConf conf, TajoClient client,
       TajoCliContext context) throws IOException, ServiceException {
 
-    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+    if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
       if (!HAServiceUtil.isMasterAlive(conf.getVar(
         TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS), conf)) {
         TajoClient tajoClient = null;
@@ -88,7 +88,7 @@ public class TajoHAClientUtil {
 
 
   public static InetSocketAddress getRpcClientAddress(TajoConf conf) {
-    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+    if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
       return NetUtils.createSocketAddr(HAServiceUtil.getMasterClientName(conf));
     } else {
       return NetUtils.createSocketAddr(conf.getVar(TajoConf.ConfVars

--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -136,8 +136,8 @@ public class TajoConf extends Configuration {
     TAJO_MASTER_INFO_ADDRESS("tajo.master.info-http.address", "0.0.0.0:26080", Validators.networkAddr()),
 
     // High availability configurations
-    HA_ENABLE("tajo.ha.enable", false, Validators.bool()),
-    HA_MONITOR_INTERVAL("tajo.ha.monitor.interval", 5 * 1000), // 5 sec
+    TAJO_MASTER_HA_ENABLE("tajo.master.ha.enable", false, Validators.bool()),
+    TAJO_MASTER_HA_MONITOR_INTERVAL("tajo.master.ha.monitor.interval", 5 * 1000), // 5 sec
 
     // Service discovery
     DEFAULT_SERVICE_TRACKER_CLASS("tajo.discovery.service-tracker.class", BaseServiceTracker.class.getCanonicalName()),

--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.tajo.ConfigKey;
 import org.apache.tajo.SessionVars;
 import org.apache.tajo.TajoConstants;
+import org.apache.tajo.service.BaseServiceTracker;
 import org.apache.tajo.util.NetUtils;
 import org.apache.tajo.util.NumberUtil;
 import org.apache.tajo.util.TUtil;
@@ -134,9 +135,13 @@ public class TajoConf extends Configuration {
         Validators.networkAddr()),
     TAJO_MASTER_INFO_ADDRESS("tajo.master.info-http.address", "0.0.0.0:26080", Validators.networkAddr()),
 
-    // Tajo Master HA Configurations
-    TAJO_MASTER_HA_ENABLE("tajo.master.ha.enable", false, Validators.bool()),
-    TAJO_MASTER_HA_MONITOR_INTERVAL("tajo.master.ha.monitor.interval", 5 * 1000), // 5 sec
+    // High availability configurations
+    HA_ENABLE("tajo.ha.enable", false, Validators.bool()),
+    HA_MONITOR_INTERVAL("tajo.ha.monitor.interval", 5 * 1000), // 5 sec
+
+    // Service discovery
+    DEFAULT_SERVICE_TRACKER_CLASS("tajo.discovery.service-tracker.class", BaseServiceTracker.class.getCanonicalName()),
+    HA_SERVICE_TRACKER_CLASS("tajo.discovery.ha-service-tracker.class", "org.apache.tajo.ha.HdfsServiceTracker"),
 
     // Resource tracker service
     RESOURCE_TRACKER_RPC_ADDRESS("tajo.resource-tracker.rpc.address", "localhost:26003",

--- a/tajo-common/src/main/java/org/apache/tajo/ha/HAServiceUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/ha/HAServiceUtil.java
@@ -34,15 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class HAServiceUtil {
-  private static Log LOG = LogFactory.getLog(HAServiceUtil.class);
-
-  public static InetSocketAddress getMasterUmbilicalAddress(TajoConf conf) {
-    return getMasterAddress(conf, HAConstants.MASTER_UMBILICAL_RPC_ADDRESS);
-  }
-
-  public static String getMasterUmbilicalName(TajoConf conf) {
-    return NetUtils.normalizeInetSocketAddress(getMasterUmbilicalAddress(conf));
-  }
 
   public static InetSocketAddress getMasterClientAddress(TajoConf conf) {
     return getMasterAddress(conf, HAConstants.MASTER_CLIENT_RPC_ADDRESS);
@@ -50,30 +41,6 @@ public class HAServiceUtil {
 
   public static String getMasterClientName(TajoConf conf) {
     return NetUtils.normalizeInetSocketAddress(getMasterClientAddress(conf));
-  }
-
-  public static InetSocketAddress getResourceTrackerAddress(TajoConf conf) {
-    return getMasterAddress(conf, HAConstants.RESOURCE_TRACKER_RPC_ADDRESS);
-  }
-
-  public static String getResourceTrackerName(TajoConf conf) {
-    return NetUtils.normalizeInetSocketAddress(getResourceTrackerAddress(conf));
-  }
-
-  public static InetSocketAddress getCatalogAddress(TajoConf conf) {
-    return getMasterAddress(conf, HAConstants.CATALOG_ADDRESS);
-  }
-
-  public static String getCatalogName(TajoConf conf) {
-    return NetUtils.normalizeInetSocketAddress(getCatalogAddress(conf));
-  }
-
-  public static InetSocketAddress getMasterInfoAddress(TajoConf conf) {
-    return getMasterAddress(conf, HAConstants.MASTER_INFO_ADDRESS);
-  }
-
-  public static String getMasterInfoName(TajoConf conf) {
-    return NetUtils.normalizeInetSocketAddress(getMasterInfoAddress(conf));
   }
 
   public static InetSocketAddress getMasterAddress(TajoConf conf, int type) {
@@ -151,10 +118,6 @@ public class HAServiceUtil {
     }
 
     return masterAddress;
-  }
-
-  public static boolean isMasterAlive(InetSocketAddress masterAddress, TajoConf conf) {
-    return isMasterAlive(NetUtils.normalizeInetSocketAddress(masterAddress), conf);
   }
 
   public static boolean isMasterAlive(String masterName, TajoConf conf) {

--- a/tajo-common/src/main/java/org/apache/tajo/ha/HAServiceUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/ha/HAServiceUtil.java
@@ -79,7 +79,7 @@ public class HAServiceUtil {
   public static InetSocketAddress getMasterAddress(TajoConf conf, int type) {
     InetSocketAddress masterAddress = null;
 
-    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+    if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
       try {
         FileSystem fs = getFileSystem(conf);
         Path activePath = new Path(TajoConf.getSystemHADir(conf), TajoConstants.SYSTEM_HA_ACTIVE_DIR_NAME);

--- a/tajo-common/src/main/java/org/apache/tajo/ha/HAServiceUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/ha/HAServiceUtil.java
@@ -18,8 +18,6 @@
 
 package org.apache.tajo.ha;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.*;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.conf.TajoConf;
@@ -46,7 +44,7 @@ public class HAServiceUtil {
   public static InetSocketAddress getMasterAddress(TajoConf conf, int type) {
     InetSocketAddress masterAddress = null;
 
-    if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+    if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
       try {
         FileSystem fs = getFileSystem(conf);
         Path activePath = new Path(TajoConf.getSystemHADir(conf), TajoConstants.SYSTEM_HA_ACTIVE_DIR_NAME);

--- a/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.service;
+
+import org.apache.tajo.conf.TajoConf;
+import org.apache.tajo.util.TUtil;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public class BaseServiceTracker implements ServiceTracker {
+  private final TajoConf conf;
+  private TajoMasterInfo tajoMasterInfo;
+  private List<TajoMasterInfo> tajoMasterInfos;
+
+  @SuppressWarnings("unused")
+  public BaseServiceTracker(TajoConf conf) {
+    this.conf = conf;
+
+    tajoMasterInfo = new TajoMasterInfo();
+    tajoMasterInfo.setActive(true);
+    tajoMasterInfo.setAvailable(true);
+    tajoMasterInfo.setTajoMasterAddress(conf.getSocketAddrVar(TajoConf.ConfVars.TAJO_MASTER_UMBILICAL_RPC_ADDRESS));
+    tajoMasterInfo.setTajoClientAddress(conf.getSocketAddrVar(TajoConf.ConfVars.TAJO_MASTER_CLIENT_RPC_ADDRESS));
+    tajoMasterInfo.setWorkerResourceTrackerAddr(conf.getSocketAddrVar(TajoConf.ConfVars.RESOURCE_TRACKER_RPC_ADDRESS));
+    tajoMasterInfo.setCatalogAddress(conf.getSocketAddrVar(TajoConf.ConfVars.CATALOG_ADDRESS));
+    tajoMasterInfo.setWebServerAddress(conf.getSocketAddrVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS));
+
+    tajoMasterInfos = TUtil.newList(tajoMasterInfo);
+  }
+
+  @Override
+  public boolean isHighAvailable() {
+    return false;
+  }
+
+  @Override
+  public InetSocketAddress getUmbilicalAddress() {
+    return tajoMasterInfo.getTajoMasterAddress();
+  }
+
+  @Override
+  public InetSocketAddress getClientServiceAddress() {
+    return tajoMasterInfo.getTajoClientAddress();
+  }
+
+  @Override
+  public InetSocketAddress getResourceTrackerAddress() {
+    return tajoMasterInfo.getWorkerResourceTrackerAddr();
+  }
+
+  @Override
+  public InetSocketAddress getCatalogAddress() {
+    return tajoMasterInfo.getCatalogAddress();
+  }
+
+  @Override
+  public InetSocketAddress getMasterHttpInfo() throws ServiceTrackerException {
+    return tajoMasterInfo.getWebServerAddress();
+  }
+
+  @Override
+  public void register() throws IOException {
+  }
+
+  @Override
+  public void delete() throws IOException {
+  }
+
+  @Override
+  public boolean isActiveStatus() {
+    return true;
+  }
+
+  @Override
+  public List<TajoMasterInfo> getMasters() throws IOException {
+    return tajoMasterInfos;
+  }
+
+}

--- a/tajo-common/src/main/java/org/apache/tajo/service/HAServiceTracker.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/HAServiceTracker.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.service;
+
+import org.apache.hadoop.net.NetUtils;
+
+import javax.net.SocketFactory;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+public abstract class HAServiceTracker implements ServiceTracker {
+
+  static SocketFactory socketFactory = SocketFactory.getDefault();
+
+  public boolean isHighAvailable() {
+    return true;
+  }
+
+  public static boolean checkConnection(InetSocketAddress address) {
+    boolean isAlive = true;
+
+    try {
+      int connectionTimeout = 10;
+
+      Socket socket = socketFactory.createSocket();
+      NetUtils.connect(socket, address, connectionTimeout);
+    } catch (Exception e) {
+      isAlive = false;
+    }
+    return isAlive;
+  }
+}

--- a/tajo-common/src/main/java/org/apache/tajo/service/ServiceTracker.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/ServiceTracker.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.service;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public interface ServiceTracker {
+
+  public abstract boolean isHighAvailable();
+
+  public abstract InetSocketAddress getUmbilicalAddress() throws ServiceTrackerException;
+
+  public abstract InetSocketAddress getClientServiceAddress() throws ServiceTrackerException;
+
+  public abstract InetSocketAddress getResourceTrackerAddress() throws ServiceTrackerException;
+
+  public abstract InetSocketAddress getCatalogAddress() throws ServiceTrackerException;
+
+  public abstract InetSocketAddress getMasterHttpInfo() throws ServiceTrackerException;
+
+  /**
+   * Add master name to shared storage.
+   */
+  public void register() throws IOException;
+
+
+  /**
+   * Delete master name to shared storage.
+   *
+   */
+  public void delete() throws IOException;
+
+  /**
+   *
+   * @return True if current master is an active master.
+   */
+  public boolean isActiveStatus();
+
+  /**
+   *
+   * @return return all master list
+   * @throws IOException
+   */
+  public List<TajoMasterInfo> getMasters() throws IOException;
+}

--- a/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerException.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerException.java
@@ -16,41 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.tajo.ha;
+package org.apache.tajo.service;
 
-import java.io.IOException;
-import java.util.List;
+public class ServiceTrackerException extends RuntimeException {
 
-/**
- * The HAService is responsible for setting active TajoMaster on startup or when the
- * current active is changing (eg due to failure), monitoring the health of TajoMaster.
- *
- */
-public interface HAService {
+  public ServiceTrackerException(Throwable t) {
+    super(t);
+  }
 
-  /**
-   * Add master name to shared storage.
-   */
-  public void register() throws IOException;
-
-
-  /**
-   * Delete master name to shared storage.
-   *
-   */
-  public void delete() throws IOException;
-
-  /**
-   *
-   * @return True if current master is an active master.
-   */
-  public boolean isActiveStatus();
-
-  /**
-   *
-   * @return return all master list
-   * @throws IOException
-   */
-  public List<TajoMasterInfo> getMasters() throws IOException;
-
+  public ServiceTrackerException(String message) {
+    super(message);
+  }
 }

--- a/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerFactory.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerFactory.java
@@ -27,7 +27,7 @@ public class ServiceTrackerFactory {
     Class<ServiceTracker> trackerClass;
 
     try {
-      if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+      if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
         trackerClass = (Class<ServiceTracker>) conf.getClassVar(TajoConf.ConfVars.HA_SERVICE_TRACKER_CLASS);
       } else {
         trackerClass = (Class<ServiceTracker>) conf.getClassVar(TajoConf.ConfVars.DEFAULT_SERVICE_TRACKER_CLASS);

--- a/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerFactory.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.service;
+
+import org.apache.tajo.conf.TajoConf;
+import org.apache.tajo.util.ReflectionUtil;
+
+public class ServiceTrackerFactory {
+
+  public static ServiceTracker getServiceTracker(TajoConf conf) {
+    Class<ServiceTracker> trackerClass;
+
+    try {
+      if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+        trackerClass = (Class<ServiceTracker>) conf.getClassVar(TajoConf.ConfVars.HA_SERVICE_TRACKER_CLASS);
+      } else {
+        trackerClass = (Class<ServiceTracker>) conf.getClassVar(TajoConf.ConfVars.DEFAULT_SERVICE_TRACKER_CLASS);
+      }
+      return ReflectionUtil.newInstance(trackerClass, conf);
+
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+}

--- a/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerFactory.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/ServiceTrackerFactory.java
@@ -23,7 +23,7 @@ import org.apache.tajo.util.ReflectionUtil;
 
 public class ServiceTrackerFactory {
 
-  public static ServiceTracker getServiceTracker(TajoConf conf) {
+  public static ServiceTracker get(TajoConf conf) {
     Class<ServiceTracker> trackerClass;
 
     try {

--- a/tajo-common/src/main/java/org/apache/tajo/service/TajoMasterInfo.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/TajoMasterInfo.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.tajo.ha;
+package org.apache.tajo.service;
 
 import java.net.InetSocketAddress;
 

--- a/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
@@ -178,7 +178,7 @@ public class HdfsServiceTracker extends HAServiceTracker {
 
     try {
       out.writeUTF(sb.toString());
-      out.hflush();
+      out.hsync();
       out.close();
     } catch (FileAlreadyExistsException e) {
       createMasterFile(false);

--- a/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
@@ -75,7 +75,7 @@ public class HdfsServiceTracker extends HAServiceTracker {
     InetSocketAddress socketAddress = conf.getSocketAddrVar(ConfVars.TAJO_MASTER_UMBILICAL_RPC_ADDRESS);
     this.masterName = socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort();
 
-    monitorInterval = conf.getIntVar(ConfVars.HA_MONITOR_INTERVAL);
+    monitorInterval = conf.getIntVar(ConfVars.TAJO_MASTER_HA_MONITOR_INTERVAL);
   }
 
   private void initSystemDirectory() throws IOException {

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoContainerProxy.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoContainerProxy.java
@@ -174,7 +174,7 @@ public class TajoContainerProxy extends ContainerProxy {
       // if worker can't connect the master, worker should try to connect another master and
       // update master address in worker context.
       TajoConf conf = context.getConf();
-      if (conf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      if (conf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
         try {
           tmClient = connPool.getConnection(context.getQueryMasterContext().getWorkerContext().getTajoMasterAddress(),
               QueryCoordinatorProtocol.class, true);

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -40,18 +40,18 @@ import org.apache.tajo.catalog.LocalCatalogWrapper;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.conf.TajoConf.ConfVars;
 import org.apache.tajo.engine.function.FunctionLoader;
-import org.apache.tajo.ha.HAService;
-import org.apache.tajo.ha.HAServiceHDFSImpl;
-import org.apache.tajo.metrics.CatalogMetricsGaugeSet;
-import org.apache.tajo.metrics.WorkerResourceMetricsGaugeSet;
 import org.apache.tajo.master.rm.TajoWorkerResourceManager;
 import org.apache.tajo.master.rm.WorkerResourceManager;
-import org.apache.tajo.session.SessionManager;
+import org.apache.tajo.metrics.CatalogMetricsGaugeSet;
+import org.apache.tajo.metrics.WorkerResourceMetricsGaugeSet;
 import org.apache.tajo.rpc.RpcChannelFactory;
 import org.apache.tajo.rule.EvaluationContext;
 import org.apache.tajo.rule.EvaluationFailedException;
 import org.apache.tajo.rule.SelfDiagnosisRuleEngine;
 import org.apache.tajo.rule.SelfDiagnosisRuleSession;
+import org.apache.tajo.service.ServiceTracker;
+import org.apache.tajo.service.ServiceTrackerFactory;
+import org.apache.tajo.session.SessionManager;
 import org.apache.tajo.storage.FileStorageManager;
 import org.apache.tajo.storage.StorageManager;
 import org.apache.tajo.util.*;
@@ -127,7 +127,7 @@ public class TajoMaster extends CompositeService {
 
   private TajoSystemMetrics systemMetrics;
 
-  private HAService haService;
+  private ServiceTracker haService;
 
   private JvmPauseMonitor pauseMonitor;
 
@@ -226,15 +226,6 @@ public class TajoMaster extends CompositeService {
     }
   }
 
-
-  private void initHAManger() throws Exception {
-    // If tajo provides haService based on ZooKeeper, following codes need to update.
-    if (systemConf.getBoolVar(ConfVars.TAJO_MASTER_HA_ENABLE)) {
-      haService = new HAServiceHDFSImpl(context);
-      haService.register();
-    }
-  }
-
   public boolean isActiveMaster() {
     return (haService != null ? haService.isActiveStatus() : true);
   }
@@ -326,11 +317,8 @@ public class TajoMaster extends CompositeService {
 
     initSystemMetrics();
 
-    try {
-      initHAManger();
-    } catch (IOException e) {
-      LOG.error(e.getMessage(), e);
-    }
+    haService = ServiceTrackerFactory.getServiceTracker(systemConf);
+    haService.register();
 
     historyWriter = new HistoryWriter(getMasterName(), true);
     historyWriter.init(getConfig());
@@ -477,7 +465,7 @@ public class TajoMaster extends CompositeService {
       return systemMetrics;
     }
 
-    public HAService getHAService() {
+    public ServiceTracker getHAService() {
       return haService;
     }
 

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -317,7 +317,7 @@ public class TajoMaster extends CompositeService {
 
     initSystemMetrics();
 
-    haService = ServiceTrackerFactory.getServiceTracker(systemConf);
+    haService = ServiceTrackerFactory.get(systemConf);
     haService.register();
 
     historyWriter = new HistoryWriter(getMasterName(), true);

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/QueryMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/QueryMaster.java
@@ -229,7 +229,7 @@ public class QueryMaster extends CompositeService implements EventHandler {
       // worker may fail to connect existing active master. Thus,
       // if worker can't connect the master, worker should try to connect another master and
       // update master address in worker context.
-      if (systemConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
         try {
           rpc = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
               QueryCoordinatorProtocol.class, true);
@@ -357,7 +357,7 @@ public class QueryMaster extends CompositeService implements EventHandler {
         // worker may fail to connect existing active master. Thus,
         // if worker can't connect the master, worker should try to connect another master and
         // update master address in worker context.
-        if (systemConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+        if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
           try {
             tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
                 QueryCoordinatorProtocol.class, true);
@@ -474,7 +474,7 @@ public class QueryMaster extends CompositeService implements EventHandler {
               // worker may fail to connect existing active master. Thus,
               // if worker can't connect the master, worker should try to connect another master and
               // update master address in worker context.
-              if (systemConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+              if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
                 try {
                   tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
                       QueryCoordinatorProtocol.class, true);

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/QueryMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/QueryMaster.java
@@ -44,6 +44,7 @@ import org.apache.tajo.rpc.NettyClientBase;
 import org.apache.tajo.rpc.NullCallback;
 import org.apache.tajo.rpc.RpcConnectionPool;
 import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos;
+import org.apache.tajo.service.ServiceTracker;
 import org.apache.tajo.util.NetUtils;
 import org.apache.tajo.util.history.QueryHistory;
 import org.apache.tajo.worker.TajoWorker;
@@ -229,23 +230,9 @@ public class QueryMaster extends CompositeService implements EventHandler {
       // worker may fail to connect existing active master. Thus,
       // if worker can't connect the master, worker should try to connect another master and
       // update master address in worker context.
-      if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-        try {
-          rpc = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-              QueryCoordinatorProtocol.class, true);
-        } catch (Exception e) {
-          queryMasterContext.getWorkerContext().setWorkerResourceTrackerAddr(
-              HAServiceUtil.getResourceTrackerAddress(systemConf));
-          queryMasterContext.getWorkerContext().setTajoMasterAddress(
-              HAServiceUtil.getMasterUmbilicalAddress(systemConf));
-          rpc = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-              QueryCoordinatorProtocol.class, true);
-        }
-      } else {
-        rpc = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-            QueryCoordinatorProtocol.class, true);
-      }
 
+      ServiceTracker serviceTracker = workerContext.getServiceTracker();
+      rpc = connPool.getConnection(serviceTracker.getUmbilicalAddress(), QueryCoordinatorProtocol.class, true);
       QueryCoordinatorProtocolService masterService = rpc.getStub();
 
       CallFuture<WorkerResourcesRequest> callBack = new CallFuture<WorkerResourcesRequest>();
@@ -353,24 +340,8 @@ public class QueryMaster extends CompositeService implements EventHandler {
 
       NettyClientBase tmClient = null;
       try {
-        // In TajoMaster HA mode, if backup master be active status,
-        // worker may fail to connect existing active master. Thus,
-        // if worker can't connect the master, worker should try to connect another master and
-        // update master address in worker context.
-        if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-          try {
-            tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-                QueryCoordinatorProtocol.class, true);
-          } catch (Exception e) {
-            queryMasterContext.getWorkerContext().setWorkerResourceTrackerAddr(HAServiceUtil.getResourceTrackerAddress(systemConf));
-            queryMasterContext.getWorkerContext().setTajoMasterAddress(HAServiceUtil.getMasterUmbilicalAddress(systemConf));
-            tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-                QueryCoordinatorProtocol.class, true);
-          }
-        } else {
-          tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-              QueryCoordinatorProtocol.class, true);
-        }
+        tmClient = connPool.getConnection(workerContext.getServiceTracker().getUmbilicalAddress(),
+            QueryCoordinatorProtocol.class, true);
 
         QueryCoordinatorProtocolService masterClientService = tmClient.getStub();
         masterClientService.heartbeat(future.getController(), queryHeartbeat, future);
@@ -470,32 +441,13 @@ public class QueryMaster extends CompositeService implements EventHandler {
           for(QueryMasterTask eachTask: tempTasks) {
             NettyClientBase tmClient;
             try {
-              // In TajoMaster HA mode, if backup master be active status,
-              // worker may fail to connect existing active master. Thus,
-              // if worker can't connect the master, worker should try to connect another master and
-              // update master address in worker context.
-              if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-                try {
-                  tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-                      QueryCoordinatorProtocol.class, true);
-                } catch (Exception e) {
-                  queryMasterContext.getWorkerContext().setWorkerResourceTrackerAddr(
-                      HAServiceUtil.getResourceTrackerAddress(systemConf));
-                  queryMasterContext.getWorkerContext().setTajoMasterAddress(
-                      HAServiceUtil.getMasterUmbilicalAddress(systemConf));
-                  tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-                      QueryCoordinatorProtocol.class, true);
-                }
-              } else {
-                tmClient = connPool.getConnection(queryMasterContext.getWorkerContext().getTajoMasterAddress(),
-                    QueryCoordinatorProtocol.class, true);
-              }
 
+              ServiceTracker serviceTracker = queryMasterContext.getWorkerContext().getServiceTracker();
+              tmClient = connPool.getConnection(serviceTracker.getUmbilicalAddress(),
+                  QueryCoordinatorProtocol.class, true);
               QueryCoordinatorProtocolService masterClientService = tmClient.getStub();
 
-              CallFuture<QueryCoordinatorProtocol.TajoHeartbeatResponse> callBack =
-                  new CallFuture<QueryCoordinatorProtocol.TajoHeartbeatResponse>();
-
+              CallFuture<TajoHeartbeatResponse> callBack = new CallFuture<TajoHeartbeatResponse>();
               TajoHeartbeat queryHeartbeat = buildTajoHeartBeat(eachTask);
               masterClientService.heartbeat(callBack.getController(), queryHeartbeat, callBack);
             } catch (Throwable t) {

--- a/tajo-core/src/main/java/org/apache/tajo/util/JSPUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/JSPUtil.java
@@ -23,16 +23,16 @@ import org.apache.tajo.catalog.FunctionDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.statistics.TableStats;
 import org.apache.tajo.conf.TajoConf;
-import org.apache.tajo.master.TajoMaster.MasterContext;
-import org.apache.tajo.ha.HAService;
 import org.apache.tajo.master.QueryInProgress;
+import org.apache.tajo.master.TajoMaster.MasterContext;
 import org.apache.tajo.querymaster.QueryMasterTask;
-import org.apache.tajo.querymaster.Task;
 import org.apache.tajo.querymaster.Stage;
-import org.apache.tajo.util.history.TaskHistory;
+import org.apache.tajo.querymaster.Task;
+import org.apache.tajo.service.ServiceTracker;
 import org.apache.tajo.util.history.StageHistory;
-import org.apache.tajo.worker.TaskRunnerHistory;
+import org.apache.tajo.util.history.TaskHistory;
 import org.apache.tajo.worker.TaskRunner;
+import org.apache.tajo.worker.TaskRunnerHistory;
 
 import java.text.DecimalFormat;
 import java.util.*;
@@ -191,7 +191,7 @@ public class JSPUtil {
   }
 
   public static String getMasterActiveLabel(MasterContext context) {
-    HAService haService = context.getHAService();
+    ServiceTracker haService = context.getHAService();
     String activeLabel = "";
     if (haService != null) {
       if (haService.isActiveStatus()) {

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TajoResourceAllocator.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TajoResourceAllocator.java
@@ -279,7 +279,7 @@ public class TajoResourceAllocator extends AbstractResourceAllocator {
         // worker may fail to connect existing active master. Thus,
         // if worker can't connect the master, worker should try to connect another master and
         // update master address in worker context.
-        if (tajoConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+        if (tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
           try {
             tmClient = connPool.getConnection(
               queryTaskContext.getQueryMasterContext().getWorkerContext().getTajoMasterAddress(),

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TajoResourceAllocator.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TajoResourceAllocator.java
@@ -51,6 +51,7 @@ import org.apache.tajo.rpc.CallFuture;
 import org.apache.tajo.rpc.NettyClientBase;
 import org.apache.tajo.rpc.NullCallback;
 import org.apache.tajo.rpc.RpcConnectionPool;
+import org.apache.tajo.service.ServiceTracker;
 import org.apache.tajo.util.ApplicationIdUtils;
 
 import java.net.InetSocketAddress;
@@ -274,31 +275,8 @@ public class TajoResourceAllocator extends AbstractResourceAllocator {
       RpcConnectionPool connPool = RpcConnectionPool.getPool();
       NettyClientBase tmClient = null;
       try {
-
-        // In TajoMaster HA mode, if backup master be active status,
-        // worker may fail to connect existing active master. Thus,
-        // if worker can't connect the master, worker should try to connect another master and
-        // update master address in worker context.
-        if (tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-          try {
-            tmClient = connPool.getConnection(
-              queryTaskContext.getQueryMasterContext().getWorkerContext().getTajoMasterAddress(),
-              QueryCoordinatorProtocol.class, true);
-          } catch (Exception e) {
-            queryTaskContext.getQueryMasterContext().getWorkerContext().
-              setWorkerResourceTrackerAddr(HAServiceUtil.getResourceTrackerAddress(tajoConf));
-            queryTaskContext.getQueryMasterContext().getWorkerContext().
-              setTajoMasterAddress(HAServiceUtil.getMasterUmbilicalAddress(tajoConf));
-            tmClient = connPool.getConnection(
-              queryTaskContext.getQueryMasterContext().getWorkerContext().getTajoMasterAddress(),
-              QueryCoordinatorProtocol.class, true);
-          }
-        } else {
-          tmClient = connPool.getConnection(
-            queryTaskContext.getQueryMasterContext().getWorkerContext().getTajoMasterAddress(),
-            QueryCoordinatorProtocol.class, true);
-        }
-
+        ServiceTracker serviceTracker = queryTaskContext.getQueryMasterContext().getWorkerContext().getServiceTracker();
+        tmClient = connPool.getConnection(serviceTracker.getUmbilicalAddress(), QueryCoordinatorProtocol.class, true);
         QueryCoordinatorProtocolService masterClientService = tmClient.getStub();
         masterClientService.allocateWorkerResources(null, request, callBack);
       } catch (Exception e) {

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorker.java
@@ -35,7 +35,7 @@ import org.apache.tajo.catalog.CatalogClient;
 import org.apache.tajo.catalog.CatalogService;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.ha.HAServiceUtil;
-import org.apache.tajo.ha.TajoMasterInfo;
+import org.apache.tajo.service.TajoMasterInfo;
 import org.apache.tajo.ipc.QueryCoordinatorProtocol.ClusterResourceSummary;
 import org.apache.tajo.master.cluster.WorkerConnectionInfo;
 import org.apache.tajo.master.rm.TajoWorkerResourceManager;
@@ -350,7 +350,7 @@ public class TajoWorker extends CompositeService {
     startJvmPauseMonitor();
 
     tajoMasterInfo = new TajoMasterInfo();
-    if (systemConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+    if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
       tajoMasterInfo.setTajoMasterAddress(HAServiceUtil.getMasterUmbilicalAddress(systemConf));
       tajoMasterInfo.setWorkerResourceTrackerAddr(HAServiceUtil.getResourceTrackerAddress(systemConf));
     } else {

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorker.java
@@ -34,7 +34,6 @@ import org.apache.tajo.TajoConstants;
 import org.apache.tajo.catalog.CatalogClient;
 import org.apache.tajo.catalog.CatalogService;
 import org.apache.tajo.conf.TajoConf;
-import org.apache.tajo.ha.HAServiceUtil;
 import org.apache.tajo.service.ServiceTracker;
 import org.apache.tajo.service.ServiceTrackerFactory;
 import org.apache.tajo.service.TajoMasterInfo;
@@ -64,7 +63,6 @@ import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -356,7 +354,7 @@ public class TajoWorker extends CompositeService {
     startJvmPauseMonitor();
 
     tajoMasterInfo = new TajoMasterInfo();
-    if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
+    if (systemConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
       tajoMasterInfo.setTajoMasterAddress(serviceTracker.getUmbilicalAddress());
       tajoMasterInfo.setWorkerResourceTrackerAddr(serviceTracker.getResourceTrackerAddress());
     } else {
@@ -428,16 +426,8 @@ public class TajoWorker extends CompositeService {
       return serviceTracker;
     }
 
-    public TajoWorkerManagerService getTajoWorkerManagerService() {
-      return tajoWorkerManagerService;
-    }
-
     public QueryMasterManagerService getQueryMasterManagerService() {
       return queryMasterManagerService;
-    }
-
-    public TajoWorkerClientService getTajoWorkerClientService() {
-      return tajoWorkerClientService;
     }
 
     public TaskRunnerManager getTaskRunnerManager() {

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorkerClientService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TajoWorkerClientService.java
@@ -118,7 +118,7 @@ public class TajoWorkerClientService extends AbstractService {
       try {
         QueryId queryId = new QueryId(request.getQueryId());
 
-        QueryMasterTask queryMasterTask = workerContext.getQueryMaster().getQueryMasterTask(queryId);
+        QueryMasterTask queryMasterTask = workerContext.getQueryMaster().getQueryMasterTask(queryId, true);
         QueryHistory queryHistory = null;
         if (queryMasterTask == null) {
           queryHistory = workerContext.getHistoryReader().getQueryHistory(queryId.toString());

--- a/tajo-core/src/main/java/org/apache/tajo/worker/WorkerHeartbeatService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/WorkerHeartbeatService.java
@@ -187,7 +187,7 @@ public class WorkerHeartbeatService extends AbstractService {
           // worker may fail to connect existing active master. Thus,
           // if worker can't connect the master, worker should try to connect another master and
           // update master address in worker context.
-          if (systemConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+          if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
             try {
               rmClient = connectionPool.getConnection(context.getResourceTrackerAddress(), TajoResourceTrackerProtocol.class, true);
             } catch (Exception e) {

--- a/tajo-core/src/main/java/org/apache/tajo/worker/WorkerHeartbeatService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/WorkerHeartbeatService.java
@@ -35,6 +35,7 @@ import org.apache.tajo.rpc.CallFuture;
 import org.apache.tajo.rpc.NettyClientBase;
 import org.apache.tajo.rpc.RpcConnectionPool;
 import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos;
+import org.apache.tajo.service.ServiceTracker;
 import org.apache.tajo.storage.DiskDeviceInfo;
 import org.apache.tajo.storage.DiskMountInfo;
 import org.apache.tajo.storage.DiskUtil;
@@ -183,22 +184,9 @@ public class WorkerHeartbeatService extends AbstractService {
         try {
           CallFuture<TajoHeartbeatResponse> callBack = new CallFuture<TajoHeartbeatResponse>();
 
-          // In TajoMaster HA mode, if backup master be active status,
-          // worker may fail to connect existing active master. Thus,
-          // if worker can't connect the master, worker should try to connect another master and
-          // update master address in worker context.
-          if (systemConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-            try {
-              rmClient = connectionPool.getConnection(context.getResourceTrackerAddress(), TajoResourceTrackerProtocol.class, true);
-            } catch (Exception e) {
-              context.setWorkerResourceTrackerAddr(HAServiceUtil.getResourceTrackerAddress(systemConf));
-              context.setTajoMasterAddress(HAServiceUtil.getMasterUmbilicalAddress(systemConf));
-              rmClient = connectionPool.getConnection(context.getResourceTrackerAddress(), TajoResourceTrackerProtocol.class, true);
-            }
-          } else {
-            rmClient = connectionPool.getConnection(context.getResourceTrackerAddress(), TajoResourceTrackerProtocol.class, true);
-          }
-
+          ServiceTracker serviceTracker = context.getServiceTracker();
+          rmClient = connectionPool.getConnection(serviceTracker.getResourceTrackerAddress(),
+              TajoResourceTrackerProtocol.class, true);
           TajoResourceTrackerProtocol.TajoResourceTrackerProtocolService resourceTracker = rmClient.getStub();
           resourceTracker.heartbeat(callBack.getController(), heartbeatProto, callBack);
 

--- a/tajo-core/src/main/java/org/apache/tajo/worker/rule/ConnectivityCheckerRuleForTajoWorker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/rule/ConnectivityCheckerRuleForTajoWorker.java
@@ -45,7 +45,7 @@ public class ConnectivityCheckerRuleForTajoWorker implements SelfDiagnosisRule {
     InetSocketAddress masterAddress = null;
     
     try {
-      if (tajoConf.getBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE)) {
+      if (tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
         masterAddress = HAServiceUtil.getMasterUmbilicalAddress(tajoConf);
       } else {
         masterAddress = NetUtils.createSocketAddr(tajoConf.getVar(ConfVars.TAJO_MASTER_UMBILICAL_RPC_ADDRESS));

--- a/tajo-core/src/main/java/org/apache/tajo/worker/rule/ConnectivityCheckerRuleForTajoWorker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/rule/ConnectivityCheckerRuleForTajoWorker.java
@@ -26,6 +26,8 @@ import org.apache.tajo.rpc.NettyClientBase;
 import org.apache.tajo.rpc.RpcConnectionPool;
 import org.apache.tajo.rule.*;
 import org.apache.tajo.rule.EvaluationResult.EvaluationResultCode;
+import org.apache.tajo.service.ServiceTracker;
+import org.apache.tajo.service.ServiceTrackerFactory;
 import org.apache.tajo.util.NetUtils;
 import org.apache.tajo.worker.TajoWorker;
 
@@ -45,13 +47,8 @@ public class ConnectivityCheckerRuleForTajoWorker implements SelfDiagnosisRule {
     InetSocketAddress masterAddress = null;
     
     try {
-      if (tajoConf.getBoolVar(TajoConf.ConfVars.HA_ENABLE)) {
-        masterAddress = HAServiceUtil.getMasterUmbilicalAddress(tajoConf);
-      } else {
-        masterAddress = NetUtils.createSocketAddr(tajoConf.getVar(ConfVars.TAJO_MASTER_UMBILICAL_RPC_ADDRESS));
-      }
-      masterClient = pool.getConnection(masterAddress, QueryCoordinatorProtocol.class, true);
-      
+      ServiceTracker serviceTracker = ServiceTrackerFactory.get(tajoConf);
+      masterClient = pool.getConnection(serviceTracker.getUmbilicalAddress(), QueryCoordinatorProtocol.class, true);
       masterClient.getStub();
     } finally {
       if (masterClient != null) {

--- a/tajo-core/src/main/resources/webapps/admin/catalogview.jsp
+++ b/tajo-core/src/main/resources/webapps/admin/catalogview.jsp
@@ -24,12 +24,13 @@
 <%@ page import="org.apache.tajo.catalog.TableDesc" %>
 <%@ page import="org.apache.tajo.catalog.partition.PartitionMethodDesc" %>
 <%@ page import="org.apache.tajo.master.TajoMaster" %>
-<%@ page import="org.apache.tajo.ha.HAService" %>
+<%@ page import="org.apache.tajo.service.ServiceTracker" %>
 <%@ page import="org.apache.tajo.util.FileUtil" %>
 <%@ page import="org.apache.tajo.webapp.StaticHttpServer" %>
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.apache.tajo.service.ServiceTracker" %>
 <%
   TajoMaster master = (TajoMaster) StaticHttpServer.getInstance().getAttribute("tajo.info.server.object");
   CatalogService catalog = master.getCatalog();
@@ -59,7 +60,7 @@
   //TODO filter with database
   Collection<String> tableNames = catalog.getAllTableNames(selectedDatabase);
 
-  HAService haService = master.getContext().getHAService();
+  ServiceTracker haService = master.getContext().getHAService();
   String activeLabel = "";
   if (haService != null) {
     if (haService.isActiveStatus()) {

--- a/tajo-core/src/main/resources/webapps/admin/cluster.jsp
+++ b/tajo-core/src/main/resources/webapps/admin/cluster.jsp
@@ -21,8 +21,8 @@
 
 <%@ page import="org.apache.tajo.master.TajoMaster" %>
 <%@ page import="org.apache.tajo.master.cluster.WorkerConnectionInfo" %>
-<%@ page import="org.apache.tajo.ha.HAService" %>
-<%@ page import="org.apache.tajo.ha.TajoMasterInfo" %>
+<%@ page import="org.apache.tajo.service.ServiceTracker" %>
+<%@ page import="org.apache.tajo.service.TajoMasterInfo" %>
 <%@ page import="org.apache.tajo.master.rm.Worker" %>
 <%@ page import="org.apache.tajo.master.rm.WorkerResource" %>
 <%@ page import="org.apache.tajo.master.rm.WorkerState" %>
@@ -30,6 +30,7 @@
 <%@ page import="org.apache.tajo.util.TUtil" %>
 <%@ page import="org.apache.tajo.webapp.StaticHttpServer" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.apache.tajo.service.ServiceTracker" %>
 
 <%
   TajoMaster master = (TajoMaster) StaticHttpServer.getInstance().getAttribute("tajo.info.server.object");
@@ -75,7 +76,7 @@
   String deadWorkersHtml = deadWorkers.isEmpty() ? "0": "<font color='red'>" + deadWorkers.size() + "</font>";
   String deadQueryMastersHtml = deadQueryMasters.isEmpty() ? "0": "<font color='red'>" + deadQueryMasters.size() + "</font>";
 
-  HAService haService = master.getContext().getHAService();
+  ServiceTracker haService = master.getContext().getHAService();
   List<TajoMasterInfo> masters = TUtil.newList();
 
   String activeLabel = "";

--- a/tajo-core/src/main/resources/webapps/admin/index.jsp
+++ b/tajo-core/src/main/resources/webapps/admin/index.jsp
@@ -23,8 +23,8 @@
 <%@ page import="org.apache.tajo.conf.TajoConf" %>
 <%@ page import="org.apache.tajo.ipc.QueryCoordinatorProtocol" %>
 <%@ page import="org.apache.tajo.master.TajoMaster" %>
-<%@ page import="org.apache.tajo.ha.HAService" %>
-<%@ page import="org.apache.tajo.ha.TajoMasterInfo" %>
+<%@ page import="org.apache.tajo.service.ServiceTracker" %>
+<%@ page import="org.apache.tajo.service.TajoMasterInfo" %>
 <%@ page import="org.apache.tajo.master.QueryInProgress" %>
 <%@ page import="org.apache.tajo.master.rm.Worker" %>
 <%@ page import="org.apache.tajo.master.rm.WorkerState" %>
@@ -35,6 +35,7 @@
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.apache.tajo.service.ServiceTracker" %>
 
 <%
   TajoMaster master = (TajoMaster) StaticHttpServer.getInstance().getAttribute("tajo.info.server.object");
@@ -85,7 +86,7 @@
   String numDeadWorkersHtml = numDeadWorkers == 0 ? "0" : "<font color='red'>" + numDeadWorkers + "</font>";
   String numDeadQueryMastersHtml = numDeadQueryMasters == 0 ? "0" : "<font color='red'>" + numDeadQueryMasters + "</font>";
 
-  HAService haService = master.getContext().getHAService();
+  ServiceTracker haService = master.getContext().getHAService();
   List<TajoMasterInfo> masters = TUtil.newList();
 
   String activeLabel = "";

--- a/tajo-core/src/main/resources/webapps/admin/query_executor.jsp
+++ b/tajo-core/src/main/resources/webapps/admin/query_executor.jsp
@@ -19,13 +19,14 @@
 %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ page import="org.apache.tajo.master.TajoMaster" %>
-<%@ page import="org.apache.tajo.ha.HAService" %>
+<%@ page import="org.apache.tajo.service.ServiceTracker" %>
 <%@ page import="org.apache.tajo.webapp.StaticHttpServer" %>
+<%@ page import="javax.xml.ws.Service" %>
 
 <%
   TajoMaster master = (TajoMaster) StaticHttpServer.getInstance().getAttribute("tajo.info.server.object");
 
-  HAService haService = master.getContext().getHAService();
+  ServiceTracker haService = master.getContext().getHAService();
   String activeLabel = "";
   if (haService != null) {
       if (haService.isActiveStatus()) {

--- a/tajo-core/src/test/java/org/apache/tajo/TajoTestingCluster.java
+++ b/tajo-core/src/test/java/org/apache/tajo/TajoTestingCluster.java
@@ -106,7 +106,7 @@ public class TajoTestingCluster {
 
   public TajoTestingCluster(boolean masterHaEMode) {
     this.conf = new TajoConf();
-    this.conf.setBoolVar(ConfVars.TAJO_MASTER_HA_ENABLE, masterHaEMode);
+    this.conf.setBoolVar(ConfVars.HA_ENABLE, masterHaEMode);
 
     setTestingFlagProperties();
     initPropertiesAndConfigs();

--- a/tajo-core/src/test/java/org/apache/tajo/TajoTestingCluster.java
+++ b/tajo-core/src/test/java/org/apache/tajo/TajoTestingCluster.java
@@ -106,7 +106,7 @@ public class TajoTestingCluster {
 
   public TajoTestingCluster(boolean masterHaEMode) {
     this.conf = new TajoConf();
-    this.conf.setBoolVar(ConfVars.HA_ENABLE, masterHaEMode);
+    this.conf.setBoolVar(ConfVars.TAJO_MASTER_HA_ENABLE, masterHaEMode);
 
     setTestingFlagProperties();
     initPropertiesAndConfigs();

--- a/tajo-core/src/test/java/org/apache/tajo/ha/TestHAServiceHDFSImpl.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ha/TestHAServiceHDFSImpl.java
@@ -112,7 +112,7 @@ public class TestHAServiceHDFSImpl  {
     conf.setVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS,
       masterAddress + ":" + NetUtils.getFreeSocketPort());
 
-    conf.setBoolVar(TajoConf.ConfVars.HA_ENABLE, true);
+    conf.setBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE, true);
 
     //Client API service RPC Server
     conf.setIntVar(TajoConf.ConfVars.MASTER_SERVICE_RPC_SERVER_WORKER_THREAD_NUM, 2);

--- a/tajo-core/src/test/java/org/apache/tajo/ha/TestHAServiceHDFSImpl.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ha/TestHAServiceHDFSImpl.java
@@ -27,6 +27,8 @@ import org.apache.tajo.client.TajoClient;
 import org.apache.tajo.client.TajoClientImpl;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.master.TajoMaster;
+import org.apache.tajo.service.ServiceTracker;
+import org.apache.tajo.service.ServiceTrackerFactory;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
@@ -56,7 +58,8 @@ public class TestHAServiceHDFSImpl  {
     try {
       FileSystem fs = cluster.getDefaultFileSystem();
 
-      masterAddress = HAServiceUtil.getMasterUmbilicalName(conf).split(":")[0];
+      ServiceTracker serviceTracker = ServiceTrackerFactory.get(conf);
+      masterAddress = serviceTracker.getUmbilicalAddress().getHostName();
 
       setConfiguration();
 

--- a/tajo-core/src/test/java/org/apache/tajo/ha/TestHAServiceHDFSImpl.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ha/TestHAServiceHDFSImpl.java
@@ -18,8 +18,6 @@
 
 package org.apache.tajo.ha;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.net.NetUtils;
@@ -37,8 +35,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestHAServiceHDFSImpl  {
-  private static Log LOG = LogFactory.getLog(TestHAServiceHDFSImpl.class);
-
   private TajoTestingCluster cluster;
   private TajoMaster backupMaster;
 
@@ -112,7 +108,8 @@ public class TestHAServiceHDFSImpl  {
       masterAddress + ":" + NetUtils.getFreeSocketPort());
     conf.setVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS,
       masterAddress + ":" + NetUtils.getFreeSocketPort());
-    conf.setBoolVar(TajoConf.ConfVars.TAJO_MASTER_HA_ENABLE, true);
+
+    conf.setBoolVar(TajoConf.ConfVars.HA_ENABLE, true);
 
     //Client API service RPC Server
     conf.setIntVar(TajoConf.ConfVars.MASTER_SERVICE_RPC_SERVER_WORKER_THREAD_NUM, 2);

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/JdbcConnection.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/JdbcConnection.java
@@ -23,12 +23,11 @@ import com.google.protobuf.ServiceException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.TajoConstants;
-import org.apache.tajo.client.CatalogAdminClient;
-import org.apache.tajo.client.QueryClient;
-import org.apache.tajo.client.TajoClient;
-import org.apache.tajo.client.TajoClientImpl;
+import org.apache.tajo.client.*;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.jdbc.util.QueryStringDecoder;
+import org.apache.tajo.service.ServiceTracker;
+import org.apache.tajo.util.NetUtils;
 
 import java.io.IOException;
 import java.net.URI;
@@ -109,7 +108,8 @@ public class JdbcConnection implements Connection {
     }
 
     try {
-      tajoClient = new TajoClientImpl(hostName, port, databaseName);
+      ServiceTracker serviceTracker = new DummyServiceTracker(NetUtils.createSocketAddr(hostName, port));
+      tajoClient = new TajoClientImpl(tajoConf, serviceTracker, databaseName);
     } catch (Exception e) {
       throw new SQLException("Cannot create TajoClient instance:" + e.getMessage(), "TAJO-002");
     }

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoStatement.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoStatement.java
@@ -118,7 +118,7 @@ public class TajoStatement implements Statement {
   @Override
   public ResultSet executeQuery(String sql) throws SQLException {
     if (isClosed) {
-      throw new SQLFeatureNotSupportedException("Can't execute after statement has been closed");
+      throw new SQLException("Can't execute after statement has been closed");
     }
 
     try {
@@ -130,7 +130,7 @@ public class TajoStatement implements Statement {
         return tajoClient.executeQueryAndGetResult(sql);
       }
     } catch (Exception e) {
-      throw new SQLFeatureNotSupportedException(e.getMessage(), e);
+      throw new SQLException(e.getMessage(), e);
     }
   }
 

--- a/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/StorageUtil.java
+++ b/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/StorageUtil.java
@@ -38,14 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class StorageUtil extends StorageConstants {
-  public static int getRowByteSize(Schema schema) {
-    int sum = 0;
-    for(Column col : schema.getColumns()) {
-      sum += StorageUtil.getColByteSize(col);
-    }
-
-    return sum;
-  }
 
   public static int getColByteSize(Column col) {
     switch (col.getDataType().getType()) {
@@ -82,14 +74,6 @@ public class StorageUtil extends StorageConstants {
       default:
         return 0;
     }
-  }
-
-  public static void writeTableMeta(Configuration conf, Path tableroot, TableMeta meta) throws IOException {
-    FileSystem fs = tableroot.getFileSystem(conf);
-    FSDataOutputStream out = fs.create(new Path(tableroot, ".meta"));
-    FileUtil.writeProto(out, meta.getProto());
-    out.flush();
-    out.close();
   }
   
   public static Path concatPath(String parent, String...childs) {


### PR DESCRIPTION
In this patch, I added an abstract class ServiceTracker which registers Tajo rpc services and provides discovery services for them. I changed  almost all parts using HAServiceUtil to use ServiceTracker.