### PR TITLE
TAJO-1147: Simple query doesn't work in Web UI

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/webapp/QueryExecutorServlet.java
+++ b/tajo-core/src/main/java/org/apache/tajo/webapp/QueryExecutorServlet.java
@@ -483,7 +483,7 @@ public class QueryExecutorServlet extends HttpServlet {
     private void MakeResultText(ResultSet res, TableDesc desc) throws SQLException {
       ResultSetMetaData rsmd = res.getMetaData();
       resultRows = desc.getStats() == null ? 0 : desc.getStats().getNumRows();
-      if (resultRows == 0) {
+      if (resultRows <= 0) {
         resultRows = 1000;
       }
       LOG.info("Tajo Query Result: " + desc.getPath() + "\n");


### PR DESCRIPTION
'resultRows' can be -1.
-1 means TajoConstants.UNKNOWN_ROW_NUMBER.