### PR TITLE
TAJO-1505 Transferred plan should not include supplementary of FunctionDesc

### DIFF
--- a/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
+++ b/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
@@ -21,6 +21,7 @@ package org.apache.tajo.catalog;
 import com.google.protobuf.ServiceException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.annotation.Nullable;
 import org.apache.tajo.catalog.CatalogProtocol.CatalogProtocolService;
 import org.apache.tajo.catalog.exception.NoSuchFunctionException;
@@ -521,7 +522,7 @@ public abstract class AbstractCatalogClient implements CatalogService {
       return new ServerCallable<Boolean>(this.pool, getCatalogServerAddr(), CatalogProtocol.class, false) {
         public Boolean call(NettyClientBase client) throws ServiceException {
           CatalogProtocolService.BlockingInterface stub = getStub(client);
-          return stub.createTable(null, desc.getProto()).getValue();
+          return stub.createTable(null, desc.getProto(SerializeOption.GENERIC)).getValue();
         }
       }.withRetries();
     } catch (ServiceException e) {
@@ -589,7 +590,7 @@ public abstract class AbstractCatalogClient implements CatalogService {
       return new ServerCallable<Boolean>(this.pool, getCatalogServerAddr(), CatalogProtocol.class, false) {
         public Boolean call(NettyClientBase client) throws ServiceException {
           CatalogProtocolService.BlockingInterface stub = getStub(client);
-          return stub.createIndex(null, index.getProto()).getValue();
+          return stub.createIndex(null, index.getProto(SerializeOption.GENERIC)).getValue();
         }
       }.withRetries();
     } catch (ServiceException e) {
@@ -724,7 +725,7 @@ public abstract class AbstractCatalogClient implements CatalogService {
       return new ServerCallable<Boolean>(this.pool, getCatalogServerAddr(), CatalogProtocol.class, false) {
         public Boolean call(NettyClientBase client) throws ServiceException {
           CatalogProtocolService.BlockingInterface stub = getStub(client);
-          return stub.createFunction(null, funcDesc.getProto()).getValue();
+          return stub.createFunction(null, funcDesc.getProto(SerializeOption.GENERIC)).getValue();
         }
       }.withRetries();
     } catch (ServiceException e) {
@@ -837,7 +838,7 @@ public abstract class AbstractCatalogClient implements CatalogService {
       return new ServerCallable<Boolean>(this.pool, getCatalogServerAddr(), CatalogProtocol.class, false) {
         public Boolean call(NettyClientBase client) throws ServiceException {
           CatalogProtocolService.BlockingInterface stub = getStub(client);
-          return stub.alterTable(null, desc.getProto()).getValue();
+          return stub.alterTable(null, desc.getProto(SerializeOption.GENERIC)).getValue();
         }
       }.withRetries();
     } catch (ServiceException e) {

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/AlterTableDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/AlterTableDesc.java
@@ -20,6 +20,7 @@ package org.apache.tajo.catalog;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.partition.PartitionDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos;
@@ -145,12 +146,12 @@ public class AlterTableDesc implements ProtoObject<AlterTableDescProto>, GsonObj
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, AlterTableDesc.class);
   }
 
   @Override
-  public AlterTableDescProto getProto() {
+  public AlterTableDescProto getProto(SerializeOption option) {
     AlterTableDescProto.Builder builder = AlterTableDescProto.newBuilder();
 
     if (null != this.tableName) {
@@ -166,10 +167,10 @@ public class AlterTableDesc implements ProtoObject<AlterTableDescProto>, GsonObj
       builder.setAlterColumnName(alterColumnBuilder.build());
     }
     if (null != this.addColumn) {
-      builder.setAddColumn(addColumn.getProto());
+      builder.setAddColumn(addColumn.getProto(option));
     }
     if (null != this.properties) {
-      builder.setParams(properties.getProto());
+      builder.setParams(properties.getProto(option));
     }
 
     switch (alterTableType) {
@@ -195,7 +196,7 @@ public class AlterTableDesc implements ProtoObject<AlterTableDescProto>, GsonObj
     }
 
     if (null != this.partitionDesc) {
-      builder.setPartitionDesc(partitionDesc.getProto());
+      builder.setPartitionDesc(partitionDesc.getProto(option));
     }
 
     return builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
@@ -20,11 +20,11 @@ package org.apache.tajo.catalog;
 
 import com.google.common.collect.Maps;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.DataTypeUtil;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.catalog.partition.PartitionMethodDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos;
-import org.apache.tajo.catalog.proto.CatalogProtos.ColumnProto;
 import org.apache.tajo.catalog.proto.CatalogProtos.SchemaProto;
 import org.apache.tajo.catalog.proto.CatalogProtos.TableDescProto;
 import org.apache.tajo.common.TajoDataTypes;
@@ -328,7 +328,7 @@ public class CatalogUtil {
   public static SchemaProto getQualfiedSchema(String tableName, SchemaProto schema) {
     Schema restored = new Schema(schema);
     restored.setQualifier(tableName);
-    return restored.getProto();
+    return restored.getProto(SerializeOption.GENERIC);
   }
 
   public static DataType newDataType(Type type, String code) {

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Column.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Column.java
@@ -20,6 +20,7 @@ package org.apache.tajo.catalog;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos.ColumnProto;
 import org.apache.tajo.common.ProtoObject;
@@ -144,9 +145,10 @@ public class Column implements ProtoObject<ColumnProto>, GsonObject {
   /**
    *
    * @return The protocol buffer object for Column
+   * @param option
    */
 	@Override
-	public ColumnProto getProto() {
+	public ColumnProto getProto(SerializeOption option) {
     ColumnProto.Builder builder = ColumnProto.newBuilder();
     builder
         .setName(this.name)
@@ -161,7 +163,7 @@ public class Column implements ProtoObject<ColumnProto>, GsonObject {
 	}
 
   @Override
-	public String toJson() {
+	public String toJson(SerializeOption option) {
 		return CatalogGsonHelper.toJson(this, Column.class);
 	}
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/FunctionDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/FunctionDesc.java
@@ -20,6 +20,7 @@ package org.apache.tajo.catalog;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.annotation.NotNull;
 import org.apache.tajo.function.*;
 import org.apache.tajo.json.GsonObject;
@@ -61,6 +62,7 @@ public class FunctionDesc implements ProtoObject<FunctionDescProto>, Cloneable, 
     this.supplement = new FunctionSupplement(proto.getSupplement());
   }
 
+  @SuppressWarnings("unchecked")
   public FunctionDesc(String signature, String className, FunctionType type,
                       DataType retType,
                       @NotNull DataType... argTypes) throws ClassNotFoundException {
@@ -165,7 +167,7 @@ public class FunctionDesc implements ProtoObject<FunctionDescProto>, Cloneable, 
   public boolean equals(Object obj) {
     if (obj instanceof FunctionDesc) {
       FunctionDesc other = (FunctionDesc) obj;
-      if(this.getProto().equals(other.getProto()))
+      if(this.getProto(SerializeOption.GENERIC).equals(other.getProto(SerializeOption.GENERIC)))
         return true;
     }
     return false;
@@ -183,15 +185,15 @@ public class FunctionDesc implements ProtoObject<FunctionDescProto>, Cloneable, 
   }
 
   @Override
-  public FunctionDescProto getProto() {
+  public FunctionDescProto getProto(SerializeOption option) {
     if (builder == null) {
       builder = FunctionDescProto.newBuilder();
     } else {
       builder.clear();
     }
-    builder.setSignature(signature.getProto());
-    builder.setSupplement(supplement.getProto());
-    builder.setInvocation(invocation.getProto());
+    builder.setSignature(signature.getProto(option));
+    builder.setSupplement(supplement.getProto(option));
+    builder.setInvocation(invocation.getProto(option));
     return builder.build();
   }
   
@@ -200,7 +202,7 @@ public class FunctionDesc implements ProtoObject<FunctionDescProto>, Cloneable, 
 	  return getHelpSignature();
   }
   
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, FunctionDesc.class);
   }
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/IndexDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/IndexDesc.java
@@ -21,6 +21,7 @@ package org.apache.tajo.catalog;
 import com.google.common.base.Objects;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.IndexDescProto;
 import org.apache.tajo.catalog.proto.CatalogProtos.IndexMethod;
@@ -89,7 +90,7 @@ public class IndexDesc implements ProtoObject<IndexDescProto>, Cloneable {
   }
 
   @Override
-  public IndexDescProto getProto() {
+  public IndexDescProto getProto(SerializeOption option) {
     IndexDescProto.Builder builder = IndexDescProto.newBuilder();
 
     CatalogProtos.TableIdentifierProto.Builder tableIdentifierBuilder = CatalogProtos.TableIdentifierProto.newBuilder();
@@ -102,7 +103,7 @@ public class IndexDesc implements ProtoObject<IndexDescProto>, Cloneable {
 
     builder.setTableIdentifier(tableIdentifierBuilder.build());
     builder.setIndexName(this.indexName);
-    builder.setColumn(this.column.getProto());
+    builder.setColumn(this.column.getProto(option));
     builder.setIndexMethod(indexMethod);
     builder.setIsUnique(this.isUnique);
     builder.setIsClustered(this.isClustered);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SortSpec.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SortSpec.java
@@ -20,6 +20,7 @@ package org.apache.tajo.catalog;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.json.GsonObject;
@@ -103,7 +104,7 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, SortSpec.class);
   }
 
@@ -112,9 +113,9 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
   }
 
   @Override
-  public SortSpecProto getProto() {
+  public SortSpecProto getProto(SerializeOption option) {
     SortSpecProto.Builder builder = SortSpecProto.newBuilder();
-    builder.setColumn(sortKey.getProto());
+    builder.setColumn(sortKey.getProto(option));
     builder.setAscending(ascending);
     builder.setNullFirst(nullFirst);
     return builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableDesc.java
@@ -25,6 +25,7 @@ import com.google.gson.annotations.Expose;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.partition.PartitionMethodDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos.StoreType;
@@ -196,30 +197,30 @@ public class TableDesc implements ProtoObject<TableDescProto>, GsonObject, Clone
     return gson.toJson(this);
   }
 	
-	public String toJson() {
+	public String toJson(SerializeOption option) {
 		return CatalogGsonHelper.toJson(this, TableDesc.class);
 	}
 
-  public TableDescProto getProto() {
+  public TableDescProto getProto(SerializeOption option) {
     TableDescProto.Builder builder = TableDescProto.newBuilder();
 
     if (this.tableName != null) {
       builder.setTableName(this.tableName);
     }
     if (this.schema != null) {
-      builder.setSchema(schema.getProto());
+      builder.setSchema(schema.getProto(option));
     }
     if (this.meta != null) {
-      builder.setMeta(meta.getProto());
+      builder.setMeta(meta.getProto(option));
     }
     if (this.uri != null) {
       builder.setPath(this.uri.toString());
     }
     if (this.stats != null) {
-      builder.setStats(this.stats.getProto());
+      builder.setStats(this.stats.getProto(option));
     }
     if (this.partitionMethodDesc != null) {
-      builder.setPartition(this.partitionMethodDesc.getProto());
+      builder.setPartition(this.partitionMethodDesc.getProto(option));
     }
     if (this.external != null) {
       builder.setIsExternal(external);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableMeta.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableMeta.java
@@ -22,6 +22,7 @@ import com.google.common.base.Objects;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.StoreType;
@@ -132,17 +133,19 @@ public class TableMeta implements ProtoObject<CatalogProtos.TableProto>, GsonObj
   public Map<String,String> toMap() {
     return getOptions().getAllKeyValus();
   }
-	
+
+  @Override
 	public boolean equals(Object object) {
 		if(object instanceof TableMeta) {
 			TableMeta other = (TableMeta) object;
 			
-			return this.getProto().equals(other.getProto());
+			return this.getProto(SerializeOption.GENERIC).equals(other.getProto(SerializeOption.GENERIC));
 		}
 		
 		return false;		
 	}
-	
+
+  @Override
 	public int hashCode() {
 	  return Objects.hashCode(getStoreType(), getOptions());
 	}
@@ -166,15 +169,15 @@ public class TableMeta implements ProtoObject<CatalogProtos.TableProto>, GsonObj
 	////////////////////////////////////////////////////////////////////////
 	// ProtoObject
 	////////////////////////////////////////////////////////////////////////
-	public TableProto getProto() {
-    mergeLocalToProto();
+	public TableProto getProto(SerializeOption option) {
+    mergeLocalToProto(option);
     proto = viaProto ? proto : builder.build();
     viaProto = true;
     return proto;
 	}
 
   @Override
-	public String toJson() {
+	public String toJson(SerializeOption option) {
     mergeProtoToLocal();
 		return CatalogGsonHelper.toJson(this, TableMeta.class);
 	}
@@ -191,20 +194,20 @@ public class TableMeta implements ProtoObject<CatalogProtos.TableProto>, GsonObj
     viaProto = true;
   }
 
-  private void mergeLocalToBuilder() {
+  private void mergeLocalToBuilder(SerializeOption option) {
     if (storeType != null) {
       builder.setStoreType(storeType);
     }
     if (this.options != null) {
-      builder.setParams(options.getProto());
+      builder.setParams(options.getProto(option));
     }
   }
 
-  private void mergeLocalToProto() {
+  private void mergeLocalToProto(SerializeOption option) {
     if(viaProto) {
       maybeInitBuilder();
     }
-    mergeLocalToBuilder();
+    mergeLocalToBuilder(option);
     proto = builder.build();
     viaProto = true;
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionDesc.java
@@ -22,7 +22,7 @@ import com.google.common.base.Objects;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
-import org.apache.tajo.catalog.Column;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.ProtoObject;
@@ -131,7 +131,7 @@ public class PartitionDesc implements ProtoObject<CatalogProtos.PartitionDescPro
 
 
   @Override
-  public CatalogProtos.PartitionDescProto getProto() {
+  public CatalogProtos.PartitionDescProto getProto(SerializeOption option) {
     if (builder == null) {
       builder = CatalogProtos.PartitionDescProto.newBuilder();
     }
@@ -143,7 +143,7 @@ public class PartitionDesc implements ProtoObject<CatalogProtos.PartitionDescPro
     builder.clearPartitionKeys();
     if (this.partitionKeys != null) {
       for(PartitionKey partitionKey : this.partitionKeys) {
-        builder.addPartitionKeys(partitionKey.getProto());
+        builder.addPartitionKeys(partitionKey.getProto(option));
       }
     }
 
@@ -161,7 +161,7 @@ public class PartitionDesc implements ProtoObject<CatalogProtos.PartitionDescPro
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, PartitionDesc.class);
   }
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionKey.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionKey.java
@@ -20,6 +20,7 @@ package org.apache.tajo.catalog.partition;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.ProtoObject;
@@ -105,7 +106,7 @@ public class PartitionKey implements ProtoObject<CatalogProtos.PartitionKeyProto
   }
 
   @Override
-  public CatalogProtos.PartitionKeyProto getProto() {
+  public CatalogProtos.PartitionKeyProto getProto(SerializeOption option) {
     if (builder == null) {
       builder = CatalogProtos.PartitionKeyProto.newBuilder();
     }
@@ -127,7 +128,7 @@ public class PartitionKey implements ProtoObject<CatalogProtos.PartitionKeyProto
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, PartitionKey.class);
   }
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionMethodDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/partition/PartitionMethodDesc.java
@@ -22,6 +22,7 @@ import com.google.common.base.Objects;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
@@ -114,7 +115,7 @@ public class PartitionMethodDesc implements ProtoObject<CatalogProtos.PartitionM
   }
 
   @Override
-  public CatalogProtos.PartitionMethodProto getProto() {
+  public CatalogProtos.PartitionMethodProto getProto(SerializeOption option) {
     TableIdentifierProto.Builder tableIdentifierBuilder = TableIdentifierProto.newBuilder();
     if (databaseName != null) {
       tableIdentifierBuilder.setDatabaseName(databaseName);
@@ -127,7 +128,7 @@ public class PartitionMethodDesc implements ProtoObject<CatalogProtos.PartitionM
     builder.setTableIdentifier(tableIdentifierBuilder.build());
     builder.setPartitionType(partitionType);
     builder.setExpression(expression);
-    builder.setExpressionSchema(expressionSchema.getProto());
+    builder.setExpressionSchema(expressionSchema.getProto(option));
     return builder.build();
   }
 
@@ -148,7 +149,7 @@ public class PartitionMethodDesc implements ProtoObject<CatalogProtos.PartitionM
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, PartitionMethodDesc.class);
   }
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/ColumnStats.java
@@ -24,6 +24,7 @@ package org.apache.tajo.catalog.statistics;
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
 import com.google.protobuf.ByteString;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
@@ -144,17 +145,17 @@ public class ColumnStats implements ProtoObject<CatalogProtos.ColumnStatsProto>,
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, ColumnStats.class);
   }
 
 
   @Override
-  public CatalogProtos.ColumnStatsProto getProto() {
+  public CatalogProtos.ColumnStatsProto getProto(SerializeOption option) {
     CatalogProtos.ColumnStatsProto.Builder builder = CatalogProtos.ColumnStatsProto.newBuilder();
 
     if (this.column != null) {
-      builder.setColumn(this.column.getProto());
+      builder.setColumn(this.column.getProto(option));
     }
     if (this.numDistVals != null) {
       builder.setNumDistVal(this.numDistVals);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/StatSet.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/StatSet.java
@@ -21,6 +21,7 @@ package org.apache.tajo.catalog.statistics;
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.StatProto;
@@ -122,7 +123,7 @@ public class StatSet implements ProtoObject<StatSetProto>, Cloneable {
   }
 
   @Override
-  public StatSetProto getProto() {
+  public StatSetProto getProto(SerializeOption option) {
     if (!viaProto) {
       mergeLocalToBuilder();
       proto = builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/TableStats.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/TableStats.java
@@ -24,6 +24,7 @@ package org.apache.tajo.catalog.statistics;
 import com.google.common.base.Objects;
 import com.google.gson.Gson;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.json.GsonObject;
@@ -232,12 +233,12 @@ public class TableStats implements ProtoObject<TableStatsProto>, Cloneable, Gson
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, TableStats.class);
   }
 
   @Override
-  public TableStatsProto getProto() {
+  public TableStatsProto getProto(SerializeOption option) {
     TableStatsProto.Builder builder = CatalogProtos.TableStatsProto.newBuilder();
 
     builder.setNumRows(this.numRows);
@@ -257,7 +258,7 @@ public class TableStats implements ProtoObject<TableStatsProto>, Cloneable, Gson
     }
     if (this.columnStatses != null) {
       for (ColumnStats colStat : columnStatses) {
-        builder.addColStat(colStat.getProto());
+        builder.addColStat(colStat.getProto(option));
       }
     }
     return builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/ClassBaseInvocationDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/ClassBaseInvocationDesc.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.function;
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.ClassBaseInvocationDescProto;
@@ -63,7 +64,7 @@ public class ClassBaseInvocationDesc<T> implements ProtoObject<ClassBaseInvocati
   }
 
   @Override
-  public ClassBaseInvocationDescProto getProto() {
+  public ClassBaseInvocationDescProto getProto(SerializeOption option) {
     ClassBaseInvocationDescProto.Builder builder = ClassBaseInvocationDescProto.newBuilder();
     builder.setClassName(functionClass.getName());
     return builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/Function.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/Function.java
@@ -20,6 +20,7 @@ package org.apache.tajo.function;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.json.GsonObject;
 import org.apache.tajo.catalog.Column;
@@ -58,7 +59,7 @@ public abstract class Function<T extends Datum> implements Cloneable, GsonObject
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, Function.class);
   }
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionInvocation.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionInvocation.java
@@ -20,6 +20,7 @@ package org.apache.tajo.function;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionInvocationProto;
@@ -122,22 +123,22 @@ public class FunctionInvocation implements ProtoObject<FunctionInvocationProto> 
   }
 
   @Override
-  public FunctionInvocationProto getProto() {
+  public FunctionInvocationProto getProto(SerializeOption option) {
     FunctionInvocationProto.Builder builder = FunctionInvocationProto.newBuilder();
     if (hasLegacy()) {
-      builder.setLegacy(legacy.getProto());
+      builder.setLegacy(legacy.getProto(option));
     }
     if (hasScalar()) {
-      builder.setScalar(scalar.getProto());
+      builder.setScalar(scalar.getProto(option));
     }
     if (hasAggregation()) {
-      builder.setAggregation(aggregation.getProto());
+      builder.setAggregation(aggregation.getProto(option));
     }
     if (hasScalarJIT()) {
-      builder.setScalarJIT(scalarJIT.getProto());
+      builder.setScalarJIT(scalarJIT.getProto(option));
     }
     if (hasAggregationJIT()) {
-      builder.setAggregationJIT(aggregationJIT.getProto());
+      builder.setAggregationJIT(aggregationJIT.getProto(option));
     }
     return builder.build();
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -20,6 +20,7 @@ package org.apache.tajo.function;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.annotation.NotNull;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
@@ -105,7 +106,7 @@ public class FunctionSignature implements Comparable<FunctionSignature>, ProtoOb
   }
 
   @Override
-  public FunctionSignatureProto getProto() {
+  public FunctionSignatureProto getProto(SerializeOption option) {
     FunctionSignatureProto.Builder builder = FunctionSignatureProto.newBuilder();
     builder.setType(functionType);
     builder.setName(name);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSupplement.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSupplement.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.function;
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionSupplementProto;
@@ -88,15 +89,15 @@ public class FunctionSupplement implements ProtoObject<FunctionSupplementProto>,
   }
 
   @Override
-  public FunctionSupplementProto getProto() {
+  public FunctionSupplementProto getProto(SerializeOption option) {
     FunctionSupplementProto.Builder builder = FunctionSupplementProto.newBuilder();
-    if (shortDescription != null) {
+    if (shortDescription != null && option != SerializeOption.INTERNAL) {
       builder.setShortDescription(shortDescription);
     }
-    if (detail != null) {
+    if (detail != null && option != SerializeOption.INTERNAL) {
       builder.setDetail(detail);
     }
-    if (example != null) {
+    if (example != null && option != SerializeOption.INTERNAL) {
       builder.setExample(example);
     }
     return builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/StaticMethodInvocationDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/StaticMethodInvocationDesc.java
@@ -21,6 +21,7 @@ package org.apache.tajo.function;
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.ClassUtil;
 import org.apache.tajo.util.TUtil;
@@ -121,7 +122,7 @@ public class StaticMethodInvocationDesc implements ProtoObject<StaticMethodInvoc
 
 
   @Override
-  public StaticMethodInvocationDescProto getProto() {
+  public StaticMethodInvocationDescProto getProto(SerializeOption option) {
     StaticMethodInvocationDescProto.Builder builder = StaticMethodInvocationDescProto.newBuilder();
     builder.setClassName(baseClassName.getName());
     builder.setMethodName(methodName);

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestColumn.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestColumn.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.TajoDataTypes.DataType;
@@ -94,16 +95,16 @@ public class TestColumn {
 
 	@Test
 	public final void testToJson() {
-		Column col = new Column(field1.getProto());
-		String json = col.toJson();
+		Column col = new Column(field1.getProto(SerializeOption.GENERIC));
+		String json = col.toJson(SerializeOption.GENERIC);
 		Column fromJson = CatalogGsonHelper.fromJson(json, Column.class);
 		assertEquals(col, fromJson);
 	}
 
   @Test
   public final void testToProto() {
-    Column column = new Column(field1.getProto());
-    CatalogProtos.ColumnProto proto = column.getProto();
+    Column column = new Column(field1.getProto(SerializeOption.GENERIC));
+    CatalogProtos.ColumnProto proto = column.getProto(SerializeOption.GENERIC);
     Column fromProto = new Column(proto);
     assertEquals(column, fromProto);
   }

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestFunctionDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestFunctionDesc.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.function.Function;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
@@ -76,7 +77,7 @@ public class TestFunctionDesc {
 
     CommonTestingUtil.getTestDir(TEST_PATH);
     File save = new File(TEST_PATH + "/save.dat");
-    FileUtil.writeProto(save, desc.getProto());
+    FileUtil.writeProto(save, desc.getProto(SerializeOption.GENERIC));
 
     FunctionDescProto proto = FunctionDescProto.getDefaultInstance();
     proto = (FunctionDescProto) FileUtil.loadProto(save, proto);
@@ -91,7 +92,7 @@ public class TestFunctionDesc {
     assertArrayEquals(CatalogUtil.newSimpleDataTypeArray(Type.INT4, Type.INT8),
         newDesc.getParamTypes());
 
-    assertEquals(desc.getProto(), newDesc.getProto());
+    assertEquals(desc.getProto(SerializeOption.GENERIC), newDesc.getProto(SerializeOption.GENERIC));
   }
   
   @Test
@@ -99,10 +100,10 @@ public class TestFunctionDesc {
 	  FunctionDesc desc = new FunctionDesc("sum", TestSum.class, FunctionType.GENERAL,
         CatalogUtil.newSimpleDataType(Type.INT4),
         CatalogUtil.newSimpleDataTypeArray(Type.INT4, Type.INT8));
-	  String json = desc.toJson();
+	  String json = desc.toJson(SerializeOption.GENERIC);
 	  FunctionDesc fromJson = CatalogGsonHelper.fromJson(json, FunctionDesc.class);
 	  assertEquals(desc, fromJson);
-	  assertEquals(desc.getProto(), fromJson.getProto());
+	  assertEquals(desc.getProto(SerializeOption.GENERIC), fromJson.getProto(SerializeOption.GENERIC));
   }
 
   @Test
@@ -110,10 +111,10 @@ public class TestFunctionDesc {
     FunctionDesc desc = new FunctionDesc("sum", TestSum.class, FunctionType.GENERAL,
         CatalogUtil.newSimpleDataType(Type.INT4),
         CatalogUtil.newSimpleDataTypeArray(Type.INT4, Type.INT8));
-    FunctionDescProto proto = desc.getProto();
+    FunctionDescProto proto = desc.getProto(SerializeOption.GENERIC);
     FunctionDesc fromProto = new FunctionDesc(proto);
     assertEquals(desc, fromProto);
-    assertEquals(desc.toJson(), fromProto.toJson());
+    assertEquals(desc.toJson(SerializeOption.GENERIC), fromProto.toJson(SerializeOption.GENERIC));
   }
   
   @Test

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestIndexDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestIndexDesc.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.proto.CatalogProtos.IndexDescProto;
 import org.apache.tajo.catalog.proto.CatalogProtos.IndexMethod;
 import org.apache.tajo.common.TajoDataTypes.Type;
@@ -58,8 +59,8 @@ public class TestIndexDesc {
 
   @Test
   public void testIndexDescProto() {
-    IndexDescProto proto = desc1.getProto();
-    assertEquals(desc1.getProto(), proto);
+    IndexDescProto proto = desc1.getProto(SerializeOption.GENERIC);
+    assertEquals(desc1.getProto(SerializeOption.GENERIC), proto);
     assertEquals(desc1, new IndexDesc(proto));
   }
 

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestKeyValueSet.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestKeyValueSet.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos;
 import org.apache.tajo.util.KeyValueSet;
 import org.junit.Test;
@@ -88,7 +89,7 @@ public class TestKeyValueSet {
 		opts.set("name", "abc");
 		opts.set("delimiter", ",");
 		
-		PrimitiveProtos.KeyValueSetProto proto = opts.getProto();
+		PrimitiveProtos.KeyValueSetProto proto = opts.getProto(SerializeOption.GENERIC);
 		KeyValueSet opts2 = new KeyValueSet(proto);
 		
 		assertEquals(opts, opts2);
@@ -109,7 +110,7 @@ public class TestKeyValueSet {
       assertTrue(true);
     }
 		
-		KeyValueSet opts2 = new KeyValueSet(opts.getProto());
+		KeyValueSet opts2 = new KeyValueSet(opts.getProto(SerializeOption.GENERIC));
     try {
       opts2.get("name");
       assertTrue(false);

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestSchema.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.exception.AlreadyExistsFieldException;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos.SchemaProto;
@@ -135,7 +136,7 @@ public class TestSchema {
 
 	@Test
 	public final void testSchemaSchemaProto() {
-		Schema schema2 = new Schema(schema.getProto());
+		Schema schema2 = new Schema(schema.getProto(SerializeOption.GENERIC));
 		
 		assertEquals(schema, schema2);
 	}
@@ -167,7 +168,7 @@ public class TestSchema {
 
 	@Test
 	public final void testGetProto() {
-		SchemaProto proto = schema.getProto();
+		SchemaProto proto = schema.getProto(SerializeOption.GENERIC);
 		
 		assertEquals("name", proto.getFields(0).getName());
 		assertEquals("age", proto.getFields(1).getName());
@@ -180,13 +181,13 @@ public class TestSchema {
 	  schema.addColumn("abc", Type.FLOAT8);
 	  schema.addColumn("bbc", Type.FLOAT8);
 	  
-	  Schema schema2 = new Schema(schema.getProto());
-	  assertEquals(schema.getProto(), schema2.getProto());
+	  Schema schema2 = new Schema(schema.getProto(SerializeOption.GENERIC));
+	  assertEquals(schema.getProto(SerializeOption.GENERIC), schema2.getProto(SerializeOption.GENERIC));
 	  assertEquals(schema.getColumn(0), schema2.getColumn(0));
 	  assertEquals(schema.size(), schema2.size());
 	  
 	  Schema schema3 = (Schema) schema.clone();
-	  assertEquals(schema.getProto(), schema3.getProto());
+	  assertEquals(schema.getProto(SerializeOption.GENERIC), schema3.getProto(SerializeOption.GENERIC));
     assertEquals(schema.getColumn(0), schema3.getColumn(0));
     assertEquals(schema.size(), schema3.size());
 	}
@@ -201,24 +202,24 @@ public class TestSchema {
 
 	@Test
 	public final void testJson() {
-		Schema schema2 = new Schema(schema.getProto());
-		String json = schema2.toJson();
+		Schema schema2 = new Schema(schema.getProto(SerializeOption.GENERIC));
+		String json = schema2.toJson(SerializeOption.GENERIC);
 		Schema fromJson = CatalogGsonHelper.fromJson(json, Schema.class);
 		assertEquals(schema2, fromJson);
-    assertEquals(schema2.getProto(), fromJson.getProto());
+    assertEquals(schema2.getProto(SerializeOption.GENERIC), fromJson.getProto(SerializeOption.GENERIC));
 	}
 
   @Test
   public final void testProto() {
-    Schema schema2 = new Schema(schema.getProto());
-    SchemaProto proto = schema2.getProto();
+    Schema schema2 = new Schema(schema.getProto(SerializeOption.GENERIC));
+    SchemaProto proto = schema2.getProto(SerializeOption.GENERIC);
     Schema fromJson = new Schema(proto);
     assertEquals(schema2, fromJson);
   }
 
   @Test
   public final void testSetQualifier() {
-    Schema schema2 = new Schema(schema.getProto());
+    Schema schema2 = new Schema(schema.getProto(SerializeOption.GENERIC));
     schema2.setQualifier("test1");
     Column column = schema2.getColumn(1);
     assertEquals(1, schema2.getColumnIdByName("age"));
@@ -294,7 +295,7 @@ public class TestSchema {
   public static void verifySchema(Schema s1) {
     assertEquals(s1, s1);
 
-    SchemaProto proto = s1.getProto();
+    SchemaProto proto = s1.getProto(SerializeOption.GENERIC);
     assertEquals("Proto (de)serialized schema is different from the original: ", s1, new Schema(proto));
 
     Schema cloned = null;

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestTableDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestTableDesc.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.catalog;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.StoreType;
@@ -89,7 +90,7 @@ public class TestTableDesc {
     Path path = new Path(CommonTestingUtil.getTestDir(), "tajo");
     TableDesc desc = new TableDesc("table1", schema, info, path.toUri());
     desc.setStats(stats);
-    CatalogProtos.TableDescProto proto = desc.getProto();
+    CatalogProtos.TableDescProto proto = desc.getProto(SerializeOption.GENERIC);
 
     TableDesc fromProto = new TableDesc(proto);
     assertEquals("equality check the object deserialized from json", desc, fromProto);
@@ -100,11 +101,11 @@ public class TestTableDesc {
     Path path = new Path(CommonTestingUtil.getTestDir(), "tajo");
     TableDesc desc = new TableDesc("table1", schema, info, path.toUri());
     desc.setStats(stats);
-    String json = desc.toJson();
+    String json = desc.toJson(SerializeOption.GENERIC);
 
     TableDesc fromJson = CatalogGsonHelper.fromJson(json, TableDesc.class);
     assertEquals("equality check the object deserialized from json", desc, fromJson);
-    assertEquals("equality between protos", desc.getProto(), fromJson.getProto());
+    assertEquals("equality between protos", desc.getProto(SerializeOption.GENERIC), fromJson.getProto(SerializeOption.GENERIC));
   }
 
   public TableDesc testClone(TableDesc desc) throws CloneNotSupportedException {

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestTableMeta.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestTableMeta.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos.StoreType;
 import org.apache.tajo.catalog.proto.CatalogProtos.TableProto;
@@ -42,7 +43,7 @@ public class TestTableMeta {
     schema1.addColumn("addr", Type.TEXT);
     TableMeta meta1 = CatalogUtil.newTableMeta(StoreType.CSV);
     
-    TableMeta meta2 = new TableMeta(meta1.getProto());
+    TableMeta meta2 = new TableMeta(meta1.getProto(SerializeOption.GENERIC));
     assertEquals(meta1, meta2);
   }
   
@@ -89,16 +90,16 @@ public class TestTableMeta {
   
   @Test
   public void testGetProto() {
-    TableProto proto = meta.getProto();
+    TableProto proto = meta.getProto(SerializeOption.GENERIC);
     TableMeta newMeta = new TableMeta(proto);
     assertEquals(meta, newMeta);
   }
 
   @Test
   public void testToJson() {
-    String json = meta.toJson();
+    String json = meta.toJson(SerializeOption.GENERIC);
     TableMeta fromJson = CatalogGsonHelper.fromJson(json, TableMeta.class);
     assertEquals(meta, fromJson);
-    assertEquals(meta.getProto(), fromJson.getProto());
+    assertEquals(meta.getProto(SerializeOption.GENERIC), fromJson.getProto(SerializeOption.GENERIC));
   }
 }

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestColumnStat.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestColumnStat.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog.statistics;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.common.TajoDataTypes.Type;
@@ -38,7 +39,7 @@ public class TestColumnStat {
     assertTrue(1000 == stat.getNumDistValues());
     assertTrue(999 == stat.getNumNulls());
     
-    ColumnStats stat2 = new ColumnStats(stat.getProto());
+    ColumnStats stat2 = new ColumnStats(stat.getProto(SerializeOption.GENERIC));
     assertTrue(1000 == stat2.getNumDistValues());
     assertTrue(999 == stat2.getNumNulls());
   }
@@ -51,7 +52,7 @@ public class TestColumnStat {
     stat.setMinValue(DatumFactory.createInt8(5));
     stat.setMaxValue(DatumFactory.createInt8(10));
     
-    ColumnStats stat2 = new ColumnStats(stat.getProto());
+    ColumnStats stat2 = new ColumnStats(stat.getProto(SerializeOption.GENERIC));
     assertEquals(stat, stat2);
   }
 
@@ -63,7 +64,7 @@ public class TestColumnStat {
     stat.setMinValue(DatumFactory.createInt8(5));
     stat.setMaxValue(DatumFactory.createInt8(10));
 
-    String json = stat.toJson();
+    String json = stat.toJson(SerializeOption.GENERIC);
     ColumnStats fromJson = CatalogGsonHelper.fromJson(json, ColumnStats.class);
     assertEquals(stat, fromJson);
   }

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestStatSet.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestStatSet.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog.statistics;
 
+import org.apache.tajo.SerializeOption;
 import org.junit.Test;
 import org.apache.tajo.catalog.proto.CatalogProtos.StatType;
 
@@ -52,7 +53,7 @@ public class TestStatSet {
     assertEquals(101, group.getStat(StatType.TABLE_NUM_ROWS).getValue());
     assertEquals(1, group.getStat(StatType.TABLE_NUM_BLOCKS).getValue());
     
-    StatSet group2 = new StatSet(group.getProto());
+    StatSet group2 = new StatSet(group.getProto(SerializeOption.GENERIC));
     assertEquals(2, group2.getAllStats().size());
     assertEquals(stat, group2.getStat(StatType.TABLE_NUM_ROWS));
     assertEquals(101, group2.getStat(StatType.TABLE_NUM_ROWS).getValue());

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestTableStat.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/statistics/TestTableStat.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.catalog.statistics;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos.TableStatsProto;
@@ -63,13 +64,13 @@ public class TestTableStat {
       assertEquals(cols[i], stat.getColumnStats().get(i));
     }
     
-    TableStats stat2 = new TableStats(stat.getProto());
+    TableStats stat2 = new TableStats(stat.getProto(SerializeOption.GENERIC));
     tableStatEquals(stat, stat2);
     
     TableStats stat3 = (TableStats) stat.clone();
     tableStatEquals(stat, stat3);
 
-    String json = stat.toJson();
+    String json = stat.toJson(SerializeOption.GENERIC);
     TableStats fromJson = CatalogGsonHelper.fromJson(json, TableStats.class);
     tableStatEquals(stat, fromJson);
   }
@@ -108,7 +109,7 @@ public class TestTableStat {
         public void run() {
           for (int j = 0; j < 100; j++) {
             try {
-              TableStatsProto proto = tableStats.getProto();
+              TableStatsProto proto = tableStats.getProto(SerializeOption.GENERIC);
               if (tableStats.getColumnStats().size() != proto.getColStatList().size()) {
                 success.set(false);
                 break;

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hcatalog/src/main/java/org/apache/tajo/catalog/store/HCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hcatalog/src/main/java/org/apache/tajo/catalog/store/HCatalogStore.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe;
 import org.apache.hcatalog.common.HCatUtil;
 import org.apache.hcatalog.data.schema.HCatFieldSchema;
 import org.apache.hcatalog.data.schema.HCatSchema;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.catalog.*;
 import org.apache.tajo.catalog.exception.*;
@@ -279,7 +280,7 @@ public class HCatalogStore extends CatalogConstants implements CatalogStore {
     if (partitions != null) {
       tableDesc.setPartitionMethod(partitions);
     }
-    return tableDesc.getProto();
+    return tableDesc.getProto(SerializeOption.GENERIC);
   }
 
 

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hcatalog/src/test/java/org/apache/tajo/catalog/store/TestHCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hcatalog/src/test/java/org/apache/tajo/catalog/store/TestHCatalogStore.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.*;
 import org.apache.tajo.catalog.partition.PartitionDesc;
 import org.apache.tajo.catalog.partition.PartitionKey;
@@ -100,7 +101,7 @@ public class TestHCatalogStore {
 
     TableDesc table = new TableDesc(CatalogUtil.buildFQName(DB_NAME, CUSTOMER), schema, meta,
         new Path(warehousePath, new Path(DB_NAME, CUSTOMER)).toUri());
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, CUSTOMER));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, CUSTOMER));
@@ -129,7 +130,7 @@ public class TestHCatalogStore {
 
     TableDesc table = new TableDesc(CatalogUtil.buildFQName(DB_NAME, REGION), schema, meta,
         new Path(warehousePath, new Path(DB_NAME, REGION)).toUri());
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, REGION));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, REGION));
@@ -158,7 +159,7 @@ public class TestHCatalogStore {
 
     TableDesc table = new TableDesc(CatalogUtil.buildFQName(DB_NAME, REGION), schema, meta,
         new Path(warehousePath, new Path(DB_NAME, REGION)).toUri());
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, REGION));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, REGION));
@@ -192,7 +193,7 @@ public class TestHCatalogStore {
     TableDesc table = new TableDesc(CatalogUtil.buildFQName(DB_NAME, SUPPLIER), schema, meta,
         new Path(warehousePath, new Path(DB_NAME, SUPPLIER)).toUri());
 
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, SUPPLIER));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, SUPPLIER));
@@ -242,7 +243,7 @@ public class TestHCatalogStore {
         CatalogProtos.PartitionType.COLUMN, "n_nationkey,n_date", expressionSchema);
     table.setPartitionMethod(partitions);
 
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, NATION));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, NATION));
@@ -298,7 +299,7 @@ public class TestHCatalogStore {
 
     alterTableDesc.setPartitionDesc(partitionDesc);
 
-    store.alterTable(alterTableDesc.getProto());
+    store.alterTable(alterTableDesc.getProto(SerializeOption.GENERIC));
 
     CatalogProtos.PartitionDescProto resultDesc = store.getPartition(DB_NAME, NATION, partitionName);
     assertNotNull(resultDesc);
@@ -324,7 +325,7 @@ public class TestHCatalogStore {
 
     alterTableDesc.setPartitionDesc(partitionDesc);
 
-    store.alterTable(alterTableDesc.getProto());
+    store.alterTable(alterTableDesc.getProto(SerializeOption.GENERIC));
   }
 
   @Test
@@ -340,7 +341,7 @@ public class TestHCatalogStore {
     for(String tableName : tableNames){
       TableDesc table = new TableDesc(CatalogUtil.buildFQName("default", tableName), schema, meta,
           new Path(warehousePath, new Path(DB_NAME, tableName)).toUri());
-      store.createTable(table.getProto());
+      store.createTable(table.getProto(SerializeOption.GENERIC));
     }
 
     List<String> tables = store.getAllTableNames("default");
@@ -365,7 +366,7 @@ public class TestHCatalogStore {
 
     String tableName = "table1";
     TableDesc table = new TableDesc(DB_NAME + "." + tableName, schema, meta, warehousePath.toUri());
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, tableName));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, tableName));
@@ -390,7 +391,7 @@ public class TestHCatalogStore {
 
     TableDesc table = new TableDesc(CatalogUtil.buildFQName(DB_NAME, REGION), schema, meta,
         new Path(warehousePath, new Path(DB_NAME, REGION)).toUri());
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, REGION));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, REGION));
@@ -419,7 +420,7 @@ public class TestHCatalogStore {
 
     TableDesc table = new TableDesc(CatalogUtil.buildFQName(DB_NAME, REGION), schema, meta,
         new Path(warehousePath, new Path(DB_NAME, REGION)).toUri());
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, REGION));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, REGION));
@@ -451,7 +452,7 @@ public class TestHCatalogStore {
 
     TableDesc table = new TableDesc(CatalogUtil.buildFQName(DB_NAME, CUSTOMER), schema, meta,
         new Path(warehousePath, new Path(DB_NAME, CUSTOMER)).toUri());
-    store.createTable(table.getProto());
+    store.createTable(table.getProto(SerializeOption.GENERIC));
     assertTrue(store.existTable(DB_NAME, CUSTOMER));
 
     TableDesc table1 = new TableDesc(store.getTable(DB_NAME, CUSTOMER));

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/CatalogServer.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/CatalogServer.java
@@ -28,12 +28,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.AbstractService;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.annotation.ThreadSafe;
 import org.apache.tajo.catalog.CatalogProtocol.CatalogProtocolService;
 import org.apache.tajo.catalog.dictionary.InfoSchemaMetadataDictionary;
 import org.apache.tajo.catalog.exception.*;
-import org.apache.tajo.catalog.partition.PartitionDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos.*;
 import org.apache.tajo.catalog.store.CatalogStore;
 import org.apache.tajo.catalog.store.DerbyStore;
@@ -61,7 +61,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import static org.apache.tajo.catalog.proto.CatalogProtos.AlterTablespaceProto.AlterTablespaceCommand;
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionType.*;
 import static org.apache.tajo.rpc.protocolrecords.PrimitiveProtos.StringListProto;
-import static org.apache.tajo.catalog.proto.CatalogProtos.UpdateTableStatsProto;
 
 /**
  * This class provides the catalog service. The catalog service enables clients
@@ -170,7 +169,7 @@ public class CatalogServer extends AbstractService {
   private void initBuiltinFunctions(Collection<FunctionDesc> functions)
       throws ServiceException {
     for (FunctionDesc desc : functions) {
-      handler.createFunction(null, desc.getProto());
+      handler.createFunction(null, desc.getProto(SerializeOption.GENERIC));
     }
   }
 

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/MemStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/MemStore.java
@@ -25,12 +25,12 @@ import com.google.common.collect.Maps;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.FunctionDesc;
 import org.apache.tajo.catalog.TableMeta;
 import org.apache.tajo.catalog.exception.*;
-import org.apache.tajo.catalog.partition.PartitionDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.ColumnProto;
 import org.apache.tajo.catalog.proto.CatalogProtos.DatabaseProto;
@@ -363,7 +363,7 @@ public class MemStore implements CatalogStore {
         }
 
         TableMeta newMeta = new TableMeta(tableDescProto.getMeta().getStoreType(), properties);
-        newTableDescProto = tableDescProto.toBuilder().setMeta(newMeta.getProto()).build();
+        newTableDescProto = tableDescProto.toBuilder().setMeta(newMeta.getProto(SerializeOption.GENERIC)).build();
         database.put(tableName, newTableDescProto);
         break;
       default:

--- a/tajo-client/src/main/java/org/apache/tajo/client/CatalogAdminClientImpl.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/CatalogAdminClientImpl.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.client;
 
 import com.google.protobuf.ServiceException;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.annotation.Nullable;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.Schema;
@@ -144,11 +145,11 @@ public class CatalogAdminClientImpl implements CatalogAdminClient {
         ClientProtos.CreateTableRequest.Builder builder = ClientProtos.CreateTableRequest.newBuilder();
         builder.setSessionId(connection.sessionId);
         builder.setName(tableName);
-        builder.setSchema(schema.getProto());
-        builder.setMeta(meta.getProto());
+        builder.setSchema(schema.getProto(SerializeOption.GENERIC));
+        builder.setMeta(meta.getProto(SerializeOption.GENERIC));
         builder.setPath(path.toString());
         if (partitionMethodDesc != null) {
-          builder.setPartition(partitionMethodDesc.getProto());
+          builder.setPartition(partitionMethodDesc.getProto(SerializeOption.GENERIC));
         }
         ClientProtos.TableResponse res = tajoMasterService.createExternalTable(null, builder.build());
         if (res.getResultCode() == ClientProtos.ResultCode.OK) {

--- a/tajo-client/src/main/java/org/apache/tajo/client/SessionConnection.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/SessionConnection.java
@@ -21,6 +21,7 @@ package org.apache.tajo.client;
 import com.google.protobuf.ServiceException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.SessionVars;
 import org.apache.tajo.TajoIdProtos;
 import org.apache.tajo.annotation.Nullable;
@@ -164,7 +165,7 @@ public class SessionConnection implements Closeable {
         keyValueSet.putAll(variables);
         ClientProtos.UpdateSessionVariableRequest request = ClientProtos.UpdateSessionVariableRequest.newBuilder()
             .setSessionId(sessionId)
-            .setSessionVars(keyValueSet.getProto()).build();
+            .setSessionVars(keyValueSet.getProto(SerializeOption.GENERIC)).build();
 
         SessionUpdateResponse response = tajoMasterService.updateSessionVariables(null, request);
 
@@ -364,7 +365,7 @@ public class SessionConnection implements Closeable {
           keyValueSet.putAll(sessionVarsCache);
           ClientProtos.UpdateSessionVariableRequest request = ClientProtos.UpdateSessionVariableRequest.newBuilder()
               .setSessionId(sessionId)
-              .setSessionVars(keyValueSet.getProto()).build();
+              .setSessionVars(keyValueSet.getProto(SerializeOption.GENERIC)).build();
 
           if (tajoMasterService.updateSessionVariables(null, request).getResultCode() != ResultCode.OK) {
             tajoMasterService.removeSession(null, sessionId);

--- a/tajo-common/src/main/java/org/apache/tajo/SerializeOption.java
+++ b/tajo-common/src/main/java/org/apache/tajo/SerializeOption.java
@@ -16,12 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.tajo.common;
+package org.apache.tajo;
 
-import com.google.protobuf.Message;
-import org.apache.tajo.SerializeOption;
-
-public interface ProtoObject<P extends Message> {
-
-	P getProto(SerializeOption option);
+// serialization option for protobuf or json
+public enum SerializeOption {
+  GENERIC, INTERNAL
 }

--- a/tajo-common/src/main/java/org/apache/tajo/datum/Datum.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/Datum.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.datum;
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.SessionVars;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.conf.TajoConf.ConfVars;
@@ -208,7 +209,7 @@ public abstract class Datum implements Comparable<Datum>, GsonObject {
   public abstract int compareTo(Datum datum);
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CommonGsonHelper.toJson(this, Datum.class);
   }
 

--- a/tajo-common/src/main/java/org/apache/tajo/json/GsonObject.java
+++ b/tajo-common/src/main/java/org/apache/tajo/json/GsonObject.java
@@ -18,6 +18,9 @@
 
 package org.apache.tajo.json;
 
+import org.apache.tajo.SerializeOption;
+
 public interface GsonObject {
-  public String toJson();
+
+  String toJson(SerializeOption option);
 }

--- a/tajo-common/src/main/java/org/apache/tajo/util/KeyValueSet.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/KeyValueSet.java
@@ -21,6 +21,7 @@ package org.apache.tajo.util;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.json.CommonGsonHelper;
 import org.apache.tajo.json.GsonObject;
@@ -227,7 +228,7 @@ public class KeyValueSet implements ProtoObject<KeyValueSetProto>, Cloneable, Gs
 	}
 	
 	@Override
-	public KeyValueSetProto getProto() {
+	public KeyValueSetProto getProto(SerializeOption option) {
     KeyValueSetProto.Builder builder = KeyValueSetProto.newBuilder();
 
     KeyValueProto.Builder kvBuilder = KeyValueProto.newBuilder();
@@ -243,7 +244,7 @@ public class KeyValueSet implements ProtoObject<KeyValueSetProto>, Cloneable, Gs
     return builder.build();
 	}
   
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CommonGsonHelper.toJson(this, KeyValueSet.class);
   }
 }

--- a/tajo-common/src/main/java/org/apache/tajo/util/ProtoUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/ProtoUtil.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.util;
 
 import com.google.common.collect.Lists;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 
 import java.util.Collection;
@@ -54,20 +55,22 @@ public class ProtoUtil {
   }
 
   public static KeyValueSetProto convertFromMap(Map<String, String> map) {
-    return new KeyValueSet(map).getProto();
+    return new KeyValueSet(map).getProto(SerializeOption.GENERIC);
   }
 
   /**
-   * It converts an array of ProtoObjects into Iteratable one.
+   * Converts an array of ProtoObjects into an Iterable.
    *
-   * @param protoObjects
    * @param <T>
+   * @param protoObjects
+   * @param option
    * @return
    */
-  public static <T> Iterable<T> toProtoObjects(ProtoObject[] protoObjects) {
+  @SuppressWarnings("unchecked")
+  public static <T> Iterable<T> toProtoObjects(ProtoObject[] protoObjects, SerializeOption option) {
     List<T> converted = Lists.newArrayList();
     for (int i = 0; i < protoObjects.length; i++) {
-      converted.add((T) protoObjects[i].getProto());
+      converted.add((T) protoObjects[i].getProto(option));
     }
     return converted;
   }

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestBytesDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestBytesDatum.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.datum;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.TajoDataTypes.Type;
 import org.apache.tajo.json.CommonGsonHelper;
 import org.apache.tajo.util.Bytes;
@@ -52,7 +53,7 @@ public class TestBytesDatum {
   @Test
   public final void testJson() {
 	  Datum d = DatumFactory.createBlob("12345".getBytes());
-	  String json = d.toJson();
+	  String json = d.toJson(SerializeOption.GENERIC);
 	  Datum fromJson = CommonGsonHelper.fromJson(json, Datum.class);
 	  assertTrue(d.equalsTo(fromJson).asBool());
   }

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestDateDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestDateDatum.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.datum;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.TajoDataTypes.Type;
 import org.apache.tajo.exception.InvalidCastException;
 import org.apache.tajo.json.CommonGsonHelper;
@@ -83,7 +84,7 @@ public class TestDateDatum {
   @Test
   public final void testToJson() {
     Datum d = DatumFactory.createDate(DATE);
-    Datum copy = CommonGsonHelper.fromJson(d.toJson(), Datum.class);
+    Datum copy = CommonGsonHelper.fromJson(d.toJson(SerializeOption.GENERIC), Datum.class);
     assertEquals(d, copy);
   }
 

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestInet4Datum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestInet4Datum.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.datum;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.json.CommonGsonHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,7 +86,7 @@ public class TestInet4Datum {
 	@Test
 	public final void testJson() {
 		Datum d = DatumFactory.createInet4("163.152.163.152");
-		String json = d.toJson();
+		String json = d.toJson(SerializeOption.GENERIC);
 		Datum fromJson = CommonGsonHelper.fromJson(json, Datum.class);
 		assertTrue(d.equalsTo(fromJson).asBool());
 	}

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestTimeDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestTimeDatum.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.datum;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.TajoDataTypes.Type;
 import org.apache.tajo.common.TajoDataTypes.DataType;
 import org.apache.tajo.exception.InvalidCastException;
@@ -84,7 +85,7 @@ public class TestTimeDatum {
   @Test
   public final void testToJson() {
     Datum d = DatumFactory.createTime(TIME);
-    Datum copy = CommonGsonHelper.fromJson(d.toJson(), Datum.class);
+    Datum copy = CommonGsonHelper.fromJson(d.toJson(SerializeOption.GENERIC), Datum.class);
     assertEquals(d, copy);
   }
 

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestTimestampDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestTimestampDatum.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.datum;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.TajoDataTypes.Type;
 import org.apache.tajo.exception.InvalidCastException;
 import org.apache.tajo.json.CommonGsonHelper;
@@ -112,7 +113,7 @@ public class TestTimestampDatum {
   @Test
   public final void testToJson() {
     Datum d = DatumFactory.createTimestmpDatumWithUnixTime(unixtime);
-    Datum copy = CommonGsonHelper.fromJson(d.toJson(), Datum.class);
+    Datum copy = CommonGsonHelper.fromJson(d.toJson(SerializeOption.GENERIC), Datum.class);
     assertEquals(d, copy);
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/codegen/EvalCodeGenContext.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/codegen/EvalCodeGenContext.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.engine.codegen;
 
 import com.google.common.collect.Maps;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.datum.Datum;
@@ -75,22 +76,22 @@ public class EvalCodeGenContext extends TajoGeneratorAdapter {
   }
 
   public static void emitCreateSchema(TajoGeneratorAdapter adapter, MethodVisitor mv, Schema schema) {
-    mv.visitLdcInsn(schema.toJson());
+    mv.visitLdcInsn(schema.toJson(SerializeOption.GENERIC));
     adapter.invokeStatic(EvalCodeGenerator.class, "createSchema", Schema.class, new Class[] {String.class});
   }
 
   public static void emitCreateEval(TajoGeneratorAdapter adapter, MethodVisitor mv, EvalNode evalNode) {
-    mv.visitLdcInsn(evalNode.toJson());
+    mv.visitLdcInsn(evalNode.toJson(SerializeOption.GENERIC));
     adapter.invokeStatic(EvalCodeGenerator.class, "createEval", EvalNode.class, new Class[] {String.class});
   }
 
   public static void emitConstEval(TajoGeneratorAdapter adapter, MethodVisitor mv, ConstEval evalNode) {
-    mv.visitLdcInsn(evalNode.toJson());
+    mv.visitLdcInsn(evalNode.toJson(SerializeOption.GENERIC));
     adapter.invokeStatic(EvalCodeGenerator.class, "createConstEval", ConstEval.class, new Class[] {String.class});
   }
 
   public static void emitRowConstantEval(TajoGeneratorAdapter adapter, MethodVisitor mv, RowConstantEval evalNode) {
-    mv.visitLdcInsn(evalNode.toJson());
+    mv.visitLdcInsn(evalNode.toJson(SerializeOption.GENERIC));
     adapter.invokeStatic(EvalCodeGenerator.class, "createRowConstantEval", RowConstantEval.class,
         new Class[] {String.class});
   }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ObjectArrays;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.SessionVars;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.SortSpec;
@@ -914,14 +915,15 @@ public class PhysicalPlannerImpl implements PhysicalPlanner {
 
         if (broadcastFlag) {
           PartitionedTableScanNode partitionedTableScanNode = (PartitionedTableScanNode) scanNode;
-          List<Fragment> fileFragments = TUtil.newList();
+          List<FileFragment> fileFragments = TUtil.newList();
           FileStorageManager fileStorageManager = (FileStorageManager)StorageManager.getFileStorageManager(ctx.getConf());
           for (Path path : partitionedTableScanNode.getInputPaths()) {
             fileFragments.addAll(TUtil.newList(fileStorageManager.split(scanNode.getCanonicalName(), path)));
           }
 
           FragmentProto[] fragments =
-                FragmentConvertor.toFragmentProtoArray(fileFragments.toArray(new FileFragment[fileFragments.size()]));
+                FragmentConvertor.toFragmentProtoArray(
+                    SerializeOption.INTERNAL, fileFragments.toArray(new FileFragment[fileFragments.size()]));
 
           ctx.addFragments(scanNode.getCanonicalName(), fragments);
           return new PartitionMergeScanExec(ctx, scanNode, fragments);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/enforce/Enforcer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/enforce/Enforcer.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.engine.planner.enforce;
 
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.annotation.Nullable;
 import org.apache.tajo.catalog.SortSpec;
 import org.apache.tajo.catalog.proto.CatalogProtos;
@@ -78,7 +79,7 @@ public class Enforcer implements ProtoObject<EnforcerProto> {
     SortedInputEnforce.Builder enforce = SortedInputEnforce.newBuilder();
     enforce.setTableName(tableName);
     for (SortSpec sortSpec : sortSpecs) {
-      enforce.addSortSpecs(sortSpec.getProto());
+      enforce.addSortSpecs(sortSpec.getProto(SerializeOption.INTERNAL));
     }
 
     builder.setType(EnforceType.SORTED_INPUT);
@@ -113,7 +114,7 @@ public class Enforcer implements ProtoObject<EnforcerProto> {
     enforce.setAlgorithm(GroupbyAlgorithm.SORT_AGGREGATION);
     if (sortSpecs != null) {
       for (SortSpec sortSpec : sortSpecs) {
-        enforce.addSortSpecs(sortSpec.getProto());
+        enforce.addSortSpecs(sortSpec.getProto(SerializeOption.INTERNAL));
       }
     }
 
@@ -238,7 +239,7 @@ public class Enforcer implements ProtoObject<EnforcerProto> {
   }
 
   @Override
-  public EnforcerProto getProto() {
+  public EnforcerProto getProto(SerializeOption option) {
     EnforcerProto.Builder builder = EnforcerProto.newBuilder();
     builder.addAllProperties(getProperties());
     return builder.build();

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/DataChannel.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/DataChannel.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.engine.planner.global;
 
 import com.google.common.base.Preconditions;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.Schema;
@@ -152,7 +153,7 @@ public class DataChannel {
     return storeType;
   }
 
-  public DataChannelProto getProto() {
+  public DataChannelProto getProto(SerializeOption option) {
     DataChannelProto.Builder builder = DataChannelProto.newBuilder();
     builder.setSrcId(srcId.getProto());
     builder.setTargetId(targetId.getProto());
@@ -161,11 +162,11 @@ public class DataChannel {
     }
     builder.setShuffleType(shuffleType);
     if (schema != null) {
-      builder.setSchema(schema.getProto());
+      builder.setSchema(schema.getProto(option));
     }
     if (shuffleKeys != null) {
       for (Column column : shuffleKeys) {
-        builder.addShuffleKeys(column.getProto());
+        builder.addShuffleKeys(column.getProto(option));
       }
     }
     if (numOutputs != null) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/builder/DistinctGroupbyBuilder.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/builder/DistinctGroupbyBuilder.java
@@ -21,6 +21,7 @@ package org.apache.tajo.engine.planner.global.builder;
 import com.google.common.base.Preconditions;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.proto.CatalogProtos.SortSpecProto;
@@ -537,12 +538,12 @@ public class DistinctGroupbyBuilder {
           Target target = new Target(new FieldEval(column));
           firstGroupbyTargets.add(target);
         }
-        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[]{}));
+        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[firstGroupbyTargets.size()]));
 
         // SecondStage:
         //   Set grouping column with origin groupby's columns
         //   Remove distinct group column from targets
-        secondStageGroupbyNode.setGroupingColumns(originGroupColumns.toArray(new Column[]{}));
+        secondStageGroupbyNode.setGroupingColumns(originGroupColumns.toArray(new Column[originGroupColumns.size()]));
 
         Target[] oldTargets = secondStageGroupbyNode.getTargets();
         List<Target> secondGroupbyTargets = new ArrayList<Target>();
@@ -573,7 +574,7 @@ public class DistinctGroupbyBuilder {
           }
           columnIdIndex++;
         }
-        secondStageGroupbyNode.setTargets(secondGroupbyTargets.toArray(new Target[]{}));
+        secondStageGroupbyNode.setTargets(secondGroupbyTargets.toArray(new Target[secondGroupbyTargets.size()]));
       } else {
         // FirstStage: Change target of aggFunction to function name expr
         List<Target> firstGroupbyTargets = new ArrayList<Target>();
@@ -602,7 +603,7 @@ public class DistinctGroupbyBuilder {
           columnIdIndex++;
           aggFuncIdx++;
         }
-        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[]{}));
+        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[firstGroupbyTargets.size()]));
         secondStageGroupbyNode.setInSchema(firstStageGroupbyNode.getOutSchema());
       }
       grpIdx++;
@@ -661,7 +662,7 @@ public class DistinctGroupbyBuilder {
         }
       }
     }
-    firstStageDistinctNode.setTargets(firstTargets.toArray(new Target[]{}));
+    firstStageDistinctNode.setTargets(firstTargets.toArray(new Target[firstTargets.size()]));
     firstStageDistinctNode.setResultColumnIds(TUtil.toArray(firstStageColumnIds));
 
     //Set SecondStage ColumnId and Input schema
@@ -694,7 +695,7 @@ public class DistinctGroupbyBuilder {
     for (GroupbyNode groupbyNode: firstStageDistinctNode.getSubPlans()) {
       List<SortSpecProto> sortSpecs = new ArrayList<SortSpecProto>();
       for (Column column: groupbyNode.getGroupingColumns()) {
-        sortSpecs.add(SortSpecProto.newBuilder().setColumn(column.getProto()).build());
+        sortSpecs.add(SortSpecProto.newBuilder().setColumn(column.getProto(SerializeOption.INTERNAL)).build());
       }
       sortSpecArrays.add( SortSpecArray.newBuilder()
           .setNodeId(secondStageDistinctNode.getSubPlans().get(index).getPID())
@@ -722,7 +723,7 @@ public class DistinctGroupbyBuilder {
     for (GroupbyNode groupbyNode: firstStageDistinctNode.getSubPlans()) {
       List<SortSpecProto> sortSpecs = new ArrayList<SortSpecProto>();
       for (Column column: groupbyNode.getGroupingColumns()) {
-        sortSpecs.add(SortSpecProto.newBuilder().setColumn(column.getProto()).build());
+        sortSpecs.add(SortSpecProto.newBuilder().setColumn(column.getProto(SerializeOption.INTERNAL)).build());
       }
       sortSpecArrays.add( SortSpecArray.newBuilder()
           .setNodeId(thirdStageDistinctNode.getSubPlans().get(index).getPID())

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/GlobalPlanEqualityTester.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/GlobalPlanEqualityTester.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.engine.planner.global.rewriter.rules;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.engine.planner.global.ExecutionBlock;
 import org.apache.tajo.engine.planner.global.ExecutionBlockCursor;
 import org.apache.tajo.engine.planner.global.MasterPlan;
@@ -50,7 +51,7 @@ public class GlobalPlanEqualityTester implements GlobalPlanRewriteRule {
         ExecutionBlock eb = cursor.nextBlock();
         LogicalNode node = eb.getPlan();
         if (node != null) {
-          PlanProto.LogicalNodeTree tree = LogicalNodeSerializer.serialize(node);
+          PlanProto.LogicalNodeTree tree = LogicalNodeSerializer.serialize(node, SerializeOption.GENERIC);
           LogicalNode deserialize = LogicalNodeDeserializer.deserialize(plan.getContext(), tree);
           assert node.deepEquals(deserialize);
         }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/PhysicalPlanUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/PhysicalPlanUtil.java
@@ -21,6 +21,7 @@ package org.apache.tajo.engine.planner.physical;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.SessionVars;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.SortSpec;
@@ -116,7 +117,8 @@ public class PhysicalPlanUtil {
         fragments.add(fileFragment);
       }
     }
-    return FragmentConvertor.toFragmentProtoArray(fragments.toArray(new FileFragment[]{}));
+    return FragmentConvertor.toFragmentProtoArray(
+        SerializeOption.INTERNAL, fragments.toArray(new FileFragment[fragments.size()]));
   }
 
   /**

--- a/tajo-core/src/main/java/org/apache/tajo/engine/query/QueryContext.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/query/QueryContext.java
@@ -20,6 +20,7 @@ package org.apache.tajo.engine.query;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.tajo.ConfigKey;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.OverridableConf;
 import org.apache.tajo.QueryVars;
 import org.apache.tajo.SessionVars;
@@ -107,7 +108,8 @@ public class QueryContext extends OverridableConf {
   }
 
   public void setPartitionMethod(PartitionMethodDesc partitionMethodDesc) {
-    put(QueryVars.OUTPUT_PARTITIONS, partitionMethodDesc != null ? partitionMethodDesc.toJson() : null);
+    put(QueryVars.OUTPUT_PARTITIONS,
+        partitionMethodDesc != null ? partitionMethodDesc.toJson(SerializeOption.GENERIC) : null);
   }
 
 //  public PartitionMethodDesc getPartitionMethod() {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/query/TaskRequestImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/query/TaskRequestImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.engine.query;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.engine.planner.enforce.Enforcer;
@@ -89,8 +90,8 @@ public class TaskRequestImpl implements TaskRequest {
 	}
 
 	@Override
-	public TaskRequestProto getProto() {
-		mergeLocalToProto();
+	public TaskRequestProto getProto(SerializeOption option) {
+		mergeLocalToProto(option);
 		proto = viaProto ? proto : builder.build();
 		viaProto = true;
 		return proto;
@@ -115,9 +116,7 @@ public class TaskRequestImpl implements TaskRequest {
 		if (fragments != null) {
 			return fragments;
 		}
-		if (fragments == null) {
-			fragments = new ArrayList<FragmentProto>();
-		}
+    fragments = new ArrayList<FragmentProto>(p.getFragmentsCount());
 		for (int i = 0; i < p.getFragmentsCount(); i++) {
 			fragments.add(p.getFragments(i));
 		}
@@ -279,7 +278,7 @@ public class TaskRequestImpl implements TaskRequest {
 		viaProto = true;
 	}
 	
-	private void mergeLocalToBuilder() {
+	private void mergeLocalToBuilder(SerializeOption option) {
 		if (id != null) {
 			builder.setId(this.id.getProto());
 		}
@@ -302,28 +301,28 @@ public class TaskRequestImpl implements TaskRequest {
 		}
     if (this.fetches != null) {
       for (int i = 0; i < fetches.size(); i++) {
-        builder.addFetches(fetches.get(i).getProto());
+        builder.addFetches(fetches.get(i).getProto(option));
       }
     }
     if (this.shouldDie != null) {
       builder.setShouldDie(this.shouldDie);
     }
     if (this.queryContext != null) {
-      builder.setQueryContext(queryContext.getProto());
+      builder.setQueryContext(queryContext.getProto(option));
     }
     if (this.dataChannel != null) {
-      builder.setDataChannel(dataChannel.getProto());
+      builder.setDataChannel(dataChannel.getProto(option));
     }
     if (this.enforcer != null) {
-      builder.setEnforcer(enforcer.getProto());
+      builder.setEnforcer(enforcer.getProto(option));
     }
 	}
 
-	private void mergeLocalToProto() {
+	private void mergeLocalToProto(SerializeOption option) {
 		if(viaProto) {
 			maybeInitBuilder();
 		}
-		mergeLocalToBuilder();
+		mergeLocalToBuilder(option);
 		proto = builder.build();
 		viaProto = true;
 	}

--- a/tajo-core/src/main/java/org/apache/tajo/master/QueryCoordinatorService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/QueryCoordinatorService.java
@@ -23,6 +23,7 @@ import com.google.protobuf.RpcController;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.service.AbstractService;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.ipc.ContainerProtocol;
 import org.apache.tajo.ipc.QueryCoordinatorProtocol;
@@ -148,7 +149,7 @@ public class QueryCoordinatorService extends AbstractService {
 
         WorkerResourceProto.Builder workerResource = WorkerResourceProto.newBuilder();
 
-        workerResource.setConnectionInfo(worker.getConnectionInfo().getProto());
+        workerResource.setConnectionInfo(worker.getConnectionInfo().getProto(SerializeOption.INTERNAL));
         workerResource.setMemoryMB(resource.getMemoryMB());
         workerResource.setDiskSlots(resource.getDiskSlots());
 

--- a/tajo-core/src/main/java/org/apache/tajo/master/QueryInProgress.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/QueryInProgress.java
@@ -21,6 +21,7 @@ package org.apache.tajo.master;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.TajoProtos;
 import org.apache.tajo.engine.query.QueryContext;
@@ -187,10 +188,11 @@ public class QueryInProgress {
 
       QueryExecutionRequestProto.Builder builder = TajoWorkerProtocol.QueryExecutionRequestProto.newBuilder();
       builder.setQueryId(queryId.getProto())
-          .setQueryContext(queryInfo.getQueryContext().getProto())
-          .setSession(session.getProto())
+          .setQueryContext(queryInfo.getQueryContext().getProto(SerializeOption.INTERNAL))
+          .setSession(session.getProto(SerializeOption.INTERNAL))
           .setExprInJson(PrimitiveProtos.StringProto.newBuilder().setValue(queryInfo.getJsonExpr()))
-          .setLogicalPlanJson(PrimitiveProtos.StringProto.newBuilder().setValue(plan.toJson()).build());
+          .setLogicalPlanJson(PrimitiveProtos.StringProto.newBuilder().setValue(plan.toJson(SerializeOption.INTERNAL))
+          .build());
 
       queryMasterRpcClient.executeQuery(null, builder.build(), NullCallback.get());
       querySubmitted.set(true);

--- a/tajo-core/src/main/java/org/apache/tajo/master/QueryInfo.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/QueryInfo.java
@@ -20,6 +20,7 @@ package org.apache.tajo.master;
 
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.TajoProtos;
 import org.apache.tajo.catalog.TableDesc;
@@ -182,7 +183,7 @@ public class QueryInfo implements GsonObject, History, Comparable<QueryInfo> {
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CoreGsonHelper.toJson(this, QueryInfo.class);
   }
 
@@ -201,12 +202,12 @@ public class QueryInfo implements GsonObject, History, Comparable<QueryInfo> {
     return queryIdStr;
   }
 
-  public QueryInfoProto getProto() {
+  public QueryInfoProto getProto(SerializeOption option) {
     QueryInfoProto.Builder builder = QueryInfoProto.newBuilder();
 
     builder.setQueryId(queryId.toString())
         .setQueryState(queryState)
-        .setContextVars(context.getProto())
+        .setContextVars(context.getProto(option))
         .setProgress(progress)
         .setStartTime(startTime)
         .setFinishTime(finishTime)
@@ -215,7 +216,7 @@ public class QueryInfo implements GsonObject, History, Comparable<QueryInfo> {
         .setQueryMasterInfoPort(queryMasterInfoPort);
 
     if (resultDesc != null) {
-      builder.setResultDesc(resultDesc.getProto());
+      builder.setResultDesc(resultDesc.getProto(option));
     }
 
     if (sql != null) {

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoContainerProxy.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoContainerProxy.java
@@ -21,11 +21,10 @@ package org.apache.tajo.master;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.TaskAttemptId;
-import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.engine.query.QueryContext;
-import org.apache.tajo.ha.HAServiceUtil;
 import org.apache.tajo.ipc.ContainerProtocol;
 import org.apache.tajo.ipc.QueryCoordinatorProtocol;
 import org.apache.tajo.ipc.TajoWorkerProtocol;
@@ -108,11 +107,11 @@ public class TajoContainerProxy extends ContainerProxy {
       TajoWorkerProtocol.RunExecutionBlockRequestProto request =
           TajoWorkerProtocol.RunExecutionBlockRequestProto.newBuilder()
               .setExecutionBlockId(executionBlockId.getProto())
-              .setQueryMaster(context.getQueryMasterContext().getWorkerContext().getConnectionInfo().getProto())
+              .setQueryMaster(context.getQueryMasterContext().getWorkerContext().getConnectionInfo().getProto(SerializeOption.INTERNAL))
               .setNodeId(container.getNodeId().toString())
               .setContainerId(container.getId().toString())
               .setQueryOutputPath(context.getStagingDir().toString())
-              .setQueryContext(queryContext.getProto())
+              .setQueryContext(queryContext.getProto(SerializeOption.INTERNAL))
               .setPlanJson(planJson)
               .build();
 

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterClientService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMasterClientService.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.AbstractService;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.QueryIdFactory;
 import org.apache.tajo.TajoIdProtos;
@@ -177,7 +178,7 @@ public class TajoMasterClientService extends AbstractService {
     public SessionUpdateResponse buildSessionUpdateOnSuccess(Map<String, String> variables) {
       SessionUpdateResponse.Builder builder = SessionUpdateResponse.newBuilder();
       builder.setResultCode(ResultCode.OK);
-      builder.setSessionVars(new KeyValueSet(variables).getProto());
+      builder.setSessionVars(new KeyValueSet(variables).getProto(SerializeOption.GENERIC));
       return builder.build();
     }
 
@@ -242,7 +243,7 @@ public class TajoMasterClientService extends AbstractService {
         String sessionId = request.getId();
         KeyValueSet keyValueSet = new KeyValueSet();
         keyValueSet.putAll(context.getSessionManager().getAllVariables(sessionId));
-        return keyValueSet.getProto();
+        return keyValueSet.getProto(SerializeOption.GENERIC);
       } catch (Throwable t) {
         throw new ServiceException(t);
       }
@@ -361,7 +362,7 @@ public class TajoMasterClientService extends AbstractService {
         switch (queryInfo.getQueryState()) {
           case QUERY_SUCCEEDED:
             if (queryInfo.hasResultdesc()) {
-              builder.setTableDesc(queryInfo.getResultDesc().getProto());
+              builder.setTableDesc(queryInfo.getResultDesc().getProto(SerializeOption.GENERIC));
             }
             break;
           case QUERY_FAILED:
@@ -550,7 +551,7 @@ public class TajoMasterClientService extends AbstractService {
 
         List<ByteString> rows = queryResultScanner.getNextRows(request.getFetchRowNum());
 
-        resultSetBuilder.setSchema(queryResultScanner.getLogicalSchema().getProto());
+        resultSetBuilder.setSchema(queryResultScanner.getLogicalSchema().getProto(SerializeOption.GENERIC));
         resultSetBuilder.addAllSerializedTuples(rows);
 
         builder.setResultSet(resultSetBuilder.build());
@@ -603,7 +604,7 @@ public class TajoMasterClientService extends AbstractService {
         }
 
         if (queryInfo != null) {
-          builder.setQueryInfo(queryInfo.getProto());
+          builder.setQueryInfo(queryInfo.getProto(SerializeOption.GENERIC));
         }
         builder.setResultCode(ResultCode.OK);
       } catch (Throwable t) {
@@ -652,7 +653,7 @@ public class TajoMasterClientService extends AbstractService {
         for(Worker worker: workers.values()) {
           WorkerResource workerResource = worker.getResource();
 
-          workerBuilder.setConnectionInfo(worker.getConnectionInfo().getProto());
+          workerBuilder.setConnectionInfo(worker.getConnectionInfo().getProto(SerializeOption.GENERIC));
           workerBuilder.setDiskSlots(workerResource.getDiskSlots());
           workerBuilder.setCpuCoreSlots(workerResource.getCpuCoreSlots());
           workerBuilder.setMemoryMB(workerResource.getMemoryMB());
@@ -802,7 +803,7 @@ public class TajoMasterClientService extends AbstractService {
         if (catalog.existsTable(databaseName, tableName)) {
           return TableResponse.newBuilder()
               .setResultCode(ResultCode.OK)
-              .setTableDesc(catalog.getTableDesc(databaseName, tableName).getProto())
+              .setTableDesc(catalog.getTableDesc(databaseName, tableName).getProto(SerializeOption.GENERIC))
               .build();
         } else {
           return TableResponse.newBuilder()
@@ -849,7 +850,7 @@ public class TajoMasterClientService extends AbstractService {
 
         return TableResponse.newBuilder()
             .setResultCode(ResultCode.OK)
-            .setTableDesc(desc.getProto()).build();
+            .setTableDesc(desc.getProto(SerializeOption.GENERIC)).build();
       } catch (InvalidSessionException ise) {
         return TableResponse.newBuilder()
             .setResultCode(ResultCode.ERROR)
@@ -889,10 +890,10 @@ public class TajoMasterClientService extends AbstractService {
 
         for (FunctionDesc eachFunction: functions) {
           if (functionName == null || functionName.isEmpty()) {
-            functionProtos.add(eachFunction.getProto());
+            functionProtos.add(eachFunction.getProto(SerializeOption.GENERIC));
           } else {
             if(functionName.equals(eachFunction.getFunctionName())) {
-              functionProtos.add(eachFunction.getProto());
+              functionProtos.add(eachFunction.getProto(SerializeOption.GENERIC));
             }
           }
         }

--- a/tajo-core/src/main/java/org/apache/tajo/master/cluster/WorkerConnectionInfo.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/cluster/WorkerConnectionInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.master.cluster;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 
 import static org.apache.tajo.TajoProtos.WorkerConnectionInfoProto;
@@ -112,7 +113,7 @@ public class WorkerConnectionInfo implements ProtoObject<WorkerConnectionInfoPro
   }
 
   @Override
-  public WorkerConnectionInfoProto getProto() {
+  public WorkerConnectionInfoProto getProto(SerializeOption option) {
     WorkerConnectionInfoProto.Builder builder = WorkerConnectionInfoProto.newBuilder();
     builder.setId(id)
         .setHost(host)

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.algebra.AlterTablespaceSetType;
 import org.apache.tajo.annotation.Nullable;
 import org.apache.tajo.catalog.*;
@@ -102,7 +103,7 @@ public class DDLExecutor {
       return true;
 
     default:
-      throw new InternalError("updateQuery cannot handle such query: \n" + root.toJson());
+      throw new InternalError("updateQuery cannot handle such query: \n" + root.toJson(SerializeOption.GENERIC));
     }
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/ExplainPlanPreprocessorForTest.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/ExplainPlanPreprocessorForTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.master.exec;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.plan.LogicalPlan;
@@ -182,7 +183,7 @@ public class ExplainPlanPreprocessorForTest {
 
     @Override
     public int compare(EvalNode o1, EvalNode o2) {
-      return o1.toJson().compareTo(o2.toJson());
+      return o1.toJson(SerializeOption.GENERIC).compareTo(o2.toJson(SerializeOption.GENERIC));
     }
   }
 
@@ -190,7 +191,7 @@ public class ExplainPlanPreprocessorForTest {
 
     @Override
     public int compare(Target o1, Target o2) {
-      return o1.toJson().compareTo(o2.toJson());
+      return o1.toJson(SerializeOption.GENERIC).compareTo(o2.toJson(SerializeOption.GENERIC));
     }
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultFileScanner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultFileScanner.java
@@ -22,6 +22,7 @@ import com.google.protobuf.ByteString;
 
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.QueryId;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.TaskId;
 import org.apache.tajo.catalog.Column;
@@ -110,7 +111,8 @@ public class NonForwardQueryResultFileScanner implements NonForwardQueryResultSc
     fragments = storageManager.getNonForwardSplit(tableDesc, currentFragmentIndex, MAX_FRAGMENT_NUM_PER_SCAN);
 
     if (fragments != null && !fragments.isEmpty()) {
-      FragmentProto[] fragmentProtos = FragmentConvertor.toFragmentProtoArray(fragments.toArray(new Fragment[] {}));
+      FragmentProto[] fragmentProtos = FragmentConvertor.toFragmentProtoArray(
+          SerializeOption.INTERNAL, fragments.toArray(new Fragment[fragments.size()]));
       this.taskContext = new TaskAttemptContext(
           new QueryContext(tajoConf), null, 
           new TaskAttemptId(new TaskId(new ExecutionBlockId(queryId, 1), 0), 0), 

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.QueryIdFactory;
 import org.apache.tajo.SessionVars;
@@ -197,7 +198,7 @@ public class QueryExecutor {
       bytesNum += encodedData.length;
       serializedResBuilder.addSerializedTuples(ByteString.copyFrom(encodedData));
     }
-    serializedResBuilder.setSchema(schema.getProto());
+    serializedResBuilder.setSchema(schema.getProto(SerializeOption.GENERIC));
     serializedResBuilder.setBytesNum(bytesNum);
 
     response.setResultSet(serializedResBuilder.build());
@@ -223,7 +224,7 @@ public class QueryExecutor {
 
     response.setQueryId(queryId.getProto());
     response.setMaxRowNum(maxRow);
-    response.setTableDesc(queryResultScanner.getTableDesc().getProto());
+    response.setTableDesc(queryResultScanner.getTableDesc().getProto(SerializeOption.GENERIC));
     response.setResultCode(ClientProtos.ResultCode.OK);
   }
 
@@ -259,7 +260,7 @@ public class QueryExecutor {
 
     response.setQueryId(queryInfo.getQueryId().getProto());
     response.setMaxRowNum(maxRow);
-    response.setTableDesc(desc.getProto());
+    response.setTableDesc(desc.getProto(SerializeOption.GENERIC));
     response.setResultCode(ClientProtos.ResultCode.OK);
   }
 
@@ -287,7 +288,7 @@ public class QueryExecutor {
       byte[] serializedBytes = encoder.toBytes(outTuple);
       ClientProtos.SerializedResultSet.Builder serializedResBuilder = ClientProtos.SerializedResultSet.newBuilder();
       serializedResBuilder.addSerializedTuples(ByteString.copyFrom(serializedBytes));
-      serializedResBuilder.setSchema(schema.getProto());
+      serializedResBuilder.setSchema(schema.getProto(SerializeOption.GENERIC));
       serializedResBuilder.setBytesNum(serializedBytes.length);
 
       responseBuilder.setResultSet(serializedResBuilder);
@@ -369,11 +370,11 @@ public class QueryExecutor {
 
       CatalogProtos.UpdateTableStatsProto.Builder builder = CatalogProtos.UpdateTableStatsProto.newBuilder();
       builder.setTableName(tableDesc.getName());
-      builder.setStats(stats.getProto());
+      builder.setStats(stats.getProto(SerializeOption.GENERIC));
 
       catalog.updateTableStats(builder.build());
 
-      responseBuilder.setTableDesc(tableDesc.getProto());
+      responseBuilder.setTableDesc(tableDesc.getProto(SerializeOption.GENERIC));
     } else {
       TableStats stats = new TableStats();
       long volume = Query.getTableVolume(context.getConf(), finalOutputDir);
@@ -386,7 +387,7 @@ public class QueryExecutor {
           .setTableName(nodeUniqName)
           .setMeta(CatalogProtos.TableProto.newBuilder().setStoreType(CatalogProtos.StoreType.CSV).build())
           .setSchema(CatalogProtos.SchemaProto.newBuilder().addAllFields(columns).build())
-          .setStats(stats.getProto())
+          .setStats(stats.getProto(SerializeOption.GENERIC))
           .build();
 
       responseBuilder.setTableDesc(tableDescProto);

--- a/tajo-core/src/main/java/org/apache/tajo/master/rm/TajoWorkerResourceManager.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/rm/TajoWorkerResourceManager.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.event.AsyncDispatcher;
 import org.apache.hadoop.yarn.event.EventHandler;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.ipc.ContainerProtocol;
@@ -332,7 +333,7 @@ public class TajoWorkerResourceManager extends CompositeService implements Worke
                 ContainerProtocol.TajoContainerIdProto containerIdProto = containerId.getProto();
                 allocatedResources.add(WorkerAllocatedResource.newBuilder()
                   .setContainerId(containerIdProto)
-                  .setConnectionInfo(allocatedResource.worker.getConnectionInfo().getProto())
+                  .setConnectionInfo(allocatedResource.worker.getConnectionInfo().getProto(SerializeOption.INTERNAL))
                   .setAllocatedMemoryMB(allocatedResource.allocatedMemoryMB)
                   .setAllocatedDiskSlots(allocatedResource.allocatedDiskSlots)
                   .build());

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.state.*;
 import org.apache.hadoop.yarn.util.Clock;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.SessionVars;
@@ -599,7 +600,7 @@ public class Query implements EventHandler<QueryEvent> {
         if (insertNode.hasTargetTable()) {
           UpdateTableStatsProto.Builder builder = UpdateTableStatsProto.newBuilder();
           builder.setTableName(finalTable.getName());
-          builder.setStats(stats.getProto());
+          builder.setStats(stats.getProto(SerializeOption.GENERIC));
 
           catalog.updateTableStats(builder.build());
         }

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/QueryMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/QueryMaster.java
@@ -382,12 +382,12 @@ public class QueryMaster extends CompositeService implements EventHandler {
   private TajoHeartbeat buildTajoHeartBeat(QueryMasterTask queryMasterTask) {
     TajoHeartbeat.Builder builder = TajoHeartbeat.newBuilder();
 
-    builder.setConnectionInfo(workerContext.getConnectionInfo().getProto());
+    builder.setConnectionInfo(workerContext.getConnectionInfo().getProto(SerializeOption.INTERNAL));
     builder.setQueryId(queryMasterTask.getQueryId().getProto());
     builder.setState(queryMasterTask.getState());
     if (queryMasterTask.getQuery() != null) {
       if (queryMasterTask.getQuery().getResultDesc() != null) {
-        builder.setResultDesc(queryMasterTask.getQuery().getResultDesc().getProto());
+        builder.setResultDesc(queryMasterTask.getQuery().getResultDesc().getProto(SerializeOption.INTERNAL));
       }
       builder.setQueryProgress(queryMasterTask.getQuery().getProgress());
     }

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Task.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Task.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.state.*;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.QueryIdFactory;
 import org.apache.tajo.TajoProtos.TaskAttemptState;
@@ -332,7 +333,7 @@ public class Task implements EventHandler<TaskEvent> {
     }
   }
 
-  public void addFragment(Fragment fragment, boolean useDataLocation) {
+  public void addFragment(Fragment fragment, SerializeOption option, boolean useDataLocation) {
     Set<FragmentProto> fragmentProtos;
     if (fragMap.containsKey(fragment.getTableName())) {
       fragmentProtos = fragMap.get(fragment.getTableName());
@@ -340,16 +341,16 @@ public class Task implements EventHandler<TaskEvent> {
       fragmentProtos = new HashSet<FragmentProto>();
       fragMap.put(fragment.getTableName(), fragmentProtos);
     }
-    fragmentProtos.add(fragment.getProto());
+    fragmentProtos.add(fragment.getProto(option));
     if (useDataLocation) {
       addDataLocation(fragment);
     }
     totalFragmentNum++;
   }
 
-  public void addFragments(Collection<Fragment> fragments) {
+  public void addFragments(Collection<Fragment> fragments, SerializeOption option) {
     for (Fragment eachFragment: fragments) {
-      addFragment(eachFragment, false);
+      addFragment(eachFragment, option, false);
     }
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/session/Session.java
+++ b/tajo-core/src/main/java/org/apache/tajo/session/Session.java
@@ -21,6 +21,7 @@ package org.apache.tajo.session;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.SessionVars;
 import org.apache.tajo.master.exec.NonForwardQueryResultScanner;
@@ -122,7 +123,7 @@ public class Session implements SessionConstants, ProtoObject<SessionProto>, Clo
   }
 
   @Override
-  public SessionProto getProto() {
+  public SessionProto getProto(SerializeOption option) {
     SessionProto.Builder builder = SessionProto.newBuilder();
     builder.setSessionId(getSessionId());
     builder.setUsername(getUserName());
@@ -132,7 +133,7 @@ public class Session implements SessionConstants, ProtoObject<SessionProto>, Clo
 
     synchronized (sessionVariables) {
       variables.putAll(this.sessionVariables);
-      builder.setVariables(variables.getProto());
+      builder.setVariables(variables.getProto(option));
       return builder.build();
     }
   }

--- a/tajo-core/src/main/java/org/apache/tajo/util/JSPUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/JSPUtil.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.util;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.FunctionDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.statistics.TableStats;
@@ -332,7 +333,7 @@ public class JSPUtil {
 
   public static String tableStatToString(TableStats tableStats) {
     if(tableStats != null){
-      return tableStatToString(tableStats.getProto());
+      return tableStatToString(tableStats.getProto(SerializeOption.GENERIC));
     }
     else {
       return "No input statistics";

--- a/tajo-core/src/main/java/org/apache/tajo/util/history/HistoryWriter.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/history/HistoryWriter.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.service.AbstractService;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.master.QueryInfo;
 import org.apache.tajo.util.Bytes;
@@ -361,7 +362,7 @@ public class HistoryWriter extends AbstractService {
       try {
         LOG.info("Saving query summary: " + queryHistoryFile);
         out = fs.create(queryHistoryFile, queryReplication);
-        out.write(queryHistory.toJson().getBytes(Bytes.UTF8_CHARSET));
+        out.write(queryHistory.toJson(SerializeOption.GENERIC).getBytes(Bytes.UTF8_CHARSET));
       } finally {
         IOUtils.cleanup(LOG, out);
       }
@@ -397,7 +398,7 @@ public class HistoryWriter extends AbstractService {
           rollingQuerySummaryWriter();
         }
       }
-      byte[] jsonBytes = ("\n" + queryInfo.toJson() + "\n").getBytes(Bytes.UTF8_CHARSET);
+      byte[] jsonBytes = ("\n" + queryInfo.toJson(SerializeOption.GENERIC) + "\n").getBytes(Bytes.UTF8_CHARSET);
       try {
         querySummaryWriter.out.writeInt(jsonBytes.length);
         querySummaryWriter.out.write(jsonBytes);
@@ -459,7 +460,7 @@ public class HistoryWriter extends AbstractService {
 
       if (writerHolder.out != null) {
         try {
-          byte[] taskHistoryBytes = taskHistory.getProto().toByteArray();
+          byte[] taskHistoryBytes = taskHistory.getProto(SerializeOption.GENERIC).toByteArray();
           writerHolder.out.writeInt(taskHistoryBytes.length);
           writerHolder.out.write(taskHistoryBytes);
         } catch (IOException ie) {

--- a/tajo-core/src/main/java/org/apache/tajo/util/history/QueryHistory.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/history/QueryHistory.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.util.history;
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.engine.json.CoreGsonHelper;
 import org.apache.tajo.ipc.ClientProtos;
 import org.apache.tajo.ipc.ClientProtos.QueryHistoryProto;
@@ -102,7 +103,7 @@ public class QueryHistory implements GsonObject, History {
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CoreGsonHelper.toJson(this, QueryHistory.class);
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/util/history/StageHistory.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/history/StageHistory.java
@@ -20,6 +20,7 @@ package org.apache.tajo.util.history;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.reflect.TypeToken;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.engine.json.CoreGsonHelper;
 import org.apache.tajo.ipc.ClientProtos.StageHistoryProto;
 import org.apache.tajo.json.GsonObject;
@@ -222,7 +223,7 @@ public class StageHistory implements GsonObject {
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CoreGsonHelper.toJson(this, StageHistory.class);
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/util/history/TaskHistory.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/history/TaskHistory.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.util.history;
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.engine.json.CoreGsonHelper;
 import org.apache.tajo.json.GsonObject;
 
@@ -153,7 +154,7 @@ public class TaskHistory implements GsonObject {
   }
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CoreGsonHelper.toJson(this, TaskHistory.class);
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/worker/FetchImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/FetchImpl.java
@@ -21,6 +21,7 @@ package org.apache.tajo.worker;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.ipc.TajoWorkerProtocol;
@@ -112,7 +113,7 @@ public class FetchImpl implements ProtoObject<TajoWorkerProtocol.FetchProto>, Cl
   }
 
   @Override
-  public TajoWorkerProtocol.FetchProto getProto() {
+  public TajoWorkerProtocol.FetchProto getProto(SerializeOption option) {
     TajoWorkerProtocol.FetchProto.Builder builder = TajoWorkerProtocol.FetchProto.newBuilder();
 
     builder.setHost(host.getHost());

--- a/tajo-core/src/main/java/org/apache/tajo/worker/Task.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/Task.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.TajoProtos;
 import org.apache.tajo.TajoProtos.TaskAttemptState;
@@ -152,7 +153,7 @@ public class Task {
       }
     }
 
-    interQuery = request.getProto().getInterQuery();
+    interQuery = request.getProto(SerializeOption.GENERIC).getInterQuery();
     if (interQuery) {
       context.setInterQuery();
       this.shuffleType = context.getDataChannel().getShuffleType();
@@ -286,7 +287,7 @@ public class Task {
     builder.setInputStats(reloadInputStats());
 
     if (context.getResultStats() != null) {
-      builder.setResultStats(context.getResultStats().getProto());
+      builder.setResultStats(context.getResultStats().getProto(SerializeOption.GENERIC));
     }
     return builder.build();
   }
@@ -312,7 +313,7 @@ public class Task {
   private CatalogProtos.TableStatsProto reloadInputStats() {
     synchronized(inputStats) {
       if (this.executor == null) {
-        return inputStats.getProto();
+        return inputStats.getProto(SerializeOption.GENERIC);
       }
 
       TableStats executorInputStats = this.executor.getInputStats();
@@ -320,7 +321,7 @@ public class Task {
       if (executorInputStats != null) {
         inputStats.setValues(executorInputStats);
       }
-      return inputStats.getProto();
+      return inputStats.getProto(SerializeOption.GENERIC);
     }
   }
 
@@ -331,9 +332,9 @@ public class Task {
     builder.setInputStats(reloadInputStats());
 
     if (context.hasResultStats()) {
-      builder.setResultStats(context.getResultStats().getProto());
+      builder.setResultStats(context.getResultStats().getProto(SerializeOption.GENERIC));
     } else {
-      builder.setResultStats(new TableStats().getProto());
+      builder.setResultStats(new TableStats().getProto(SerializeOption.GENERIC));
     }
 
     Iterator<Entry<Integer, String>> it = context.getShuffleFileOutputs();
@@ -507,7 +508,7 @@ public class Task {
       }
 
       if (context.getResultStats() != null) {
-        taskHistory.setOutputStats(context.getResultStats().getProto());
+        taskHistory.setOutputStats(context.getResultStats().getProto(SerializeOption.GENERIC));
       }
 
       if (hasFetchPhase()) {

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskAttemptContext.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskAttemptContext.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Maps;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TajoProtos.TaskAttemptState;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.catalog.Schema;
@@ -129,7 +130,7 @@ public class TaskAttemptContext {
   @VisibleForTesting
   public TaskAttemptContext(final QueryContext queryContext, final TaskAttemptId queryId,
                             final Fragment [] fragments,  final Path workDir) {
-    this(queryContext, null, queryId, FragmentConvertor.toFragmentProtoArray(fragments), workDir);
+    this(queryContext, null, queryId, FragmentConvertor.toFragmentProtoArray(SerializeOption.GENERIC, fragments), workDir);
   }
 
   public TajoConf getConf() {
@@ -257,10 +258,10 @@ public class TaskAttemptContext {
     fragmentMap.remove(tableId);
     for(Fragment t : fragments) {
       if (fragmentMap.containsKey(t.getTableName())) {
-        fragmentMap.get(t.getTableName()).add(t.getProto());
+        fragmentMap.get(t.getTableName()).add(t.getProto(SerializeOption.GENERIC));
       } else {
         List<FragmentProto> frags = new ArrayList<FragmentProto>();
-        frags.add(t.getProto());
+        frags.add(t.getProto(SerializeOption.GENERIC));
         fragmentMap.put(t.getTableName(), frags);
       }
     }

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskHistory.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskHistory.java
@@ -20,6 +20,7 @@ package org.apache.tajo.worker;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.ProtoObject;
@@ -106,13 +107,13 @@ public class TaskHistory implements ProtoObject<TaskHistoryProto>, History {
   public boolean equals(Object o) {
     if (o instanceof TaskHistory) {
       TaskHistory other = (TaskHistory) o;
-      return getProto().equals(other.getProto());
+      return getProto(SerializeOption.GENERIC).equals(other.getProto(SerializeOption.GENERIC));
     }
     return false;
   }
 
   @Override
-  public TaskHistoryProto getProto() {
+  public TaskHistoryProto getProto(SerializeOption option) {
     TaskHistoryProto.Builder builder = TaskHistoryProto.newBuilder();
     builder.setTaskAttemptId(taskAttemptId.getProto());
     builder.setState(state);

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskRunnerHistory.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskRunnerHistory.java
@@ -21,6 +21,7 @@ package org.apache.tajo.worker;
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.service.Service;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.TaskAttemptId;
 import org.apache.tajo.common.ProtoObject;
@@ -82,13 +83,13 @@ public class TaskRunnerHistory implements ProtoObject<TaskRunnerHistoryProto> {
   public boolean equals(Object o) {
     if (o instanceof TaskRunnerHistory) {
       TaskRunnerHistory other = (TaskRunnerHistory) o;
-      return getProto().equals(other.getProto());
+      return getProto(SerializeOption.GENERIC).equals(other.getProto(SerializeOption.GENERIC));
     }
     return false;
   }
 
   @Override
-  public TaskRunnerHistoryProto getProto() {
+  public TaskRunnerHistoryProto getProto(SerializeOption option) {
     TaskRunnerHistoryProto.Builder builder = TaskRunnerHistoryProto.newBuilder();
     builder.setContainerId(containerId.toString());
     builder.setState(state.toString());
@@ -96,7 +97,7 @@ public class TaskRunnerHistory implements ProtoObject<TaskRunnerHistoryProto> {
     builder.setStartTime(startTime);
     builder.setFinishTime(finishTime);
     for (TaskHistory taskHistory : taskHistoryMap.values()){
-      builder.addTaskHistories(taskHistory.getProto());
+      builder.addTaskHistories(taskHistory.getProto(option));
     }
     return builder.build();
   }

--- a/tajo-core/src/main/java/org/apache/tajo/worker/WorkerHeartbeatService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/WorkerHeartbeatService.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.AbstractService;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.ipc.QueryCoordinatorProtocol.ClusterResourceSummary;
 import org.apache.tajo.ipc.QueryCoordinatorProtocol.ServerStatusProto;
@@ -172,7 +173,7 @@ public class WorkerHeartbeatService extends AbstractService {
             .build();
 
         NodeHeartbeat heartbeatProto = NodeHeartbeat.newBuilder()
-            .setConnectionInfo(context.getConnectionInfo().getProto())
+            .setConnectionInfo(context.getConnectionInfo().getProto(SerializeOption.INTERNAL))
             .setServerStatus(serverStatus)
             .build();
 

--- a/tajo-core/src/test/java/org/apache/tajo/engine/eval/ExprTestBase.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/eval/ExprTestBase.java
@@ -20,6 +20,7 @@ package org.apache.tajo.engine.eval;
 
 import org.apache.tajo.LocalTajoTestingUtility;
 import org.apache.tajo.OverridableConf;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.SessionVars;
 import org.apache.tajo.TajoTestingCluster;
 import org.apache.tajo.algebra.Expr;
@@ -322,7 +323,7 @@ public class ExprTestBase {
   }
 
   public static void assertEvalTreeProtoSerDer(OverridableConf context, EvalNode evalNode) {
-    PlanProto.EvalNodeTree converted = EvalNodeSerializer.serialize(evalNode);
+    PlanProto.EvalNodeTree converted = EvalNodeSerializer.serialize(evalNode, SerializeOption.GENERIC);
     assertEquals(evalNode, EvalNodeDeserializer.deserialize(context, converted));
   }
 }

--- a/tajo-core/src/test/java/org/apache/tajo/engine/eval/TestEvalTree.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/eval/TestEvalTree.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.engine.eval;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.Schema;
@@ -355,7 +356,7 @@ public class TestEvalTree extends ExprTestBase {
     BinaryEval gth = new BinaryEval(EvalType.GTH, e3, plus3);
     assertCloneEqual(gth);
     
-    String json = gth.toJson();
+    String json = gth.toJson(SerializeOption.GENERIC);
     BinaryEval eval = (BinaryEval) CoreGsonHelper.fromJson(json, EvalNode.class);
     assertCloneEqual(eval);
     

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/TestLogicalPlanner.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/TestLogicalPlanner.java
@@ -21,6 +21,7 @@ package org.apache.tajo.engine.planner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.LocalTajoTestingUtility;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.TajoTestingCluster;
@@ -520,7 +521,7 @@ public class TestLogicalPlanner {
     for (Map.Entry<BinaryEval, Boolean> entry : qualMap.entrySet()) {
       if (!entry.getValue().booleanValue()) {
         Preconditions.checkArgument(false,
-            "JoinQual not found. -> required JoinQual:" + entry.getKey().toJson());
+            "JoinQual not found. -> required JoinQual:" + entry.getKey().toJson(SerializeOption.GENERIC));
       }
     }
   }
@@ -561,7 +562,7 @@ public class TestLogicalPlanner {
     for (Map.Entry<BinaryEval, Boolean> entry : qualMap.entrySet()) {
       if (!entry.getValue().booleanValue()) {
         Preconditions.checkArgument(false,
-            "SelectionQual not found. -> required JoinQual:" + entry.getKey().toJson());
+            "SelectionQual not found. -> required JoinQual:" + entry.getKey().toJson(SerializeOption.GENERIC));
       }
     }
   }
@@ -607,7 +608,7 @@ public class TestLogicalPlanner {
     for (Map.Entry<BinaryEval, Boolean> entry : qualMap.entrySet()) {
       if (!entry.getValue().booleanValue()) {
         Preconditions.checkArgument(false,
-            "ScanQual not found. -> required JoinQual:" + entry.getKey().toJson());
+            "ScanQual not found. -> required JoinQual:" + entry.getKey().toJson(SerializeOption.GENERIC));
       }
     }
   }
@@ -677,14 +678,14 @@ public class TestLogicalPlanner {
     for (Map.Entry<BinaryEval, Boolean> entry : joinQualMap.entrySet()) {
       if (!entry.getValue().booleanValue()) {
         Preconditions.checkArgument(false,
-            "JoinQual not found. -> required JoinQual:" + entry.getKey().toJson());
+            "JoinQual not found. -> required JoinQual:" + entry.getKey().toJson(SerializeOption.GENERIC));
       }
     }
 
     for (Map.Entry<BinaryEval, Boolean> entry : scanMap.entrySet()) {
       if (!entry.getValue().booleanValue()) {
         Preconditions.checkArgument(false,
-            "ScanQual not found. -> required JoinQual:" + entry.getKey().toJson());
+            "ScanQual not found. -> required JoinQual:" + entry.getKey().toJson(SerializeOption.GENERIC));
       }
     }
   }
@@ -817,7 +818,7 @@ public class TestLogicalPlanner {
 	  LogicalNode plan = planner.createPlan(qc, expr).getRootBlock().getRoot();
     testJsonSerDerObject(plan);
 
-	  String json = plan.toJson();
+	  String json = plan.toJson(SerializeOption.GENERIC);
 	  LogicalNode fromJson = CoreGsonHelper.fromJson(json, LogicalNode.class);
 	  assertEquals(NodeType.ROOT, fromJson.getType());
 	  LogicalNode project = ((LogicalRootNode)fromJson).getChild();
@@ -1098,7 +1099,7 @@ public class TestLogicalPlanner {
   }
 
   public void testJsonSerDerObject(LogicalNode rootNode) {
-    String json = rootNode.toJson();
+    String json = rootNode.toJson(SerializeOption.GENERIC);
     LogicalNode fromJson = CoreGsonHelper.fromJson(json, LogicalNode.class);
     assertTrue("JSON (de) serialization equivalence check", rootNode.deepEquals(fromJson));
   }

--- a/tajo-core/src/test/java/org/apache/tajo/master/TestRepartitioner.java
+++ b/tajo-core/src/test/java/org/apache/tajo/master/TestRepartitioner.java
@@ -20,6 +20,7 @@ package org.apache.tajo.master;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.LocalTajoTestingUtility;
 import org.apache.tajo.QueryId;
@@ -76,9 +77,9 @@ public class TestRepartitioner {
 
       fetch.setName(sid.toString());
 
-      TajoWorkerProtocol.FetchProto proto = fetch.getProto();
+      TajoWorkerProtocol.FetchProto proto = fetch.getProto(SerializeOption.GENERIC);
       fetch = new FetchImpl(proto);
-      assertEquals(proto, fetch.getProto());
+      assertEquals(proto, fetch.getProto(SerializeOption.GENERIC));
 
       Map<ExecutionBlockId, List<IntermediateEntry>> ebEntries = new HashMap<ExecutionBlockId, List<IntermediateEntry>>();
       ebEntries.put(sid, eachEntry.getValue());

--- a/tajo-core/src/test/java/org/apache/tajo/master/rm/TestTajoResourceManager.java
+++ b/tajo-core/src/test/java/org/apache/tajo/master/rm/TestTajoResourceManager.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.master.rm;
 
 import com.google.protobuf.RpcCallback;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.QueryIdFactory;
 import org.apache.tajo.conf.TajoConf;
@@ -96,7 +97,7 @@ public class TestTajoResourceManager {
       WorkerConnectionInfo connectionInfo =
           new WorkerConnectionInfo("host" + (i + 1), 28091, 28092, 21000 + i, 28093, 28080);
       NodeHeartbeat tajoHeartbeat = NodeHeartbeat.newBuilder()
-          .setConnectionInfo(connectionInfo.getProto())
+          .setConnectionInfo(connectionInfo.getProto(SerializeOption.GENERIC))
           .setServerStatus(serverStatus)
           .build();
 

--- a/tajo-core/src/test/java/org/apache/tajo/storage/TestFileFragment.java
+++ b/tajo-core/src/test/java/org/apache/tajo/storage/TestFileFragment.java
@@ -20,6 +20,7 @@ package org.apache.tajo.storage;
 
 import com.google.common.collect.Sets;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.storage.fragment.FileFragment;
 import org.apache.tajo.storage.fragment.FragmentConvertor;
 import org.apache.tajo.util.CommonTestingUtil;
@@ -54,7 +55,7 @@ public class TestFileFragment {
   public final void testGetProtoAndRestore() {
     FileFragment fragment = new FileFragment("table1_1", new Path(path, "table0"), 0, 500);
 
-    FileFragment fragment1 = FragmentConvertor.convert(FileFragment.class, fragment.getProto());
+    FileFragment fragment1 = FragmentConvertor.convert(FileFragment.class, fragment.getProto(SerializeOption.GENERIC));
     assertEquals("table1_1", fragment1.getTableName());
     assertEquals(new Path(path, "table0"), fragment1.getPath());
     assertTrue(0 == fragment1.getStartKey());

--- a/tajo-core/src/test/java/org/apache/tajo/storage/TestRowFile.java
+++ b/tajo-core/src/test/java/org/apache/tajo/storage/TestRowFile.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TajoTestingCluster;
 import org.apache.tajo.TpchTestBase;
 import org.apache.tajo.catalog.CatalogUtil;
@@ -77,7 +78,7 @@ public class TestRowFile {
     FileSystem fs = sm.getFileSystem();
     fs.mkdirs(tablePath);
 
-    FileUtil.writeProto(fs, metaPath, meta.getProto());
+    FileUtil.writeProto(fs, metaPath, meta.getProto(SerializeOption.GENERIC));
 
     Appender appender = sm.getAppender(meta, schema, dataPath);
     appender.enableStats();

--- a/tajo-core/src/test/java/org/apache/tajo/worker/TestHistory.java
+++ b/tajo-core/src/test/java/org/apache/tajo/worker/TestHistory.java
@@ -20,6 +20,7 @@ package org.apache.tajo.worker;
 
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.service.Service;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.TajoProtos;
 import org.apache.tajo.TajoTestingCluster;
 import org.apache.tajo.TaskAttemptId;
@@ -82,13 +83,13 @@ public class TestHistory {
 
     TaskRunnerHistory history = histories.iterator().next();
     assertEquals(Service.STATE.STOPPED, history.getState());
-    TaskRunnerHistory fromProto = new TaskRunnerHistory(history.getProto());
+    TaskRunnerHistory fromProto = new TaskRunnerHistory(history.getProto(SerializeOption.GENERIC));
     assertEquals(history.getExecutionBlockId(), fromProto.getExecutionBlockId());
     assertEquals(history.getFinishTime(), fromProto.getFinishTime());
     assertEquals(history.getStartTime(), fromProto.getStartTime());
     assertEquals(history.getState(), fromProto.getState());
     assertEquals(history.getContainerId(), fromProto.getContainerId());
-    assertEquals(history.getProto().getTaskHistoriesCount(), fromProto.getProto().getTaskHistoriesCount());
+    assertEquals(history.getProto(SerializeOption.GENERIC).getTaskHistoriesCount(), fromProto.getProto(SerializeOption.GENERIC).getTaskHistoriesCount());
   }
 
   @Test

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/Target.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/Target.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.plan;
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.common.TajoDataTypes.DataType;
@@ -126,12 +127,12 @@ public class Target implements Cloneable, GsonObject, ProtoObject<PlanProto.Targ
     return target;
   }
 
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return PlanGsonHelper.toJson(this, Target.class);
   }
 
   @Override
-  public PlanProto.Target getProto() {
-    return LogicalNodeSerializer.convertTarget(this);
+  public PlanProto.Target getProto(SerializeOption option) {
+    return LogicalNodeSerializer.convertTarget(this, option);
   }
 }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/CaseWhenEval.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/CaseWhenEval.java
@@ -21,6 +21,7 @@ package org.apache.tajo.plan.expr;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.Expose;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.common.TajoDataTypes.DataType;
@@ -279,7 +280,7 @@ public class CaseWhenEval extends EvalNode implements GsonObject {
     }
 
     @Override
-    public String toJson() {
+    public String toJson(SerializeOption option) {
       return PlanGsonHelper.toJson(IfThenEval.this, IfThenEval.class);
     }
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalNode.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.plan.expr;
 
 import com.google.gson.annotations.Expose;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.common.TajoDataTypes.DataType;
@@ -57,7 +58,7 @@ public abstract class EvalNode implements Cloneable, GsonObject, ProtoObject<Pla
 	public abstract String getName();
 
   @Override
-	public String toJson() {
+	public String toJson(SerializeOption option) {
     return PlanGsonHelper.toJson(this, EvalNode.class);
 	}
 
@@ -91,7 +92,7 @@ public abstract class EvalNode implements Cloneable, GsonObject, ProtoObject<Pla
   }
 
   @Override
-  public PlanProto.EvalNodeTree getProto() {
-    return EvalNodeSerializer.serialize(this);
+  public PlanProto.EvalNodeTree getProto(SerializeOption option) {
+    return EvalNodeSerializer.serialize(this, option);
   }
 }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/AggFunction.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/AggFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.plan.function;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.function.Function;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
@@ -48,7 +49,7 @@ public abstract class AggFunction<T extends Datum> extends Function<T> {
   public abstract T terminate(FunctionContext ctx);
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, AggFunction.class);
   }
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/GeneralFunction.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/GeneralFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.plan.function;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.OverridableConf;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
@@ -48,7 +49,7 @@ public abstract class GeneralFunction extends Function implements GsonObject {
 	}
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, GeneralFunction.class);
   }
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/WindowAggFunc.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/WindowAggFunc.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.plan.function;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Column;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos;
@@ -51,7 +52,7 @@ public abstract class WindowAggFunc<T extends Datum> extends AggFunction<T> {
   public abstract T terminate(FunctionContext ctx);
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return CatalogGsonHelper.toJson(this, WindowAggFunc.class);
   }
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/LogicalNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/LogicalNode.java
@@ -23,6 +23,7 @@ package org.apache.tajo.plan.logical;
 
 import com.google.gson.annotations.Expose;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.json.GsonObject;
 import org.apache.tajo.plan.PlanString;
@@ -132,7 +133,7 @@ public abstract class LogicalNode implements Cloneable, GsonObject {
 	}
 
   @Override
-  public String toJson() {
+  public String toJson(SerializeOption option) {
     return PlanGsonHelper.toJson(this, LogicalNode.class);
   }
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/LogicalPlanEqualityTester.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/LogicalPlanEqualityTester.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.plan.rewrite.rules;
 
 import org.apache.tajo.OverridableConf;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.plan.LogicalPlan;
 import org.apache.tajo.plan.PlanningException;
 import org.apache.tajo.plan.logical.LogicalNode;
@@ -47,7 +48,7 @@ public class LogicalPlanEqualityTester implements LogicalPlanRewriteRule {
   @Override
   public LogicalPlan rewrite(OverridableConf queryContext, LogicalPlan plan) throws PlanningException {
     LogicalNode root = plan.getRootBlock().getRoot();
-    PlanProto.LogicalNodeTree serialized = LogicalNodeSerializer.serialize(plan.getRootBlock().getRoot());
+    PlanProto.LogicalNodeTree serialized = LogicalNodeSerializer.serialize(root, SerializeOption.GENERIC);
     LogicalNode deserialized = LogicalNodeDeserializer.deserialize(queryContext, serialized);
     assert root.deepEquals(deserialized);
     return plan;

--- a/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/BaseTupleComparator.java
+++ b/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/BaseTupleComparator.java
@@ -18,12 +18,14 @@
 
 package org.apache.tajo.storage;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.SortSpec;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.datum.Datum;
+
+import java.util.Arrays;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.TupleComparatorSpecProto;
 import static org.apache.tajo.index.IndexProtos.TupleComparatorProto;
@@ -145,7 +147,7 @@ public class BaseTupleComparator extends TupleComparator implements ProtoObject<
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(sortKeyIds);
+    return Arrays.hashCode(sortKeyIds);
   }
 
   @Override
@@ -171,11 +173,11 @@ public class BaseTupleComparator extends TupleComparator implements ProtoObject<
   }
 
   @Override
-  public TupleComparatorProto getProto() {
+  public TupleComparatorProto getProto(SerializeOption option) {
     TupleComparatorProto.Builder builder = TupleComparatorProto.newBuilder();
-    builder.setSchema(schema.getProto());
+    builder.setSchema(schema.getProto(option));
     for (int i = 0; i < sortSpecs.length; i++) {
-      builder.addSortSpecs(sortSpecs[i].getProto());
+      builder.addSortSpecs(sortSpecs[i].getProto(option));
     }
 
     TupleComparatorSpecProto.Builder sortSpecBuilder;

--- a/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/fragment/Fragment.java
+++ b/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/fragment/Fragment.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.storage.fragment;
 
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.common.ProtoObject;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.FragmentProto;
@@ -27,7 +28,7 @@ public interface Fragment extends ProtoObject<FragmentProto> {
   public abstract String getTableName();
 
   @Override
-  public abstract FragmentProto getProto();
+  public abstract FragmentProto getProto(SerializeOption option);
 
   public abstract long getLength();
 

--- a/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/fragment/FragmentConvertor.java
+++ b/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/fragment/FragmentConvertor.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.annotation.ThreadSafe;
 
 import java.io.IOException;
@@ -111,19 +112,19 @@ public class FragmentConvertor {
     return list;
   }
 
-  public static List<FragmentProto> toFragmentProtoList(Fragment... fragments) {
+  public static List<FragmentProto> toFragmentProtoList(SerializeOption option, Fragment... fragments) {
     List<FragmentProto> list = Lists.newArrayList();
     if (fragments == null) {
       return list;
     }
     for (Fragment fragment : fragments) {
-      list.add(fragment.getProto());
+      list.add(fragment.getProto(option));
     }
     return list;
   }
 
-  public static FragmentProto [] toFragmentProtoArray(Fragment... fragments) {
-    List<FragmentProto> list = toFragmentProtoList(fragments);
+  public static FragmentProto [] toFragmentProtoArray(SerializeOption option, Fragment... fragments) {
+    List<FragmentProto> list = toFragmentProtoList(option, fragments);
     return list.toArray(new FragmentProto[list.size()]);
   }
 }

--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseFragment.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseFragment.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.Expose;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.proto.CatalogProtos.FragmentProto;
 import org.apache.tajo.catalog.proto.CatalogProtos.StoreType;
@@ -144,7 +145,7 @@ public class HBaseFragment implements Fragment, Comparable<HBaseFragment>, Clone
   }
 
   @Override
-  public FragmentProto getProto() {
+  public FragmentProto getProto(SerializeOption option) {
     HBaseFragmentProto.Builder builder = HBaseFragmentProto.newBuilder();
     builder.setTableName(tableName)
         .setHbaseTableName(hbaseTableName)

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.proto.CatalogProtos.StoreType;
 import org.apache.tajo.storage.StorageFragmentProtos.*;
@@ -211,7 +212,7 @@ public class FileFragment implements Fragment, Comparable<FileFragment>, Cloneab
         + getLength() + "}" ;
   }
 
-  public FragmentProto getProto() {
+  public FragmentProto getProto(SerializeOption option) {
     FileFragmentProto.Builder builder = FileFragmentProto.newBuilder();
     builder.setId(this.tableName);
     builder.setStartOffset(this.startOffset);

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/index/bst/BSTIndex.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/index/bst/BSTIndex.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.tajo.SerializeOption;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.proto.CatalogProtos.SchemaProto;
 import org.apache.tajo.storage.*;
@@ -147,12 +148,12 @@ public class BSTIndex implements IndexMethod {
 
     public void writeHeader(int entryNum) throws IOException {
       // schema
-      byte [] schemaBytes = keySchema.getProto().toByteArray();
+      byte [] schemaBytes = keySchema.getProto(SerializeOption.GENERIC).toByteArray();
       out.writeInt(schemaBytes.length);
       out.write(schemaBytes);
 
       // comparator
-      byte [] comparatorBytes = compartor.getProto().toByteArray();
+      byte [] comparatorBytes = compartor.getProto(SerializeOption.GENERIC).toByteArray();
       out.writeInt(comparatorBytes.length);
       out.write(comparatorBytes);
 


### PR DESCRIPTION
Considered to use node visitor, but seemed better not to modify internal shape of the plan. All modifications are just for doing,

```java
@Override
public FunctionSupplementProto getProto(SerializeOption option) {
  FunctionSupplementProto.Builder builder = FunctionSupplementProto.newBuilder();
  if (shortDescription != null && option != SerializeOption.INTERNAL) {
    builder.setShortDescription(shortDescription);
  }
  if (detail != null && option != SerializeOption.INTERNAL) {
    builder.setDetail(detail);
  }
  if (example != null && option != SerializeOption.INTERNAL) {
    builder.setExample(example);
  }
  return builder.build();
}
```