### PR TITLE
TAJO-1467: Parenthesis at the start of SQL query is ignored

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/SimpleParser.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/SimpleParser.java
@@ -315,7 +315,7 @@ public class SimpleParser {
   }
 
   private boolean isStatementStart(char character) {
-    return state == ParsingState.TOK_START && (Character.isLetterOrDigit(character));
+    return state == ParsingState.TOK_START && (Character.isLetterOrDigit(character) || character == '(');
   }
 
   private boolean isStatementContinue() {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/parser/SQLAnalyzer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/parser/SQLAnalyzer.java
@@ -204,6 +204,16 @@ public class SQLAnalyzer extends SQLParserBaseVisitor<Expr> {
   }
 
   @Override
+  public Expr visitNon_join_query_primary(Non_join_query_primaryContext ctx) {
+    if (ctx.simple_table() != null) {
+      return visitSimple_table(ctx.simple_table());
+    } else if (ctx.non_join_query_expression() != null) {
+      return visitNon_join_query_expression(ctx.non_join_query_expression());
+    }
+    return visitChildren(ctx);
+  }
+
+  @Override
   public Expr visitQuery_specification(SQLParser.Query_specificationContext ctx) {
     Expr current = null;
     if (ctx.table_expression() != null) {

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestSelectQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestSelectQuery.java
@@ -708,4 +708,18 @@ public class TestSelectQuery extends QueryTestCaseBase {
       executeString("DROP TABLE table2");
     }
   }
+
+  @Test
+  public void testSelectWithParentheses1() throws Exception {
+    ResultSet res = executeQuery();
+    assertResultSet(res);
+    cleanupQuery(res);
+  }
+
+  @Test
+  public void testSelectWithParentheses2() throws Exception {
+    ResultSet res = executeQuery();
+    assertResultSet(res);
+    cleanupQuery(res);
+  }
 }

--- a/tajo-core/src/test/resources/queries/TestSelectQuery/testSelectWithParentheses1.sql
+++ b/tajo-core/src/test/resources/queries/TestSelectQuery/testSelectWithParentheses1.sql
@@ -1,0 +1,1 @@
+(select n_nationkey, n_name from nation where n_nationkey = 1);

--- a/tajo-core/src/test/resources/queries/TestSelectQuery/testSelectWithParentheses2.sql
+++ b/tajo-core/src/test/resources/queries/TestSelectQuery/testSelectWithParentheses2.sql
@@ -1,0 +1,1 @@
+(select n1.n_nationkey, n2.n_name from nation n1 join nation n2 on n1.n_nationkey = n2.n_nationkey where n_nationkey = 1);

--- a/tajo-core/src/test/resources/results/TestSelectQuery/testSelectWithParentheses1.result
+++ b/tajo-core/src/test/resources/results/TestSelectQuery/testSelectWithParentheses1.result
@@ -1,0 +1,3 @@
+n_nationkey,n_name
+-------------------------------
+1,ARGENTINA

--- a/tajo-core/src/test/resources/results/TestSelectQuery/testSelectWithParentheses2.result
+++ b/tajo-core/src/test/resources/results/TestSelectQuery/testSelectWithParentheses2.result
@@ -1,0 +1,3 @@
+n_nationkey,n_name
+-------------------------------
+1,ARGENTINA


### PR DESCRIPTION
Fix SimpleParser to accept a SQL query starts with '(' character.
Also fix SQLAnalyzer to handle non_join_query_primary properly as defined in Tajo grammar.