### PR TITLE
TAJO-1320: HBaseStorageManager need to support Zookeeper Client Port.

### DIFF
--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseStorageConstants.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseStorageConstants.java
@@ -27,6 +27,7 @@ public interface HBaseStorageConstants {
   public static final String META_SPLIT_ROW_KEYS_KEY = "hbase.split.rowkeys";
   public static final String META_SPLIT_ROW_KEYS_FILE_KEY = "hbase.split.rowkeys.file";
   public static final String META_ZK_QUORUM_KEY = "hbase.zookeeper.quorum";
+  public static final String META_ZK_CLIENT_PORT = "hbase.zookeeper.property.clientPort";
   public static final String META_ROWKEY_DELIMITER = "hbase.rowkey.delimiter";
 
   public static final String INSERT_PUT_MODE = "tajo.hbase.insert.put.mode";

--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseStorageManager.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseStorageManager.java
@@ -312,6 +312,17 @@ public class HBaseStorageManager extends StorageManager {
           HBaseStorageConstants.META_ZK_QUORUM_KEY + "' attribute.");
     }
 
+    String zkPort = hbaseConf.get(HConstants.ZOOKEEPER_CLIENT_PORT);
+    if (tableMeta.containsOption(HBaseStorageConstants.META_ZK_CLIENT_PORT)) {
+      zkPort = tableMeta.getOption(HBaseStorageConstants.META_ZK_CLIENT_PORT, "");
+      hbaseConf.set(HConstants.ZOOKEEPER_CLIENT_PORT, zkPort);
+    }
+
+    if (zkPort == null || zkPort.trim().isEmpty()) {
+      throw new IOException("HBase mapped table is required a '" +
+        HBaseStorageConstants.META_ZK_CLIENT_PORT + "' attribute.");
+    }
+
     for (Map.Entry<String, String> eachOption: tableMeta.getOptions().getAllKeyValus().entrySet()) {
       String key = eachOption.getKey();
       if (key.startsWith(HConstants.ZK_CFG_PROPERTY_PREFIX)) {


### PR DESCRIPTION
Currently, HBaseStorageManager just use Zookeeper Quorum host names. But I think that users may want to change their Zookeeper client port. Thus, we need to support that users can set the port. For reference, HBase defines the port to ZOOKEEPER_CLIENT_PORT in HBaseConstants.