### PR TITLE
TAJO-1598 TableMeta should change equals mechanism

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableMeta.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/TableMeta.java
@@ -136,8 +136,10 @@ public class TableMeta implements ProtoObject<CatalogProtos.TableProto>, GsonObj
 	public boolean equals(Object object) {
 		if(object instanceof TableMeta) {
 			TableMeta other = (TableMeta) object;
-			
-			return this.getProto().equals(other.getProto());
+
+			boolean eq = this.getStoreType().equals(other.getStoreType());
+			eq = eq && this.getOptions().equals(other.getOptions());
+			return eq;
 		}
 		
 		return false;		

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestTableMeta.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestTableMeta.java
@@ -22,6 +22,7 @@ import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos.StoreType;
 import org.apache.tajo.catalog.proto.CatalogProtos.TableProto;
 import org.apache.tajo.common.TajoDataTypes.Type;
+import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,6 +87,32 @@ public class TestTableMeta {
     assertTrue(meta.equals(meta2));
     assertNotSame(meta, meta2);
   }
+
+	@Test
+	public void testEqualsObject2() {
+		//This testcases should insert more 2 items into one slot.
+		//HashMap's default slot count is 16
+		//so max_count is 17
+
+		int MAX_COUNT = 17;
+
+		TableMeta meta1 = CatalogUtil.newTableMeta(StoreType.CSV.toString());
+		for (int i = 0; i < MAX_COUNT; i++) {
+			meta1.putOption("key"+i, "value"+i);
+		}
+
+		PrimitiveProtos.KeyValueSetProto.Builder optionBuilder = PrimitiveProtos.KeyValueSetProto.newBuilder();
+		for (int i = 1; i <= MAX_COUNT; i++) {
+			PrimitiveProtos.KeyValueProto.Builder keyValueBuilder = PrimitiveProtos.KeyValueProto.newBuilder();
+			keyValueBuilder.setKey("key"+(MAX_COUNT-i)).setValue("value"+(MAX_COUNT-i));
+			optionBuilder.addKeyval(keyValueBuilder);
+		}
+		TableProto.Builder builder = TableProto.newBuilder();
+		builder.setStoreType(StoreType.CSV.toString());
+		builder.setParams(optionBuilder);
+		TableMeta meta2 = new TableMeta(builder.build());
+		assertTrue(meta1.equals(meta2));
+	}
   
   @Test
   public void testGetProto() {


### PR DESCRIPTION
In TableMeta equals, it compares Proto Data.
but TableMetaProto has params as KeyValueSetProto. 
It has a KeyValue Data as List.
but it can cause comparison error. becuase list type compare items' order and value. but we should compare params like map.
so this patch change compare machanism. compare storeType and Options