### PR TITLE
TAJO-1515: task history file size limit

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -279,6 +279,8 @@ public class TajoConf extends Configuration {
     HISTORY_EXPIRY_TIME_DAY("tajo.history.expiry-time-day", 7),
     HISTORY_QUERY_REPLICATION("tajo.history.query.replication", 1, Validators.min("1")),
     HISTORY_TASK_REPLICATION("tajo.history.task.replication", 1, Validators.min("1")),
+    HISTORY_QUERY_MAX_FILE_SIZE("tajo.history.query.max-file-size", (10 * 1024 * 1024)),
+    HISTORY_TASK_MAX_FILE_SIZE("tajo.history.task.max-file-size", (100 * 1024 * 1024)),
 
     // Misc -------------------------------------------------------------------
     // Fragment

--- a/tajo-core/src/main/java/org/apache/tajo/util/history/HistoryReader.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/history/HistoryReader.java
@@ -172,7 +172,7 @@ public class HistoryReader {
     FileSystem fs = HistoryWriter.getNonCrcFileSystem(queryHistoryFile, tajoConf);
 
     FileStatus fileStatus = fs.getFileStatus(queryHistoryFile);
-    if (fileStatus.getLen() > 10 * 1024 * 1024) {
+    if (fileStatus.getLen() > tajoConf.getIntVar(TajoConf.ConfVars.HISTORY_QUERY_MAX_FILE_SIZE)) {
       throw new IOException("QueryHistory file is too big: " +
           queryHistoryFile + ", " + fileStatus.getLen() + " bytes");
     }
@@ -204,7 +204,7 @@ public class HistoryReader {
     }
 
     FileStatus fileStatus = fs.getFileStatus(detailFile);
-    if (fileStatus.getLen() > 100 * 1024 * 1024) {    // 100MB
+    if (fileStatus.getLen() > tajoConf.getIntVar(TajoConf.ConfVars.HISTORY_TASK_MAX_FILE_SIZE)) {
       throw new IOException("TaskHistory file is too big: " + detailFile + ", " + fileStatus.getLen() + " bytes");
     }
 


### PR DESCRIPTION
It is possible to produce the exception described in this issue by inserting codes in TestHistoryWriterReader.java, but it seems unnecessary because the patch is quite trivial.