### PR TITLE
TAJO-1607 Tajo Rest Cache-Id should be bigger than zero

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/ClientApplication.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/ClientApplication.java
@@ -95,7 +95,11 @@ public class ClientApplication extends Application {
     for (byte generatedByte: generatedBytes) {
       generatedId = (generatedId << 8) + (generatedByte & 0xff);
     }
-    
+
+    if (generatedId < 0) {
+      generatedId = generatedId * -1;
+    }
+
     return generatedId;
   }
   


### PR DESCRIPTION
currently, tajo rest api can return cache-id that is smaller than 0.
but it is not beautiful, so I think it is better cache id is begger than 0
```
{'link': 'http://127.0.0.1:26880/rest/databases/default/queries/q_1431795664397_0008/result/-2197002215675989303', 'id': -2197002215675989303}
```