### PR TITLE
TAJO-1500 FinishedTaskCleanThread is not interrupted when worker stops

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskRunnerManager.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskRunnerManager.java
@@ -94,7 +94,7 @@ public class TaskRunnerManager extends CompositeService implements EventHandler<
     }
 
     if(finishedTaskCleanThread != null) {
-      finishedTaskCleanThread.interrupted();
+      finishedTaskCleanThread.interrupt();
     }
 
     super.stop();


### PR DESCRIPTION
Another trivial fix