### PR TITLE
TAJO-1533 Provide hint to children execs whether it will require rescan on them

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/AggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/AggregationExec.java
@@ -60,8 +60,8 @@ public abstract class AggregationExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     for (EvalNode aggFunction : aggFunctions) {
       aggFunction.bind(inSchema);
     }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BNLJoinExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BNLJoinExec.java
@@ -68,6 +68,11 @@ public class BNLJoinExec extends CommonJoinExec {
     outputTuple = new VTuple(outSchema.size());
   }
 
+  @Override
+  public void init(boolean rescan) throws IOException {
+    init(rescan, true);
+  }
+
   public Tuple next() throws IOException {
 
     if (leftTupleSlots.isEmpty()) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BSTIndexScanExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BSTIndexScanExec.java
@@ -68,8 +68,8 @@ public class BSTIndexScanExec extends PhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     progress = 0.0f;
     if (qual != null) {
       qual.bind(inSchema);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BinaryPhysicalExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BinaryPhysicalExec.java
@@ -47,13 +47,16 @@ public abstract class BinaryPhysicalExec extends PhysicalExec {
     return rightChild;
   }
 
-  @Override
-  public void init() throws IOException {
-    leftChild.init();
-    rightChild.init();
+  protected void init(boolean leftRescan, boolean rightRescan) throws IOException {
+    leftChild.init(leftRescan);
+    rightChild.init(rightRescan);
     progress = 0.0f;
+    super.init(leftRescan || rightRescan);
+  }
 
-    super.init();
+  @Override
+  public void init(boolean needsRescan) throws IOException {
+    init(needsRescan, needsRescan);
   }
 
   @Override

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
@@ -123,8 +123,8 @@ public abstract class ColPartitionStoreExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     storeTablePath = context.getOutputPath();
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyFirstAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyFirstAggregationExec.java
@@ -107,8 +107,8 @@ public class DistinctGroupbyFirstAggregationExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     // finding grouping column index
     Column[] groupingColumns = plan.getGroupingColumns();

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
@@ -57,8 +57,8 @@ public class DistinctGroupbyHashAggregationExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     List<Integer> distinctGroupingKeyIdList = new ArrayList<Integer>();
     for (Column col: plan.getGroupingColumns()) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySecondAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySecondAggregationExec.java
@@ -93,8 +93,8 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     numGroupingColumns = plan.getGroupingColumns().length;
 
     List<GroupbyNode> groupbyNodes = plan.getSubPlans();

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySortAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySortAggregationExec.java
@@ -22,7 +22,6 @@ import org.apache.tajo.catalog.statistics.TableStats;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.datum.DatumFactory;
 import org.apache.tajo.datum.NullDatum;
-import org.apache.tajo.plan.expr.AggregationFunctionCallEval;
 import org.apache.tajo.plan.logical.DistinctGroupbyNode;
 import org.apache.tajo.plan.logical.GroupbyNode;
 import org.apache.tajo.storage.Tuple;
@@ -66,9 +65,12 @@ public class DistinctGroupbySortAggregationExec extends PhysicalExec {
     for(int i = 0; i < resultColumnIds.length; i++) {
       resultColumnIdIndexes[resultColumnIds[i]] = i;
     }
+  }
 
-    for (SortAggregateExec eachExec: aggregateExecs) {
-      eachExec.init();
+  @Override
+  public void init(boolean needsScan) throws IOException {
+    for (int i = 0; i < aggregateExecs.length; i++) {
+      aggregateExecs[i].init(i < groupbyNodeNum);
     }
   }
 
@@ -169,10 +171,6 @@ public class DistinctGroupbySortAggregationExec extends PhysicalExec {
         eachExec.close();
       }
     }
-  }
-
-  @Override
-  public void init() throws IOException {
   }
 
   @Override

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
@@ -58,8 +58,8 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     numGroupingColumns = plan.getGroupingColumns().length;
     resultTupleLength = numGroupingColumns;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/EvalExprExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/EvalExprExec.java
@@ -37,8 +37,8 @@ public class EvalExprExec extends PhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     progress = 0.0f;
     for (Target target : plan.getTargets()) {
       target.getEvalTree().bind(inSchema);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashBasedColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashBasedColPartitionStoreExec.java
@@ -44,8 +44,8 @@ public class HashBasedColPartitionStoreExec extends ColPartitionStoreExec {
     super(context, plan, child);
   }
 
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
   }
 
   private Appender getAppender(String partition) throws IOException {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashShuffleFileWriteExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashShuffleFileWriteExec.java
@@ -78,8 +78,8 @@ public final class HashShuffleFileWriteExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
   }
   
   private HashShuffleAppender getAppender(int partId) throws IOException {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HavingExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HavingExec.java
@@ -37,8 +37,8 @@ public class HavingExec extends UnaryPhysicalExec  {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     qual.bind(inSchema);
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/LimitExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/LimitExec.java
@@ -48,8 +48,9 @@ public class LimitExec extends UnaryPhysicalExec {
     return tuple;
   }
 
+  @Override
   public void rescan() throws IOException {
-    super.init();
+    super.init(false);
     fetchCount = 0;
   }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/MemSortExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/MemSortExec.java
@@ -40,8 +40,8 @@ public class MemSortExec extends SortExec {
     this.plan = plan;
   }
 
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     this.tupleSlots = new ArrayList<Tuple>(10000);
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/NLJoinExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/NLJoinExec.java
@@ -44,6 +44,11 @@ public class NLJoinExec extends CommonJoinExec {
     outTuple = new VTuple(outSchema.size());
   }
 
+  @Override
+  public void init(boolean rescan) throws IOException {
+    init(rescan, true);
+  }
+
   public Tuple next() throws IOException {
     while (!context.isStopped()) {
       if (needNewOuter) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/NLLeftOuterJoinExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/NLLeftOuterJoinExec.java
@@ -50,6 +50,11 @@ public class NLLeftOuterJoinExec extends CommonJoinExec {
     rightNumCols = rightChild.getSchema().size();
   }
 
+  @Override
+  public void init(boolean rescan) throws IOException {
+    init(rescan, true);
+  }
+
   public Tuple next() throws IOException {
     while (!context.isStopped()) {
       if (needNextRightTuple) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/PhysicalExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/PhysicalExec.java
@@ -37,6 +37,9 @@ public abstract class PhysicalExec implements SchemaObject {
   protected Schema outSchema;
   protected int outColumnNum;
 
+  // some exec's hold data in memory. in high-memory pressure situation, we need paging on them
+  protected boolean parentNeedsRescan;
+
   public PhysicalExec(final TaskAttemptContext context, final Schema inSchema,
                       final Schema outSchema) {
     this.context = context;
@@ -49,7 +52,9 @@ public abstract class PhysicalExec implements SchemaObject {
     return outSchema;
   }
 
-  public void init() throws IOException {
+  // needsRescan=true : parent might rescan on this
+  public void init(boolean needsRescan) throws IOException {
+    parentNeedsRescan = needsRescan;
     if (context.getQueryContext().getBool(SessionVars.CODEGEN)) {
       this.compile();
     }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ProjectionExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ProjectionExec.java
@@ -42,8 +42,8 @@ public class ProjectionExec extends UnaryPhysicalExec {
     this.plan = plan;
   }
 
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     this.outTuple = new VTuple(outSchema.size());
     this.projector = new Projector(context, inSchema, outSchema, this.plan.getTargets());

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/RangeShuffleFileWriteExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/RangeShuffleFileWriteExec.java
@@ -58,8 +58,8 @@ public class RangeShuffleFileWriteExec extends UnaryPhysicalExec {
     this.sortSpecs = sortSpecs;
   }
 
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     indexKeys = new int[sortSpecs.length];
     keySchema = PlannerUtil.sortSpecsToSchema(sortSpecs);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ScanExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ScanExec.java
@@ -43,10 +43,10 @@ public abstract class ScanExec extends PhysicalExec {
   public abstract CatalogProtos.FragmentProto[] getFragments();
 
   @Override
-  public void init() throws IOException {
+  public void init(boolean needsRescan) throws IOException {
     canBroadcast = checkIfBroadcast();
 
-    super.init();
+    super.init(needsRescan);
   }
 
   public boolean canBroadcast() {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SelectionExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SelectionExec.java
@@ -37,8 +37,8 @@ public class SelectionExec extends UnaryPhysicalExec  {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     qual.bind(inSchema);
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SeqScanExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SeqScanExec.java
@@ -135,7 +135,7 @@ public class SeqScanExec extends ScanExec {
   }
 
   @Override
-  public void init() throws IOException {
+  public void init(boolean needsRescan) throws IOException {
     Schema projected;
 
     if (plan.hasTargets()) {
@@ -160,7 +160,7 @@ public class SeqScanExec extends ScanExec {
     }
 
     initScanner(projected);
-    super.init();
+    super.init(needsRescan);
 
     if (plan.hasQual()) {
       qual.bind(inSchema);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SortBasedColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SortBasedColPartitionStoreExec.java
@@ -44,8 +44,8 @@ public class SortBasedColPartitionStoreExec extends ColPartitionStoreExec {
     super(context, plan, child);
   }
 
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     currentKey = new VTuple(keyNum);
   }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/StoreTableExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/StoreTableExec.java
@@ -61,8 +61,8 @@ public class StoreTableExec extends UnaryPhysicalExec {
     this.plan = plan;
   }
 
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
 
     if (plan.hasOptions()) {
       meta = CatalogUtil.newTableMeta(plan.getStorageType(), plan.getOptions());

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/UnaryPhysicalExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/UnaryPhysicalExec.java
@@ -37,6 +37,7 @@ public abstract class UnaryPhysicalExec extends PhysicalExec {
     this.child = child;
   }
 
+  @SuppressWarnings("unchecked")
   public <T extends PhysicalExec> T getChild() {
     return (T) this.child;
   }
@@ -47,13 +48,12 @@ public abstract class UnaryPhysicalExec extends PhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
+  public void init(boolean needsRescan) throws IOException {
     progress = 0.0f;
     if (child != null) {
-      child.init();
+      child.init(needsRescan);
     }
-
-    super.init();
+    super.init(needsRescan);
   }
 
   @Override

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/WindowAggExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/WindowAggExec.java
@@ -180,8 +180,8 @@ public class WindowAggExec extends UnaryPhysicalExec {
   }
 
   @Override
-  public void init() throws IOException {
-    super.init();
+  public void init(boolean needsRescan) throws IOException {
+    super.init(needsRescan);
     for (EvalNode functionEval : functions) {
       functionEval.bind(inSchema);
     }

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultFileScanner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultFileScanner.java
@@ -122,7 +122,7 @@ public class NonForwardQueryResultFileScanner implements NonForwardQueryResultSc
       } catch (CloneNotSupportedException e) {
         throw new IOException(e.getMessage(), e);
       }
-      scanExec.init();
+      scanExec.init(false);
       currentFragmentIndex += fragments.size();
     }
   }

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultSystemScanner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultSystemScanner.java
@@ -124,7 +124,7 @@ public class NonForwardQueryResultSystemScanner implements NonForwardQueryResult
     outSchema = physicalExec.getSchema();
     encoder = RowStoreUtil.createEncoder(getLogicalSchema());
     
-    physicalExec.init();
+    physicalExec.init(false);
   }
 
   @Override
@@ -664,6 +664,8 @@ public class NonForwardQueryResultSystemScanner implements NonForwardQueryResult
       
       projector = new Projector(context, inSchema, outSchema, scanNode.getTargets());
     }
+
+    // this class rescans but it's not from children. so we need not to init with flag needsRescan=true
 
     @Override
     public Tuple next() throws IOException {

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
@@ -322,7 +322,7 @@ public class QueryExecutor {
     EvalExprExec evalExprExec = new EvalExprExec(taskAttemptContext, (EvalExprNode) insertNode.getChild());
     StoreTableExec exec = new StoreTableExec(taskAttemptContext, insertNode, evalExprExec);
     try {
-      exec.init();
+      exec.init(false);
       exec.next();
     } finally {
       exec.close();

--- a/tajo-core/src/main/java/org/apache/tajo/worker/Task.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/Task.java
@@ -402,7 +402,7 @@ public class Task {
 
         this.executor = executionBlockContext.getTQueryEngine().
             createPlan(context, plan);
-        this.executor.init();
+        this.executor.init(false);
 
         while(!context.isStopped() && executor.next() != null) {
         }

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestBNLJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestBNLJoinExec.java
@@ -169,7 +169,7 @@ public class TestBNLJoinExec {
     assertTrue(proj.getChild() instanceof BNLJoinExec);
 
     int i = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       i++;
     }
@@ -210,7 +210,7 @@ public class TestBNLJoinExec {
     Tuple tuple;
     int i = 1;
     int count = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       count++;
       assertTrue(i == tuple.get(0).asInt4());

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestBSTIndexExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestBSTIndexExec.java
@@ -176,7 +176,7 @@ public class TestBSTIndexExec {
 
     int tupleCount = this.randomValues.get(rndKey);
     int counter = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       counter ++;
     }

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
@@ -148,7 +148,7 @@ public class TestExternalSortExec {
     Tuple preVal = null;
     Tuple curVal;
     int cnt = 0;
-    exec.init();
+    exec.init(false);
     long start = System.currentTimeMillis();
     BaseTupleComparator comparator = new BaseTupleComparator(proj.getSchema(),
         new SortSpec[]{

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestFullOuterHashJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestFullOuterHashJoinExec.java
@@ -285,7 +285,7 @@ public class TestFullOuterHashJoinExec {
     assertTrue(proj.getChild() instanceof HashFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -324,7 +324,7 @@ public class TestFullOuterHashJoinExec {
     assertTrue(proj.getChild() instanceof HashFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -362,7 +362,7 @@ public class TestFullOuterHashJoinExec {
     assertTrue(proj.getChild() instanceof HashFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -402,7 +402,7 @@ public class TestFullOuterHashJoinExec {
     assertTrue(proj.getChild() instanceof HashFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       //TODO check contents
       count = count + 1;

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestFullOuterMergeJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestFullOuterMergeJoinExec.java
@@ -333,7 +333,7 @@ public class TestFullOuterMergeJoinExec {
     ProjectionExec proj = (ProjectionExec) exec;
     assertTrue(proj.getChild() instanceof MergeFullOuterJoinExec);
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -371,7 +371,7 @@ public class TestFullOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof MergeFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -409,7 +409,7 @@ public class TestFullOuterMergeJoinExec {
 
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -448,7 +448,7 @@ public class TestFullOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof MergeFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -487,7 +487,7 @@ public class TestFullOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof MergeFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -526,7 +526,7 @@ public class TestFullOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof MergeFullOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestHashAntiJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestHashAntiJoinExec.java
@@ -197,7 +197,7 @@ public class TestHashAntiJoinExec {
     Tuple tuple;
     int count = 0;
     int i = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       count++;
       assertTrue(i == tuple.get(0).asInt4());

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestHashJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestHashJoinExec.java
@@ -171,7 +171,7 @@ public class TestHashJoinExec {
     Tuple tuple;
     int count = 0;
     int i = 1;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       count++;
       assertTrue(i == tuple.get(0).asInt4());

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestHashSemiJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestHashSemiJoinExec.java
@@ -202,7 +202,7 @@ public class TestHashSemiJoinExec {
     Tuple tuple;
     int count = 0;
     int i = 1;
-    exec.init();
+    exec.init(false);
     // expect result without duplicated tuples.
     while ((tuple = exec.next()) != null) {
       count++;

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestLeftOuterHashJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestLeftOuterHashJoinExec.java
@@ -289,7 +289,7 @@ public class TestLeftOuterHashJoinExec {
     assertTrue(proj.getChild() instanceof HashLeftOuterJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       //TODO check contents
       count = count + 1;
@@ -328,7 +328,7 @@ public class TestLeftOuterHashJoinExec {
        Tuple tuple;
        int count = 0;
        int i = 1;
-       exec.init();
+       exec.init(false);
   
        while ((tuple = exec.next()) != null) {
          //TODO check contents
@@ -370,7 +370,7 @@ public class TestLeftOuterHashJoinExec {
        Tuple tuple;
        int count = 0;
        int i = 1;
-       exec.init();
+       exec.init(false);
   
        while ((tuple = exec.next()) != null) {
          //TODO check contents
@@ -412,7 +412,7 @@ public class TestLeftOuterHashJoinExec {
        Tuple tuple;
        int count = 0;
        int i = 1;
-       exec.init();
+       exec.init(false);
   
        while ((tuple = exec.next()) != null) {
          //TODO check contents
@@ -452,7 +452,7 @@ public class TestLeftOuterHashJoinExec {
     }
     else{
        int count = 0;
-       exec.init();
+       exec.init(false);
   
        while (exec.next() != null) {
          //TODO check contents

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestLeftOuterNLJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestLeftOuterNLJoinExec.java
@@ -283,7 +283,7 @@ public class TestLeftOuterNLJoinExec {
     }
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
        //TODO check contents
          count = count + 1;
@@ -329,7 +329,7 @@ public class TestLeftOuterNLJoinExec {
     Tuple tuple;
     int i = 1;
     int count = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
        //TODO check contents
          count = count + 1;
@@ -373,7 +373,7 @@ public class TestLeftOuterNLJoinExec {
     Tuple tuple;
     int i = 1;
     int count = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
        //TODO check contents
          count = count + 1;
@@ -418,7 +418,7 @@ public class TestLeftOuterNLJoinExec {
     Tuple tuple;
     int i = 1;
     int count = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
        //TODO check contents
          count = count + 1;
@@ -462,7 +462,7 @@ public class TestLeftOuterNLJoinExec {
     Tuple tuple;
     int i = 1;
     int count = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
        //TODO check contents
          count = count + 1;

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestMergeJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestMergeJoinExec.java
@@ -182,7 +182,7 @@ public class TestMergeJoinExec {
     Tuple tuple;
     int count = 0;
     int i = 1;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       count++;
       assertTrue(i == tuple.get(0).asInt4());

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestNLJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestNLJoinExec.java
@@ -163,7 +163,7 @@ public class TestNLJoinExec {
     PhysicalExec exec = phyPlanner.createPlan(ctx, plan);
 
     int i = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       i++;
     }
@@ -194,7 +194,7 @@ public class TestNLJoinExec {
     Tuple tuple;
     int i = 1;
     int count = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       count++;
       assertTrue(i == tuple.get(0).asInt4());

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
@@ -256,7 +256,7 @@ public class TestPhysicalPlanner {
 
     Tuple tuple;
     int i = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       assertTrue(tuple.contains(0));
       assertTrue(tuple.contains(1));
@@ -287,7 +287,7 @@ public class TestPhysicalPlanner {
 
     Tuple tuple;
     int i = 0;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       assertTrue(tuple.contains(0));
       i++;
@@ -315,7 +315,7 @@ public class TestPhysicalPlanner {
 
     int i = 0;
     Tuple tuple;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       assertEquals(6, tuple.get(2).asInt4()); // sum
       assertEquals(3, tuple.get(3).asInt4()); // max
@@ -346,7 +346,7 @@ public class TestPhysicalPlanner {
 
     int i = 0;
     Tuple tuple;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       assertEquals(12, tuple.get(1).asInt4()); // sum
       assertEquals(3, tuple.get(2).asInt4()); // max
@@ -390,7 +390,7 @@ public class TestPhysicalPlanner {
 
     int i = 0;
     Tuple tuple;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       assertEquals(6, tuple.get(2).asInt4()); // sum
       assertEquals(3, tuple.get(3).asInt4()); // max
@@ -439,7 +439,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 
@@ -490,7 +490,7 @@ public class TestPhysicalPlanner {
     // executing StoreTableExec
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 
@@ -536,7 +536,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 
@@ -653,7 +653,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
     ctx.getHashShuffleAppenderManager().close(ebId);
@@ -717,7 +717,7 @@ public class TestPhysicalPlanner {
     // Executing CREATE TABLE PARTITION BY
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 
@@ -787,7 +787,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
     ctx.getHashShuffleAppenderManager().close(ebId);
@@ -847,7 +847,7 @@ public class TestPhysicalPlanner {
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
 
-    exec.init();
+    exec.init(false);
     Tuple tuple = exec.next();
     assertEquals(30, tuple.get(0).asInt8());
     assertEquals(3, tuple.get(1).asInt4());
@@ -877,7 +877,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     Tuple tuple = exec.next();
     assertEquals(30, tuple.get(0).asInt8());
     assertNull(exec.next());
@@ -901,7 +901,7 @@ public class TestPhysicalPlanner {
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while(exec.next() != null) {
       count++;
     }
@@ -931,7 +931,7 @@ public class TestPhysicalPlanner {
     PhysicalExec exec = phyPlanner.createPlan(ctx, root);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while(exec.next() != null) {
       count++;
     }
@@ -952,7 +952,7 @@ public class TestPhysicalPlanner {
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
     Tuple tuple;
-    exec.init();
+    exec.init(false);
     tuple = exec.next();
     exec.close();
     assertEquals(true, tuple.get(0).asBool());
@@ -964,7 +964,7 @@ public class TestPhysicalPlanner {
 
     phyPlanner = new PhysicalPlannerImpl(conf);
     exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     tuple = exec.next();
     exec.close();
     assertEquals(DatumFactory.createBool(true), tuple.get(0));
@@ -988,7 +988,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
     }
     exec.close();
@@ -1022,7 +1022,7 @@ public class TestPhysicalPlanner {
     int cnt = 0;
     Set<String> expected = Sets.newHashSet(
         "name_1", "name_2", "name_3", "name_4", "name_5");
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       assertTrue(expected.contains(tuple.get(0).asChars()));
       cnt++;
@@ -1057,7 +1057,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 
@@ -1079,7 +1079,7 @@ public class TestPhysicalPlanner {
 
     phyPlanner = new PhysicalPlannerImpl(conf);
     exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 
@@ -1107,7 +1107,7 @@ public class TestPhysicalPlanner {
 
     PhysicalPlanner phyPlanner = new PhysicalPlannerImpl(conf);
     PhysicalExec exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 
@@ -1129,7 +1129,7 @@ public class TestPhysicalPlanner {
 
     phyPlanner = new PhysicalPlannerImpl(conf);
     exec = phyPlanner.createPlan(ctx, rootNode);
-    exec.init();
+    exec.init(false);
     exec.next();
     exec.close();
 

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
@@ -167,7 +167,7 @@ public class TestProgressExternalSortExec {
     Tuple preVal = null;
     Tuple curVal;
     int cnt = 0;
-    exec.init();
+    exec.init(true);
     BaseTupleComparator comparator = new BaseTupleComparator(proj.getSchema(),
         new SortSpec[]{
             new SortSpec(new Column("managerid", TajoDataTypes.Type.INT4)),

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestRightOuterHashJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestRightOuterHashJoinExec.java
@@ -257,7 +257,7 @@ public class TestRightOuterHashJoinExec {
        Tuple tuple;
        int count = 0;
        int i = 1;
-       exec.init();
+       exec.init(false);
   
        while ((tuple = exec.next()) != null) {
          //TODO check contents
@@ -298,7 +298,7 @@ public class TestRightOuterHashJoinExec {
        Tuple tuple;
        int count = 0;
        int i = 1;
-       exec.init();
+       exec.init(false);
   
        while ((tuple = exec.next()) != null) {
          //TODO check contents
@@ -339,7 +339,7 @@ public class TestRightOuterHashJoinExec {
        Tuple tuple;
        int count = 0;
        int i = 1;
-       exec.init();
+       exec.init(false);
   
        while ((tuple = exec.next()) != null) {
          //TODO check contents

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestRightOuterMergeJoinExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestRightOuterMergeJoinExec.java
@@ -333,7 +333,7 @@ public class TestRightOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof RightOuterMergeJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       //TODO check contents
       count = count + 1;
@@ -370,7 +370,7 @@ public class TestRightOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof RightOuterMergeJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       //TODO check contents
       count = count + 1;
@@ -405,7 +405,7 @@ public class TestRightOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof RightOuterMergeJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
     while (exec.next() != null) {
       //TODO check contents
       count = count + 1;
@@ -442,7 +442,7 @@ public class TestRightOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof RightOuterMergeJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -479,7 +479,7 @@ public class TestRightOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof RightOuterMergeJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents
@@ -516,7 +516,7 @@ public class TestRightOuterMergeJoinExec {
     assertTrue(proj.getChild() instanceof RightOuterMergeJoinExec);
 
     int count = 0;
-    exec.init();
+    exec.init(false);
 
     while (exec.next() != null) {
       //TODO check contents

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestSortExec.java
@@ -127,7 +127,7 @@ public class TestSortExec {
     Tuple tuple;
     Datum preVal = null;
     Datum curVal;
-    exec.init();
+    exec.init(false);
     while ((tuple = exec.next()) != null) {
       curVal = tuple.get(0);
       if (preVal != null) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/AlgebraicUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/AlgebraicUtil.java
@@ -21,6 +21,7 @@ package org.apache.tajo.plan.expr;
 import org.apache.tajo.catalog.Column;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -325,6 +326,10 @@ public class AlgebraicUtil {
         expr.getType() == EvalType.BETWEEN ||
         expr.getType() == EvalType.IN ||
         (expr.getType() == EvalType.LIKE && !((LikePredicateEval)expr).isLeadingWildCard());
+  }
+
+  public static EvalNode createSingletonExprFromCNF(Collection<EvalNode> cnfExprs) {
+    return createSingletonExprFromCNF(cnfExprs.toArray(new EvalNode[cnfExprs.size()]));
   }
 
   /**


### PR DESCRIPTION
Now ExternalSortExec cleans memory scanner when it's not needed