### PR TITLE
TAJO-1366: The timestamp type conversion occasionally leads to wrong results

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeConstants.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeConstants.java
@@ -553,7 +553,7 @@ public class DateTimeConstants {
     {"mins", TokenField.UNITS, TokenField.DTK_MINUTE},	/* "minutes" relative */
     {DMINUTE, TokenField.UNITS, TokenField.DTK_MINUTE},		/* "minute" relative */
     {"minutes", TokenField.UNITS, TokenField.DTK_MINUTE},		/* "minutes" relative */
-    {"mon", TokenField.UNITS, TokenField.DTK_MONTH},	/* "months_short" relative */
+//    {"mon", TokenField.UNITS, TokenField.DTK_MONTH},	/* "months_short" relative */
     {"mons", TokenField.UNITS, TokenField.DTK_MONTH}, /* "months_short" relative */
     {DMONTH, TokenField.UNITS, TokenField.DTK_MONTH}, /* "month" relative */
     {"months_short", TokenField.UNITS, TokenField.DTK_MONTH},
@@ -627,19 +627,24 @@ public class DateTimeConstants {
       dateTokenMap.put(dateToken.key, dateToken);
     }
 
-    for (Object[] eachToken: deltatktbl) {
-      DateToken dateToken = new DateToken();
-      dateToken.key = eachToken[0].toString();
-      dateToken.type = (TokenField)eachToken[1];
-      if (eachToken[2] instanceof TokenField) {
-        dateToken.valueType = (TokenField)eachToken[2];
-        dateToken.value = dateToken.valueType.getValue();
-      } else {
-        dateToken.valueType = TokenField.DECIMAL;
-        dateToken.value = ((Integer)eachToken[2]).intValue();
-      }
-      dateTokenMap.put(dateToken.key, dateToken);
-    }
+    /*
+     * TODO
+     * Currently, tajo does not support intervals, yet.
+     * The below code must be restored to support intervals.
+     */
+//    for (Object[] eachToken: deltatktbl) {
+//      DateToken dateToken = new DateToken();
+//      dateToken.key = eachToken[0].toString();
+//      dateToken.type = (TokenField)eachToken[1];
+//      if (eachToken[2] instanceof TokenField) {
+//        dateToken.valueType = (TokenField)eachToken[2];
+//        dateToken.value = dateToken.valueType.getValue();
+//      } else {
+//        dateToken.valueType = TokenField.DECIMAL;
+//        dateToken.value = ((Integer)eachToken[2]).intValue();
+//      }
+//      dateTokenMap.put(dateToken.key, dateToken);
+//    }
   }
 
   public static int INTERVAL_MASK(TokenField t) { return (1 << (t.getValue())); }

--- a/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeConstants.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeConstants.java
@@ -553,7 +553,7 @@ public class DateTimeConstants {
     {"mins", TokenField.UNITS, TokenField.DTK_MINUTE},	/* "minutes" relative */
     {DMINUTE, TokenField.UNITS, TokenField.DTK_MINUTE},		/* "minute" relative */
     {"minutes", TokenField.UNITS, TokenField.DTK_MINUTE},		/* "minutes" relative */
-//    {"mon", TokenField.UNITS, TokenField.DTK_MONTH},	/* "months_short" relative */
+    {"mon", TokenField.UNITS, TokenField.DTK_MONTH},	/* "months_short" relative */
     {"mons", TokenField.UNITS, TokenField.DTK_MONTH}, /* "months_short" relative */
     {DMONTH, TokenField.UNITS, TokenField.DTK_MONTH}, /* "month" relative */
     {"months_short", TokenField.UNITS, TokenField.DTK_MONTH},

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestTimestampDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestTimestampDatum.java
@@ -87,6 +87,13 @@ public class TestTimestampDatum {
     assertEquals(d, copy);
 	}
 
+  @Test
+  public void testAsText2() {
+    // TAJO-1366
+    TimestampDatum datum = DatumFactory.createTimestamp("Mon Nov 03 00:03:00 +0000 2014");
+    assertEquals("2014-11-03 00:03:00", datum.asChars());
+  }
+
 	@Test
   public final void testSize() {
     Datum d = DatumFactory.createTimestmpDatumWithUnixTime(unixtime);


### PR DESCRIPTION
Let me suppose an example query as follows:
```
select 'Mon Nov 03 00:03:00 +0000 2014'::timestamp;
```
The problem is that 'Mon' is identified as the ```UNITS``` type, but its actual type is ```DOW``` in this query.
This wrong parsing result is led by the duplicated key when managing DateTimeConstants in a map.
So, I removed all items of ```deltatktbl```, which causes the duplication problem, from the constants map.
This table is used when parsing ```interval```, but we don't support it yet.