### PR TITLE
TAJO-1576: Sometimes DefaultTajoCliOutputFormatter.parseErrorMessage() eliminates an important kind of information

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/DefaultTajoCliOutputFormatter.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/DefaultTajoCliOutputFormatter.java
@@ -196,10 +196,8 @@ public class DefaultTajoCliOutputFormatter implements TajoCliOutputFormatter {
     if (message == null) {
       return TajoCli.ERROR_PREFIX + "No error message";
     }
-    String[] lines = message.split("\n");
-    message = lines[0];
 
-    int index = message.lastIndexOf(TajoCli.ERROR_PREFIX);
+    int index = message.indexOf(TajoCli.ERROR_PREFIX);
     if (index < 0) {
       message = TajoCli.ERROR_PREFIX + message;
     } else {

--- a/tajo-core/src/test/java/org/apache/tajo/cli/tsql/TestDefaultCliOutputFormatter.java
+++ b/tajo-core/src/test/java/org/apache/tajo/cli/tsql/TestDefaultCliOutputFormatter.java
@@ -101,7 +101,10 @@ public class TestDefaultCliOutputFormatter {
         "\tat org.apache.tajo.rpc.ServerCallable.withRetries(ServerCallable.java:97)\n" +
         "\t... 6 more";
 
-    assertEquals("ERROR: no such a table: table1", DefaultTajoCliOutputFormatter.parseErrorMessage(multiLineMessage));
+    assertEquals(multiLineMessage, DefaultTajoCliOutputFormatter.parseErrorMessage(multiLineMessage));
+
+    String noPrefixMessage = "RTFM please";
+    assertEquals("ERROR: "+noPrefixMessage, DefaultTajoCliOutputFormatter.parseErrorMessage(noPrefixMessage));
   }
 
   @Test


### PR DESCRIPTION
After the patch is merged, some syntax error message is displayed like the following.

Before the patch :
```
ERROR: syntax error at or near '('
```
After the patch: 
```
ERROR: syntax error at or near '('
LINE 31:4      (select *
               ^
```