### PR TITLE
TAJO-1277: GreedyHeuristicJoinOrderAlgorithm sometimes wrongly assumes associativity of joins

### DIFF
--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestJoinQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestJoinQuery.java
@@ -226,6 +226,13 @@ public class TestJoinQuery extends QueryTestCaseBase {
   }
 
   @Test
+  public final void testJoinWithMultipleJoinTypes() throws Exception {
+    ResultSet res = executeQuery();
+    assertResultSet(res);
+    cleanupQuery(res);
+  }
+
+  @Test
   public final void testLeftOuterJoin1() throws Exception {
     ResultSet res = executeQuery();
     assertResultSet(res);

--- a/tajo-core/src/test/resources/queries/TestJoinQuery/testJoinWithMultipleJoinTypes.sql
+++ b/tajo-core/src/test/resources/queries/TestJoinQuery/testJoinWithMultipleJoinTypes.sql
@@ -1,0 +1,4 @@
+select * FROM
+customer c
+right outer join (select n_nationkey from nation) n on n.n_nationkey = c.c_custkey
+join region r on r.r_regionkey = c.c_custkey;

--- a/tajo-core/src/test/resources/results/TestJoinQuery/testJoinWithMultipleJoinTypes.result
+++ b/tajo-core/src/test/resources/results/TestJoinQuery/testJoinWithMultipleJoinTypes.result
@@ -1,0 +1,6 @@
+c_custkey,c_name,c_address,c_nationkey,c_phone,c_acctbal,c_mktsegment,c_comment,n_nationkey,r_regionkey,r_name,r_comment
+-------------------------------
+1,Customer#000000001,IVhzIApeRb ot,c,E,15,25-989-741-2988,711.56,BUILDING,to the even, regular platelets. regular, ironic epitaphs nag e,1,1,AMERICA,hs use ironic, even requests. s
+2,Customer#000000002,XSTf4,NCwDVaWNe6tEgvwfmRchLXak,13,23-768-687-3665,121.65,AUTOMOBILE,l accounts. blithely ironic theodolites integrate boldly: caref,2,2,ASIA,ges. thinly even pinto beans ca
+3,Customer#000000003,MG9kdTD2WBHm,1,11-719-748-3364,7498.12,AUTOMOBILE, deposits eat slyly ironic, even instructions. express foxes detect slyly. blithely even accounts abov,3,3,EUROPE,ly final courts cajole furiously final excuse
+4,Customer#000000004,XxVSJsLAGtn,4,14-128-190-5944,2866.83,MACHINERY, requests. final, regular ideas sleep final accou,4,4,MIDDLE EAST,uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/GreedyHeuristicJoinOrderAlgorithm.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/GreedyHeuristicJoinOrderAlgorithm.java
@@ -64,10 +64,12 @@ public class GreedyHeuristicJoinOrderAlgorithm implements JoinOrderAlgorithm {
         if (joinEdgesForGiven != null) {
           joinEdges.addAll(joinEdgesForGiven);
         }
-        for (String relationString: relationStrings) {
-          joinEdgesForGiven = joinGraph.getIncomingEdges(relationString);
-          if (joinEdgesForGiven != null) {
-            joinEdges.addAll(joinEdgesForGiven);
+        if (relationStrings.size() > 1) {
+          for (String relationString: relationStrings) {
+            joinEdgesForGiven = joinGraph.getIncomingEdges(relationString);
+            if (joinEdgesForGiven != null) {
+              joinEdges.addAll(joinEdgesForGiven);
+            }
           }
         }
 
@@ -75,6 +77,10 @@ public class GreedyHeuristicJoinOrderAlgorithm implements JoinOrderAlgorithm {
         boolean endInnerRelation = false;
         for (JoinEdge joinEdge: joinEdges) {
           switch(joinEdge.getJoinType()) {
+            case LEFT_ANTI:
+            case RIGHT_ANTI:
+            case LEFT_SEMI:
+            case RIGHT_SEMI:
             case LEFT_OUTER:
             case RIGHT_OUTER:
             case FULL_OUTER:


### PR DESCRIPTION
Basically, it limits the range of join ordering until it meets outer join operations.
For example, in the case of (((((a inner join b) inner join c) outer join d) inner join e) inner join f),
join ordering is partitioned as three parts as
1) (a inner join b) inner join c
2) (result of 1) outer join d
3) (((result of 2) inner join e) inner join f) 

Following modifications are included:
- findBestOrder() is changed to partition join ordering
- getBestPair() and findJoin() are changed to return the corresponding JoinEdges of the selected join because those JoinEdges should be removed before next join ordering

It passes 'mvn clean install' and several join cases I tested,
however, I'm not sure this is good approach.
Please, leave me comments about the patch.