### PR TITLE
TAJO-1440: Some tests fail in parallel test environment in TestKillQuery

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Stage.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Stage.java
@@ -537,8 +537,13 @@ public class Stage implements EventHandler<StageEvent> {
     eventHandler.handle(new StageCompletedEvent(getId(), finalState));
   }
 
-  public StateMachine<StageState, StageEventType, StageEvent> getStateMachine() {
-    return this.stateMachine;
+  public void doStateTransition(StageEventType type, StageEvent event) {
+    try {
+      writeLock.lock();
+      stateMachine.doTransition(type, event);
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public void setPriority(int priority) {
@@ -740,7 +745,7 @@ public class Stage implements EventHandler<StageEvent> {
       writeLock.lock();
       StageState oldState = getSynchronizedState();
       try {
-        getStateMachine().doTransition(event.getType(), event);
+        doStateTransition(event.getType(), event);
         stageState = getSynchronizedState();
       } catch (InvalidStateTransitonException e) {
         LOG.error("Can't handle this event at current state"

--- a/tajo-core/src/test/java/org/apache/tajo/querymaster/TestKillQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/querymaster/TestKillQuery.java
@@ -101,7 +101,6 @@ public class TestKillQuery {
     optimizer.optimize(plan);
 
     QueryId queryId = QueryIdFactory.newQueryId(System.currentTimeMillis(), 0);
-    System.out.println("queryID:"+queryId);
     QueryContext queryContext = new QueryContext(conf);
     MasterPlan masterPlan = new MasterPlan(queryId, queryContext, plan);
     GlobalPlanner globalPlanner = new GlobalPlanner(conf, catalog);
@@ -122,7 +121,6 @@ public class TestKillQuery {
     }
 
     Stage stage = queryMasterTask.getQuery().getStages().iterator().next();
-    assertEquals(queryId, queryMasterTask.getQueryId());
     assertNotNull(stage);
 
     try {

--- a/tajo-core/src/test/java/org/apache/tajo/querymaster/TestKillQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/querymaster/TestKillQuery.java
@@ -101,6 +101,7 @@ public class TestKillQuery {
     optimizer.optimize(plan);
 
     QueryId queryId = QueryIdFactory.newQueryId(System.currentTimeMillis(), 0);
+    System.out.println("queryID:"+queryId);
     QueryContext queryContext = new QueryContext(conf);
     MasterPlan masterPlan = new MasterPlan(queryId, queryContext, plan);
     GlobalPlanner globalPlanner = new GlobalPlanner(conf, catalog);
@@ -121,9 +122,10 @@ public class TestKillQuery {
     }
 
     Stage stage = queryMasterTask.getQuery().getStages().iterator().next();
+    assertEquals(queryId, queryMasterTask.getQueryId());
     assertNotNull(stage);
 
-    try{
+    try {
       cluster.waitForStageState(stage, StageState.INITED, 2);
     } finally {
       assertEquals(StageState.INITED, stage.getSynchronizedState());
@@ -178,23 +180,23 @@ public class TestKillQuery {
 
     assertEquals(StageState.KILLED, lastStage.getSynchronizedState());
 
-    lastStage.getStateMachine().doTransition(StageEventType.SQ_START,
-        new StageEvent(lastStage.getId(), StageEventType.SQ_START));
+    lastStage.doStateTransition(StageEventType.SQ_START,
+      new StageEvent(lastStage.getId(), StageEventType.SQ_START));
 
-    lastStage.getStateMachine().doTransition(StageEventType.SQ_KILL,
-        new StageEvent(lastStage.getId(), StageEventType.SQ_KILL));
+    lastStage.doStateTransition(StageEventType.SQ_KILL,
+      new StageEvent(lastStage.getId(), StageEventType.SQ_KILL));
 
-    lastStage.getStateMachine().doTransition(StageEventType.SQ_CONTAINER_ALLOCATED,
-        new StageEvent(lastStage.getId(), StageEventType.SQ_CONTAINER_ALLOCATED));
+    lastStage.doStateTransition(StageEventType.SQ_CONTAINER_ALLOCATED,
+      new StageEvent(lastStage.getId(), StageEventType.SQ_CONTAINER_ALLOCATED));
 
-    lastStage.getStateMachine().doTransition(StageEventType.SQ_SHUFFLE_REPORT,
-        new StageEvent(lastStage.getId(), StageEventType.SQ_SHUFFLE_REPORT));
+    lastStage.doStateTransition(StageEventType.SQ_SHUFFLE_REPORT,
+      new StageEvent(lastStage.getId(), StageEventType.SQ_SHUFFLE_REPORT));
 
-    lastStage.getStateMachine().doTransition(StageEventType.SQ_STAGE_COMPLETED,
-        new StageEvent(lastStage.getId(), StageEventType.SQ_STAGE_COMPLETED));
+    lastStage.doStateTransition(StageEventType.SQ_STAGE_COMPLETED,
+      new StageEvent(lastStage.getId(), StageEventType.SQ_STAGE_COMPLETED));
 
-    lastStage.getStateMachine().doTransition(StageEventType.SQ_FAILED,
-        new StageEvent(lastStage.getId(), StageEventType.SQ_FAILED));
+    lastStage.doStateTransition(StageEventType.SQ_FAILED,
+      new StageEvent(lastStage.getId(), StageEventType.SQ_FAILED));
   }
 
   @Test


### PR DESCRIPTION
Currently, state variable is exposed directly to outside.
Thus, changing state operation is out of locking scope and consistency may be broken.

Changing state should be protected by acquiring write lock.