### PR TITLE
TAJO-1437: Resolve findbug warnings on Tajo JDBC Module

### DIFF
--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
@@ -46,6 +46,7 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
       "abs,acos,asin,atan,atan2,ceiling,cos,degrees,exp,,floor,mod,pi,pow," +
       "radians,round,sign,sin,sqrt,tan";
   private static final String STRING_FUNCTIONS = "ascii,chr,concat,left,length,ltrim,repeat,rtrim,substring";
+  private static final String PROCEDURE_TERM = "UDF";
 
   private final JdbcConnection conn;
 
@@ -157,7 +158,7 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public String getProcedureTerm()  throws SQLException {
-    return new String("UDF");
+    return PROCEDURE_TERM;
   }
 
   @Override

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoPreparedStatement.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoPreparedStatement.java
@@ -86,8 +86,8 @@ public class TajoPreparedStatement implements PreparedStatement {
 
   @Override
   public boolean execute() throws SQLException {
-    ResultSet rs = executeImmediate(sql);
-    return rs != null;
+    resultSet = executeImmediate(sql);
+    return resultSet != null;
   }
 
   @Override

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoStatement.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoStatement.java
@@ -41,11 +41,6 @@ public class TajoStatement implements Statement {
   private ResultSet resultSet = null;
 
   /**
-   * Add SQLWarnings to the warningChain if needed.
-   */
-  private SQLWarning warningChain = null;
-
-  /**
    * Keep state so we can fail certain calls made after close().
    */
   private boolean isClosed = false;
@@ -71,9 +66,7 @@ public class TajoStatement implements Statement {
   }
 
   @Override
-  public void clearWarnings() throws SQLException {
-    warningChain = null;
-  }
+  public void clearWarnings() throws SQLException {}
 
   @Override
   public void close() throws SQLException {
@@ -219,6 +212,8 @@ public class TajoStatement implements Statement {
 
   @Override
   public Connection getConnection() throws SQLException {
+    if (isClosed)
+      throw new SQLException("Can't get connection after statement has been closed");
     return conn;
   }
 
@@ -229,6 +224,8 @@ public class TajoStatement implements Statement {
 
   @Override
   public int getFetchSize() throws SQLException {
+    if (isClosed)
+      throw new SQLException("Can't get fetch size after statement has been closed");
     return fetchSize;
   }
 
@@ -264,6 +261,8 @@ public class TajoStatement implements Statement {
 
   @Override
   public ResultSet getResultSet() throws SQLException {
+    if (isClosed)
+      throw new SQLException("Can't get result set after statement has been closed");
     return resultSet;
   }
 
@@ -284,12 +283,16 @@ public class TajoStatement implements Statement {
 
   @Override
   public int getUpdateCount() throws SQLException {
+    if (isClosed)
+      throw new SQLException("Can't get update count after statement has been closed");
     return 0;
   }
 
   @Override
   public SQLWarning getWarnings() throws SQLException {
-    return warningChain;
+    if (isClosed)
+      throw new SQLException("Can't get warnings after statement has been closed");
+    return null;
   }
 
   @Override
@@ -325,6 +328,8 @@ public class TajoStatement implements Statement {
 
   @Override
   public void setFetchSize(int rows) throws SQLException {
+    if (isClosed)
+      throw new SQLException("Can't set fetch size after statement has been closed");
     fetchSize = rows;
   }
 


### PR DESCRIPTION
- Performance: Replace 'new String("UDF")' into 'private static final String'.
- Bugfix: execute() saves the result set, now.
- Unused variable: warningChain is defined but always set to null.
- Standard compliance: raise SQLException on operation with a closed connection