### PR TITLE
TAJO-1367: Tajo Python Native Client

### DIFF
--- a/tajo-client/python2/gen_protos.sh
+++ b/tajo-client/python2/gen_protos.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rm -f ./src/proto/*.proto
+files=($(find ../../ -name "*.proto"))
+for item in ${files[*]}
+do
+    cp $item src/proto/
+done
+
+protoc --proto_path=./src/proto --python_out=./src/tajo/proto/ ./src/proto/*.proto

--- a/tajo-client/python2/src/proto/dummy
+++ b/tajo-client/python2/src/proto/dummy
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tajo-client/python2/src/tajo/__init__.py
+++ b/tajo-client/python2/src/tajo/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tajo-client/python2/src/tajo/channel.py
+++ b/tajo-client/python2/src/tajo/channel.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import proto.RpcProtos_pb2 as rpc_pb2
+from rpc.channel import RpcChannel
+from rpc.proto_util import ProtoUtils
+
+class TajoRpcChannel(RpcChannel):
+    def prepareRequest(self, method, request):
+        rpc_request = rpc_pb2.RpcRequest()
+        rpc_request.id = 1
+        rpc_request.method_name = method.name
+        rpc_request.request_message = request.SerializeToString()
+        return rpc_request
+
+    def sendRequest(self, rpc_request):
+        data = rpc_request.SerializeToString()
+        lenbytes = ProtoUtils.EncodeVarint(len(data))
+        return [lenbytes, data]
+
+    def receiveResponse(self):
+        try:
+            byte_stream = self.readMoreN(4)
+            v, l = ProtoUtils.DecodeVarint(byte_stream)
+            byte_stream = byte_stream[l:]
+            size = len(byte_stream)
+            if size < (v-l):
+                byte_stream += self.readMoreN(v-l)
+
+            rpc_response = rpc_pb2.RpcResponse()
+            rpc_response.ParseFromString(byte_stream)
+            return rpc_response
+
+        except socket.error:
+            self.closeSocket()
+            raise Exception("Error reading data from server")
+
+    def parseResponse(self, rpc_response, response_class):
+        response = response_class()
+
+        byte_stream = rpc_response.response_message
+        try:
+            response.ParseFromString(byte_stream)
+        except Exception, e:
+            raise Exception("Invalid response (decodeError): " + str(e))
+
+        return response
+

--- a/tajo-client/python2/src/tajo/client.py
+++ b/tajo-client/python2/src/tajo/client.py
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from connection import TajoSessionConnection
+from queryid import QueryId
+from memoryresultset import TajoMemoryResultSet
+from fetchresultset import TajoFetchResultSet
+
+import proto.ClientProtos_pb2 as ClientProtos_pb2
+import proto.CatalogProtos_pb2 as CatalogProtos_pb2
+from querystate import QueryState
+
+import time
+
+OK_VALUE = 0
+ERROR_VALUE = 1
+
+FETCH_ROW_NUM = 10
+
+class TajoClient(TajoSessionConnection, object):
+    def __init__(self, host, port, username='tmpuser'):
+        super(TajoClient, self).__init__(host, port, username)
+
+    def executeQuery(self, sql):
+        request = ClientProtos_pb2.QueryRequest()
+        request.sessionId.id = self.checkSessionAndGet()
+        request.query = sql
+        request.isJson = False
+        return self.service.submitQuery(request)
+
+    def getQueryStatus(self, queryId):
+        request = ClientProtos_pb2.GetQueryStatusRequest()
+        request.sessionId.id = self.checkSessionAndGet()
+        request.queryId.id = queryId.id
+        request.queryId.seq = queryId.seq
+        return self.service.getQueryStatus(request)
+
+    def createNullResultSet(self, queryId):
+        return TajoMemoryResultSet(queryId, CatalogProtos_pb2.SchemaProto(), [])
+
+    def isNullQueryId(self, queryId):
+        return queryId == QueryId.NULL_QUERY_ID
+
+    def getLogicalSchema(self, tableDesc):
+        schema = tableDesc.schema
+        if tableDesc.HasField('partition'):
+            partition = tableDesc.partition
+            start = len(schema.fields)
+            count = 0
+            for field in partition.expressionSchema.fields:
+                new_field = schema.fields.add()
+                new_field.tid = field.tid
+                new_field.name = field.name
+                new_field.dataType.type = field.dataType.type
+                new_field.dataType.code = field.dataType.code
+                new_field.dataType.length = field.dataType.length
+
+        return schema
+
+    def createResultSet(self, response, fetchRowNum):
+        if response.HasField('tableDesc'):
+            return TajoFetchResultSet(self, response.queryId,
+                    self.getLogicalSchema(response.tableDesc), FETCH_ROW_NUM)
+        else:
+            return TajoMemoryResultSet(response.queryId, response.resultSet.schema,
+                                       response.resultSet.serializedTuples)
+
+    def executeQueryAndGetResult(self, sql):
+        response = self.executeQuery(sql)
+        if self.isError(response.resultCode):
+            raise Exception(response.errorMessage + " " + response.errorTrace)
+
+        queryId = response.queryId
+        if response.isForwarded is True:
+            if self.isNullQueryId(queryId.id):
+                return self.createNullResultSet(queryId)
+            else:
+                return self.getQueryResultAndWait(queryId)
+
+        if self.isNullQueryId(queryId.id) and response.maxRowNum == 0:
+            return self.createNullResultSet(queryId)
+
+        if response.HasField('resultSet') == False and response.HasField('tableDesc') == False:
+            return self.createNullResultSet(queryId)
+
+        return self.createResultSet(response, 10)
+
+    def isError(self, code):
+        return code == ERROR_VALUE
+
+    def fetchNextQueryResult(self, queryId, schema, fetchRowNum):
+        request = ClientProtos_pb2.GetQueryResultDataRequest()
+        request.sessionId.id = self.checkSessionAndGet()
+        request.queryId.id = queryId.id
+        request.queryId.seq = queryId.seq
+        request.fetchRowNum = fetchRowNum
+        response = self.service.getQueryResultData(request)
+        if self.isError(response.resultCode):
+            raise Exception(response.errorMessage + " " + response.errorTrace)
+
+        return TajoMemoryResultSet(queryId, schema,
+                                   response.resultSet.serializedTuples)
+
+    def isQueryWaitingForSchedule(self, state):
+        return state == QueryState.QUERY_NOT_ASSIGNED or \
+                state == QueryState.QUERY_MASTER_INIT or \
+                state == QueryState.QUERY_MASTER_LAUNCHED
+
+    def isQueryInited(self, state):
+        return state == QueryState.QUERY_NEW
+
+    def isQueryRunning(self, state):
+        return self.isQueryInited(state) or (state == QueryState.QUERY_RUNNING)
+
+    def isQueryComplete(self, state):
+        return self.isQueryWaitingForSchedule(state) == False and \
+               self.isQueryRunning(state) == False
+
+    def getQueryResultAndWait(self, queryId):
+        if self.isNullQueryId(queryId.id):
+            return self.createNullResultSet(queryId)
+
+        status = self.getQueryStatus(queryId)
+        while (status != None and self.isQueryComplete(status.state) == False):
+            time.sleep(1)
+            status = self.getQueryStatus(queryId)
+
+        if status.state == QueryState.QUERY_SUCCEEDED:
+            if status.hasResult:
+                return self.getQueryResult(queryId);
+
+        return self.createNullResultSet(queryId);
+
+    def getQueryResult(self, queryId):
+        if self.isNullQueryId(queryId):
+            return self.createNullResultSet(queryId)
+
+        response = self.getResultResponse(queryId)
+        return TajoFetchResultSet(self, queryId,
+                self.getLogicalSchema(response.tableDesc), FETCH_ROW_NUM)
+
+    def getResultResponse(self, queryId):
+        request = ClientProtos_pb2.GetQueryResultRequest()
+        request.sessionId.id = self.checkSessionAndGet()
+        request.queryId.id = queryId.id
+        request.queryId.seq = queryId.seq
+        return self.service.getQueryResult(request)

--- a/tajo-client/python2/src/tajo/connection.py
+++ b/tajo-client/python2/src/tajo/connection.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rpc.service import RpcService
+from channel import TajoRpcChannel
+
+import proto.TajoMasterClientProtocol_pb2 as tajo_pb2
+import proto.ClientProtos_pb2 as ClientProtos_pb2
+
+class TajoSessionConnection():
+    def __init__(self, host, port, username="tmpuser"):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.sessionId = None
+        self.channel = TajoRpcChannel(self.host, self.port)
+        self.service = RpcService(tajo_pb2.TajoMasterClientProtocolService_Stub,
+                                  self.channel)
+
+    def createNewSessionId(self):
+        request = ClientProtos_pb2.CreateSessionRequest()
+        request.username = self.username
+        response = self.service.createSession(request)
+        self.sessionId = response.sessionId.id
+        return self.sessionId
+
+    def checkSessionAndGet(self):
+        if self.sessionId is None:
+            self.sessionId = self.createNewSessionId()
+
+        return self.sessionId
+

--- a/tajo-client/python2/src/tajo/datatypes.py
+++ b/tajo-client/python2/src/tajo/datatypes.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class TajoDataTypes:
+    BOOLEAN = 1
+    INT1 = 2
+    INT2 = 3
+    INT4 = 4
+    INT8 = 5
+    FLOAT4 = 10
+    FLOAT8 = 11
+    TEXT = 25
+    DATE = 31
+    TIME = 32
+    TIMESTAMP = 34
+    BLOB = 45
+    INET4 = 91
+    INET6 = 92

--- a/tajo-client/python2/src/tajo/fetchresultset.py
+++ b/tajo-client/python2/src/tajo/fetchresultset.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from resultset import TajoResultSet
+
+class TajoFetchResultSet(TajoResultSet):
+    def __init__(self, client, queryId, schema, fetchRowNum):
+        super(TajoFetchResultSet, self).__init__()
+        self.queryId = queryId
+        self.fetchRowNum = fetchRowNum
+        self.client = client
+        self.finished = False
+        self.resultSet = None
+        self.schema = schema
+
+    def isFinished(self):
+        return self.finished
+
+    def getQueryId(self):
+        return self.queryId
+
+    def nextTuple(self):
+        if self.isFinished() is True:
+            return None
+
+        t = None
+        if self.resultSet is not None:
+            self.resultSet.next()
+            t = self.resultSet.getCurrentTuple()
+
+        if self.resultSet is None or t is None:
+            self.resultSet = self.client.fetchNextQueryResult(self.queryId, self.schema, self.fetchRowNum)
+            if self.resultSet is None:
+                self.finished = True
+                return None
+
+            self.resultSet.next()
+            t = self.resultSet.getCurrentTuple()
+
+        if t is None:
+            if self.resultSet is not None:
+                self.resultSet = None
+
+            self.finished = True
+
+        return t

--- a/tajo-client/python2/src/tajo/memoryresultset.py
+++ b/tajo-client/python2/src/tajo/memoryresultset.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rowdecoder import RowDecoder
+from resultset import TajoResultSet
+
+class TajoMemoryResultSet(TajoResultSet):
+    def __init__(self, queryId, schema, serializedTuples):
+        super(TajoMemoryResultSet, self).__init__()
+        self.queryId = queryId
+        self.schema = schema
+        self.totalRow = len(serializedTuples)
+        self.serializedTuples = serializedTuples
+        self.decoder = RowDecoder(self.schema)
+        self.cur = None
+
+    def getQueryId(self):
+        return self.queryId
+
+    def nextTuple(self):
+        if self.curRow < self.totalRow:
+            self.cur = self.decoder.toTuple(self.serializedTuples[self.curRow])
+            return self.cur
+
+        return None

--- a/tajo-client/python2/src/tajo/proto/__init__.py
+++ b/tajo-client/python2/src/tajo/proto/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tajo-client/python2/src/tajo/queryid.py
+++ b/tajo-client/python2/src/tajo/queryid.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class QueryId:
+    NULL_QUERY_ID = "0000000000000"

--- a/tajo-client/python2/src/tajo/querystate.py
+++ b/tajo-client/python2/src/tajo/querystate.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class QueryState:
+    QUERY_MASTER_INIT = 0
+    QUERY_MASTER_LAUNCHED = 1
+    QUERY_NEW = 2
+    QUERY_INIT = 3
+    QUERY_RUNNING = 4
+    QUERY_SUCCEEDED = 5
+    QUERY_FAILED = 6
+    QUERY_KILLED = 7
+    QUERY_KILL_WAIT = 8
+    QUERY_ERROR = 9
+    QUERY_NOT_ASSIGNED = 10

--- a/tajo-client/python2/src/tajo/resultset.py
+++ b/tajo-client/python2/src/tajo/resultset.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class TajoResultSet(object):
+    def __init__(self):
+        self.curRow = 0
+        self.cur = None
+        self.schema = None
+        self.totalRow = 0
+
+    def getCurrentTuple(self):
+        return self.cur
+
+    def next(self):
+        if self.totalRow <= 0:
+            return False
+
+        self.cur = self.nextTuple()
+        self.curRow += 1
+        if self.cur is not None:
+            return True
+
+        return False
+
+    def nextTuple(self):
+        raise Exception("Not Implemented")
+
+

--- a/tajo-client/python2/src/tajo/rowdecoder.py
+++ b/tajo-client/python2/src/tajo/rowdecoder.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import struct
+import math
+from datatypes import TajoDataTypes as ttype
+
+class RowDecoder:
+    def __init__(self, schema):
+        self.schema = schema
+        self.headerSize = int(math.ceil(float(len(self.schema.fields)) / 8))
+
+    def toTuples(self, serializedTuples):
+        results = []
+        for serializedTuple in serializedTuples:
+            results.append(self.toTuple(serializedTuple))
+
+        return tuple(results)
+
+    def toTuple(self, serializedTuple):
+        size = len(self.schema.fields)
+        nullFlags = serializedTuple[:self.headerSize]
+        bb = io.BytesIO(serializedTuple[self.headerSize:])
+        results = []
+
+        for i in range(size):
+            field = self.schema.fields[i]
+            fieldType = field.dataType.type
+            results.append(self.convert(0, fieldType, bb))
+
+        return tuple(results)
+
+    def convert(self, isNull, ftype, bb):
+        if (isNull == 1):
+            return "NULL"
+
+        if ftype == ttype.INT1:
+            v = bb.read(1)
+            return struct.unpack("b", v)[0]
+
+        if ftype == ttype.INT2:
+            v = bb.read(2)
+            return struct.unpack(">h", v)[0]
+
+        if ftype == ttype.INT4 or ftype == ttype.DATE:
+            v = bb.read(4)
+            return struct.unpack(">i", v)[0]
+
+        if ftype == ttype.INT8 or ftype == ttype.TIME or ftype == ttype.TIMESTAMP:
+            v = bb.read(8)
+            return struct.unpack(">q", v)[0]
+
+        if ftype == ttype.FLOAT4:
+            v = bb.read(4)
+            return struct.unpack(">f", v)[0]
+
+        if ftype == ttype.FLOAT8:
+            v = bb.read(8)
+            return struct.unpack(">d", v)[0]
+
+        if ftype == ttype.TEXT or ftype == ttype.BLOB:
+            l = bb.read(4)
+            l2 = struct.unpack(">i", l)[0]
+            v = bb.read(l2)
+            return v

--- a/tajo-client/python2/src/tajo/rpc/__init__.py
+++ b/tajo-client/python2/src/tajo/rpc/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tajo-client/python2/src/tajo/rpc/channel.py
+++ b/tajo-client/python2/src/tajo/rpc/channel.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import google.protobuf.service
+from controller import RpcController as Controller
+
+class SocketFactory():
+    @staticmethod
+    def createSocket():
+        return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    @staticmethod
+    def prepareHandle(host, port):
+        s = SocketFactory.createSocket();
+        try:
+            s.connect((host, port))
+        except socket.gaierror:
+            s = None
+        except socket.error:
+            s = None
+
+        return s
+
+    @staticmethod
+    def closeSocket(sock):
+        if sock:
+            try:
+                sock.close()
+            except:
+                pass
+
+        return
+
+
+class RpcChannel(google.protobuf.service.RpcChannel):
+    @staticmethod
+    def createController():
+        return Controller()
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.handle = SocketFactory.prepareHandle(self.host, self.port)
+
+    def readMoreN(self, size):
+        count = 0
+        data = ""
+        while True:
+            try:
+                tmpData = self.handle.recv(4096)
+                count += len(tmpData)
+                data += str(tmpData)
+                if count >= size:
+                    return data
+            except:
+                raise Exception("Socket Read Error")
+
+    def closeSocket(self):
+        SocketFactory.closeSocket(self.handle)
+        self.handle = None
+
+    def prepareRequest(self, method, request):
+        return None
+
+    def sendData(self, packets):
+        try:
+            for packet in packets:
+                self.handle.sendall(packet)
+
+        except socket.error:
+            raise socket.error("packet send error")
+
+    def sendRequest(self, rpc_request):
+        return None
+
+    def receiveResponse(self):
+        return None
+
+    def parseResponse(self, rpc_response, response_class):
+        return None
+
+    def CallMethod(self, method, controller, request, response_class, done):
+        if self.handle is None:
+            raise Exception("Connection Error(%s:%s)" % (self.host, self.port))
+
+        rpc_request = self.prepareRequest(method, request)
+        packets = self.sendRequest(rpc_request)
+        self.sendData(packets)
+        rpc_response = self.receiveResponse()
+        response = self.parseResponse(rpc_response, response_class)
+        return response

--- a/tajo-client/python2/src/tajo/rpc/controller.py
+++ b/tajo-client/python2/src/tajo/rpc/controller.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import google.protobuf.service
+
+class RpcController(google.protobuf.service.RpcController):
+    def __init__(self):
+        self.error_code = None
+        self.error_message = None
+
+    def handleError(self, error_code, error_message):
+        self.error_code = error_code
+        self.error_message = error_message
+
+    def reset(self):
+        self.error_code = None
+        self.error_message = None
+
+    def failed(self):
+        return self.error_message is not None
+
+    def error(self):
+        return self.error_message

--- a/tajo-client/python2/src/tajo/rpc/proto_util.py
+++ b/tajo-client/python2/src/tajo/rpc/proto_util.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import google.protobuf.message
+
+class ProtoUtils():
+    @staticmethod
+    def VarSize(uint64):
+        if uint64 <= 0x7f: return 1
+        if uint64 <= 0x3fff: return 2
+        if uint64 <= 0x1fffff: return 3
+        if uint64 <= 0xfffffff: return 4
+        return 5
+
+    @staticmethod
+    def EncodeVarint(value):
+        v = []
+        bits = value & 0x7f
+        value >>= 7
+        while value:
+            v.append(chr(0x80|bits))
+            bits = value & 0x7f
+            value >>= 7
+
+        v.append(chr(bits))
+        return ''.join(v)
+
+    @staticmethod
+    def DecodeVarint(buffer):
+        pos = 0
+        result = 0
+        shift = 0
+        mask = (1 << 64) - 1
+        while 1:
+            b = ord(buffer[pos])
+            result |= ((b & 0x7f) << shift)
+            pos += 1
+
+            if not (b & 0x80):
+                result &= mask
+                return result, pos
+
+            shift += 7
+            if shift >= 64:
+                raise google.protobuf.message.DecodeError('Too many bytes when decoding varint.')

--- a/tajo-client/python2/src/tajo/rpc/service.py
+++ b/tajo-client/python2/src/tajo/rpc/service.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class RpcService(object):
+    def __init__(self, service_stub_cls, channel):
+        self.service_stub_cls = service_stub_cls
+        self.channel = channel
+        self.service = self.service_stub_cls(self.channel)
+
+        for method in self.service_stub_cls.GetDescriptor().methods:
+            func = lambda request, service=self, method=method.name, callback=None: \
+                service.call(service_stub_cls.__dict__[method], request, callback)
+
+            self.__dict__[method.name] = func
+
+    def call(self, func, request, callback):
+        controller = self.channel.createController()
+        return func(self.service, controller, request, callback)

--- a/tajo-client/src/main/proto/TajoMasterClientProtocol.proto
+++ b/tajo-client/src/main/proto/TajoMasterClientProtocol.proto
@@ -20,6 +20,7 @@
 option java_package = "org.apache.tajo.ipc";
 option java_outer_classname = "TajoMasterClientProtocol";
 option java_generic_services = true;
+option py_generic_services = true;
 option java_generate_equals_and_hash = true;
 
 import "tajo_protos.proto";


### PR DESCRIPTION
Implementation of Tajo Python Native Client(with Protocol Buffer)

currently it just supports executeQuery. But I think this is useful