### PR TITLE
TAJO-923: Add VAR_SAMP and VAR_POP window functions

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/StdDevPop.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/StdDevPop.java
@@ -24,19 +24,19 @@ import org.apache.tajo.datum.DatumFactory;
 import org.apache.tajo.datum.NullDatum;
 import org.apache.tajo.plan.function.FunctionContext;
 
-public abstract class StdDevPop extends StdDev {
+public abstract class StdDevPop extends Variance {
   public StdDevPop(Column[] definedArgs) {
     super(definedArgs);
   }
 
   @Override
   public Datum terminate(FunctionContext ctx) {
-    StdDevContext StdDevCtx = (StdDevContext) ctx;
-    if (StdDevCtx.count == 0) {
+    VarianceContext varianceCtx = (VarianceContext) ctx;
+    if (varianceCtx.count == 0) {
       return NullDatum.get();
-    } else if (StdDevCtx.count == 1) {
+    } else if (varianceCtx.count == 1) {
       return DatumFactory.createFloat8(0);
     }
-    return DatumFactory.createFloat8(Math.sqrt(StdDevCtx.squareSumOfDiff / StdDevCtx.count));
+    return DatumFactory.createFloat8(Math.sqrt(varianceCtx.squareSumOfDiff / varianceCtx.count));
   }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/StdDevSamp.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/StdDevSamp.java
@@ -24,18 +24,18 @@ import org.apache.tajo.datum.DatumFactory;
 import org.apache.tajo.datum.NullDatum;
 import org.apache.tajo.plan.function.FunctionContext;
 
-public abstract class StdDevSamp extends StdDev {
+public abstract class StdDevSamp extends Variance {
   public StdDevSamp(Column[] definedArgs) {
     super(definedArgs);
   }
 
   @Override
   public Datum terminate(FunctionContext ctx) {
-    StdDevContext StdDevCtx = (StdDevContext) ctx;
-    if (StdDevCtx.count <= 1) {
+    VarianceContext varianceCtx = (VarianceContext) ctx;
+    if (varianceCtx.count <= 1) {
       return NullDatum.get();
     }
 
-    return DatumFactory.createFloat8(Math.sqrt(StdDevCtx.squareSumOfDiff / (StdDevCtx.count - 1)));
+    return DatumFactory.createFloat8(Math.sqrt(varianceCtx.squareSumOfDiff / (varianceCtx.count - 1)));
   }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPop.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPop.java
@@ -16,23 +16,27 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.datum.Datum;
+import org.apache.tajo.datum.DatumFactory;
+import org.apache.tajo.datum.NullDatum;
+import org.apache.tajo.plan.function.FunctionContext;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
+public abstract class VarPop extends Variance {
+  public VarPop(Column[] definedArgs) {
+    super(definedArgs);
+  }
 
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+  @Override
+  public Datum terminate(FunctionContext ctx) {
+    VarianceContext varianceCtx = (VarianceContext) ctx;
+    if (varianceCtx.count == 0) {
+      return NullDatum.get();
+    } else if (varianceCtx.count == 1) {
+      return DatumFactory.createFloat8(0);
+    }
+    return DatumFactory.createFloat8(varianceCtx.squareSumOfDiff / varianceCtx.count);
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopDouble.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopDouble.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_POP",
+    description = "The variance of a set of numbers.",
+    example = "> SELECT VAR_POP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.FLOAT8})}
+)
+public class VarPopDouble extends VarPop {
+  public VarPopDouble() {
+    super(new Column[] {
+        new Column("expr", Type.FLOAT8)
+    });
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopFloat.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopFloat.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_POP",
+    description = "The variance of a set of numbers.",
+    example = "> SELECT VAR_POP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.FLOAT4})}
+)
+public class VarPopFloat extends VarPop {
+  public VarPopFloat() {
+    super(new Column[] {
+        new Column("expr", Type.FLOAT4)
+    });
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopInt.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopInt.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_POP",
+    description = "The variance of a set of numbers.",
+    example = "> SELECT VAR_POP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.INT4})}
+)
+public class VarPopInt extends VarPop {
+  public VarPopInt() {
+    super(new Column[] {
+        new Column("expr", Type.INT4)
+    });
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopLong.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarPopLong.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_POP",
+    description = "The variance of a set of numbers.",
+    example = "> SELECT VAR_POP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.INT8})}
+)
+public class VarPopLong extends VarPop {
+  public VarPopLong() {
+    super(new Column[] {
+        new Column("expr", Type.INT8)
+    });
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSamp.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSamp.java
@@ -16,23 +16,25 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.datum.Datum;
+import org.apache.tajo.datum.DatumFactory;
+import org.apache.tajo.datum.NullDatum;
+import org.apache.tajo.plan.function.FunctionContext;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
+public abstract class VarSamp extends Variance {
+  public VarSamp(Column[] definedArgs) {
+    super(definedArgs);
+  }
 
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+  @Override
+  public Datum terminate(FunctionContext ctx) {
+    VarianceContext varianceCtx = (VarianceContext) ctx;
+    if (varianceCtx.count <= 1) {
+      return NullDatum.get();
+    }
+    return DatumFactory.createFloat8(varianceCtx.squareSumOfDiff / (varianceCtx.count - 1));
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampDouble.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampDouble.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_SAMP",
+    description = "The unbiased sample variance of a set of numbers.",
+    example = "> SELECT VAR_SAMP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.FLOAT8})}
+)
+public class VarSampDouble extends VarSamp {
+  public VarSampDouble() {
+    super(new Column[] {
+        new Column("expr", Type.FLOAT8)
+    });
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampFloat.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampFloat.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_SAMP",
+    description = "The unbiased sample variance of a set of numbers.",
+    example = "> SELECT VAR_SAMP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.FLOAT4})}
+)
+public class VarSampFloat extends VarSamp {
+  public VarSampFloat() {
+    super(new Column[] {
+        new Column("expr", Type.FLOAT4)
+    });
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampInt.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampInt.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_SAMP",
+    description = "The unbiased sample variance of a set of numbers.",
+    example = "> SELECT VAR_SAMP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.INT4})}
+)
+public class VarSampInt extends VarSamp {
+  public VarSampInt() {
+    super(new Column[] {
+        new Column("expr", Type.INT4)
+    });
+  }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampLong.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/builtin/VarSampLong.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-option java_package = "org.apache.tajo";
-option java_outer_classname = "InternalTypes";
-option java_generic_services = false;
-option java_generate_equals_and_hash = true;
+package org.apache.tajo.engine.function.builtin;
 
-message AvgLongProto {
-  required int64 sum = 1;
-  required int64 count = 2;
-}
+import org.apache.tajo.catalog.Column;
+import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.engine.function.annotation.Description;
+import org.apache.tajo.engine.function.annotation.ParamTypes;
 
-message AvgDoubleProto {
-  required double sum = 1;
-  required int64 count = 2;
-}
-
-message VarianceProto {
-  required double squareSumOfDiff = 1;
-  required double avg = 2;
-  required int64 count = 3;
+@Description(
+    functionName = "VAR_SAMP",
+    description = "The unbiased sample variance of a set of numbers.",
+    example = "> SELECT VAR_SAMP(expr);",
+    returnType = Type.FLOAT8,
+    paramTypes = {@ParamTypes(paramTypes = {Type.INT8})}
+)
+public class VarSampLong extends VarSamp {
+  public VarSampLong() {
+    super(new Column[] {
+        new Column("expr", Type.INT8)
+    });
+  }
 }

--- a/tajo-core/src/test/java/org/apache/tajo/engine/function/TestBuiltinFunctions.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/function/TestBuiltinFunctions.java
@@ -597,6 +597,129 @@ public class TestBuiltinFunctions extends QueryTestCaseBase {
 
   }
 
+  @Test
+  public void testVarSamp() throws Exception {
+    KeyValueSet tableOptions = new KeyValueSet();
+    tableOptions.set(StorageConstants.TEXT_DELIMITER, StorageConstants.DEFAULT_FIELD_DELIMITER);
+    tableOptions.set(StorageConstants.TEXT_NULL, "\\\\N");
+
+    Schema schema = new Schema();
+    schema.addColumn("id", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_int", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_long", TajoDataTypes.Type.INT8);
+    schema.addColumn("value_float", TajoDataTypes.Type.FLOAT4);
+    schema.addColumn("value_double", TajoDataTypes.Type.FLOAT8);
+    String[] data = new String[]{
+            "1|\\N|-111|1.2|-50.5",
+            "2|1|\\N|\\N|52.5",
+            "3|2|-333|2.8|\\N" };
+    TajoTestingCluster.createTable("table11", schema, tableOptions, data, 1);
+
+    try {
+      ResultSet res = executeString("select var_samp(value_int) as vs_int, var_samp(value_long) as vs_long, var_samp(value_float) as vs_float, var_samp(value_double) as vs_double from table11");
+      String ascExpected = "vs_int,vs_long,vs_float,vs_double\n" +
+              "-------------------------------\n" +
+              "0.5,24642.0,1.279999847412114,5304.5\n";
+
+      assertEquals(ascExpected, resultSetToString(res));
+      res.close();
+    } finally {
+      executeString("DROP TABLE table11 PURGE");
+    }
+  }
+
+  @Test
+  public void testVarSampWithFewNumbers() throws Exception {
+    KeyValueSet tableOptions = new KeyValueSet();
+    tableOptions.set(StorageConstants.TEXT_DELIMITER, StorageConstants.DEFAULT_FIELD_DELIMITER);
+    tableOptions.set(StorageConstants.TEXT_NULL, "\\\\N");
+
+    Schema schema = new Schema();
+    schema.addColumn("id", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_int", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_long", TajoDataTypes.Type.INT8);
+    schema.addColumn("value_float", TajoDataTypes.Type.FLOAT4);
+    schema.addColumn("value_double", TajoDataTypes.Type.FLOAT8);
+    String[] data = new String[]{
+            "1|\\N|\\N|\\N|-50.5",
+            "2|1|\\N|\\N|\\N",
+            "3|\\N|\\N|\\N|\\N" };
+    TajoTestingCluster.createTable("table11", schema, tableOptions, data, 1);
+
+    try {
+      ResultSet res = executeString("select var_samp(value_int) as vsamp_int, var_samp(value_long) as vsamp_long, var_samp(value_float) as vsamp_float, var_samp(value_double) as vsamp_double from table11");
+      String ascExpected = "vsamp_int,vsamp_long,vsamp_float,vsamp_double\n" +
+              "-------------------------------\n" +
+              "null,null,null,null\n";
+
+      assertEquals(ascExpected, resultSetToString(res));
+      res.close();
+    } finally {
+      executeString("DROP TABLE table11 PURGE");
+    }
+  }
+
+  @Test
+  public void testVarPop() throws Exception {
+    KeyValueSet tableOptions = new KeyValueSet();
+    tableOptions.set(StorageConstants.TEXT_DELIMITER, StorageConstants.DEFAULT_FIELD_DELIMITER);
+    tableOptions.set(StorageConstants.TEXT_NULL, "\\\\N");
+
+    Schema schema = new Schema();
+    schema.addColumn("id", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_int", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_long", TajoDataTypes.Type.INT8);
+    schema.addColumn("value_float", TajoDataTypes.Type.FLOAT4);
+    schema.addColumn("value_double", TajoDataTypes.Type.FLOAT8);
+    String[] data = new String[]{
+            "1|\\N|-111|1.2|-50.5",
+            "2|1|\\N|\\N|52.5",
+            "3|2|-333|2.8|\\N" };
+    TajoTestingCluster.createTable("table11", schema, tableOptions, data, 1);
+
+    try {
+      ResultSet res = executeString("select var_pop(value_int) as vpop_int, var_pop(value_long) as vpop_long, var_pop(value_float) as vpop_float, var_pop(value_double) as vpop_double from table11");
+      String ascExpected = "vpop_int,vpop_long,vpop_float,vpop_double\n" +
+              "-------------------------------\n" +
+              "0.25,12321.0,0.639999923706057,2652.25\n";
+
+      assertEquals(ascExpected, resultSetToString(res));
+      res.close();
+    } finally {
+      executeString("DROP TABLE table11 PURGE");
+    }
+  }
+
+  @Test
+  public void testVarPopWithFewNumbers() throws Exception {
+    KeyValueSet tableOptions = new KeyValueSet();
+    tableOptions.set(StorageConstants.TEXT_DELIMITER, StorageConstants.DEFAULT_FIELD_DELIMITER);
+    tableOptions.set(StorageConstants.TEXT_NULL, "\\\\N");
+
+    Schema schema = new Schema();
+    schema.addColumn("id", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_int", TajoDataTypes.Type.INT4);
+    schema.addColumn("value_long", TajoDataTypes.Type.INT8);
+    schema.addColumn("value_float", TajoDataTypes.Type.FLOAT4);
+    schema.addColumn("value_double", TajoDataTypes.Type.FLOAT8);
+    String[] data = new String[]{
+            "1|\\N|\\N|\\N|-50.5",
+            "2|1|\\N|\\N|\\N",
+            "3|\\N|\\N|\\N|\\N" };
+    TajoTestingCluster.createTable("table11", schema, tableOptions, data, 1);
+
+    try {
+      ResultSet res = executeString("select var_pop(value_int) as vpop_int, var_pop(value_long) as vpop_long, var_pop(value_float) as vpop_float, var_pop(value_double) as vpop_double from table11");
+      String ascExpected = "vpop_int,vpop_long,vpop_float,vpop_double\n" +
+              "-------------------------------\n" +
+              "0.0,null,null,0.0\n";
+
+      assertEquals(ascExpected, resultSetToString(res));
+      res.close();
+    } finally {
+      executeString("DROP TABLE table11 PURGE");
+    }
+  }
 
 //  @Test
 //  public void testRandom() throws Exception {


### PR DESCRIPTION
I coded in the same way in https://github.com/apache/tajo/pull/427 (TAJO-921)
If needed, after merging pull-request 427, I will do refactoring.

This code is passed the following command.
```
mvn clean install -Pparallel-test,hcatalog-0.12.0 -DLOG_LEVEL=ERROR -Dmaven.fork.count=2 &> TAJO-923.travis.ERROR.txt
```
The result file is https://app.box.com/s/clnx9d2bisfhbh2upgo3q6g7bdx7aic5