### PR TITLE
TAJO-1570 CatalogUtil newSimpleDataTypeArray should use newSimpleDataType

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
@@ -362,7 +362,7 @@ public class CatalogUtil {
   public static DataType [] newSimpleDataTypeArray(Type... types) {
     DataType [] dataTypes = new DataType[types.length];
     for (int i = 0; i < types.length; i++) {
-      dataTypes[i] = DataType.newBuilder().setType(types[i]).build();
+      dataTypes[i] = newSimpleDataType(types[i]);
     }
     return dataTypes;
   }


### PR DESCRIPTION
It is better CatalogUtil's newSimpleDataTypeArray method use newSimpleDataType. Because their purpose is the same. 
and it is efficient when someone change newSimpleDataType method.
```java
public static DataType [] newSimpleDataTypeArray(Type... types) {
DataType [] dataTypes = new DataType[types.length];
for (int i = 0; i < types.length; i++)
{ dataTypes[i] = DataType.newBuilder().setType(types[i]).build(); }
return dataTypes;
}
```