### PR TITLE
TAJO-1618 [Rest API] queries/{queryId} should set default print type

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResource.java
@@ -18,28 +18,6 @@
 
 package org.apache.tajo.ws.rs.resources;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.QueryId;
@@ -54,12 +32,17 @@ import org.apache.tajo.querymaster.QueryJobEvent;
 import org.apache.tajo.session.InvalidSessionException;
 import org.apache.tajo.session.Session;
 import org.apache.tajo.util.TajoIdUtils;
-import org.apache.tajo.ws.rs.JerseyResourceDelegate;
-import org.apache.tajo.ws.rs.JerseyResourceDelegateContext;
-import org.apache.tajo.ws.rs.JerseyResourceDelegateContextKey;
-import org.apache.tajo.ws.rs.JerseyResourceDelegateUtil;
-import org.apache.tajo.ws.rs.ResourcesUtil;
+import org.apache.tajo.ws.rs.*;
 import org.apache.tajo.ws.rs.requests.SubmitQueryRequest;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Path("/databases/{databaseName}/queries")
 public class QueryResource {
@@ -87,7 +70,9 @@ public class QueryResource {
   private static final String submitQueryRequestKeyName = "submitQueryRequest";
   private static final String printTypeKeyName = "printType";
   private static final String queryIdKeyName = "queryId";
-  
+
+  private static final String defaultQueryInfoPrintType = "COMPLICATED";
+
   private void initializeContext() {
     context = new JerseyResourceDelegateContext();
     JerseyResourceDelegateContextKey<UriInfo> uriInfoKey =
@@ -311,7 +296,8 @@ public class QueryResource {
   @GET
   @Path("{queryId}")
   @Produces(MediaType.APPLICATION_JSON)
-  public Response getQuery(@PathParam("queryId") String queryId, @QueryParam("print") String printType) {
+  public Response getQuery(@PathParam("queryId") String queryId,
+													 @DefaultValue(defaultQueryInfoPrintType) @QueryParam("print") String printType) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Client sent a get query request.");
     }
@@ -325,6 +311,7 @@ public class QueryResource {
       context.put(queryIdKey, queryId);
       JerseyResourceDelegateContextKey<String> printTypeKey =
           JerseyResourceDelegateContextKey.valueOf(printTypeKeyName, String.class);
+
       context.put(printTypeKey, printType);
       
       response = JerseyResourceDelegateUtil.runJerseyResourceDelegate(

--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
@@ -260,7 +260,7 @@ public class QueryResultResource {
   public Response getQueryResultSet(@HeaderParam(QueryResource.tajoSessionIdHeaderName) String sessionId,
       @PathParam("cacheId") String cacheId,
       @DefaultValue("-1") @QueryParam("offset") int offset,
-      @DefaultValue("-1") @QueryParam("count") int count) {
+      @DefaultValue("100") @QueryParam("count") int count) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Client sent a get query result set request.");
     }

--- a/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResource.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResource.java
@@ -18,18 +18,7 @@
 
 package org.apache.tajo.ws.rs.resources;
 
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
+import com.google.gson.internal.StringMap;
 import org.apache.tajo.QueryTestCaseBase;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.conf.TajoConf.ConfVars;
@@ -45,7 +34,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.gson.internal.StringMap;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -106,7 +104,7 @@ public class TestQueryResource extends QueryTestCaseBase {
   public void testGetAllQueries() throws Exception {
     String sessionId = generateNewSessionAndGetId();
     SubmitQueryRequest queryRequest = createNewQueryRequest("select * from lineitem");
-    
+
     Response response = restClient.target(queriesURI)
         .request().header(tajoSessionIdHeaderName, sessionId)
         .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON));
@@ -143,7 +141,7 @@ public class TestQueryResource extends QueryTestCaseBase {
   public void testSubmitQuery() throws Exception {
     String sessionId = generateNewSessionAndGetId();
     SubmitQueryRequest queryRequest = createNewQueryRequest("select * from lineitem");
-    
+
     Response response = restClient.target(queriesURI)
         .request().header(tajoSessionIdHeaderName, sessionId)
         .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON));
@@ -164,6 +162,34 @@ public class TestQueryResource extends QueryTestCaseBase {
         .queryParam("print", "BRIEF")
         .request().get(new GenericType<QueryInfo>(QueryInfo.class));
     
+    assertNotNull(queryInfo);
+    assertEquals(queryId, queryInfo.getQueryIdStr());
+  }
+
+  @Test
+  public void testGetQueryInfoWithDefault() throws Exception {
+    String sessionId = generateNewSessionAndGetId();
+    SubmitQueryRequest queryRequest = createNewQueryRequest("select * from lineitem");
+
+    Response response = restClient.target(queriesURI)
+      .request().header(tajoSessionIdHeaderName, sessionId)
+      .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON));
+
+    assertNotNull(response);
+    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+    String locationHeader = response.getHeaderString("Location");
+    assertTrue(locationHeader != null && !locationHeader.isEmpty());
+
+    String queryId = locationHeader.lastIndexOf('/') >= 0?
+      locationHeader.substring(locationHeader.lastIndexOf('/')+1):null;
+
+    assertTrue(queryId != null && !queryId.isEmpty());
+
+    QueryInfo queryInfo = restClient.target(queriesURI)
+      .path("/{queryId}")
+      .resolveTemplate("queryId", queryId)
+      .request().get(new GenericType<QueryInfo>(QueryInfo.class));
+
     assertNotNull(queryInfo);
     assertEquals(queryId, queryInfo.getQueryIdStr());
   }


### PR DESCRIPTION
currently REST API /queries/
{queryId} cause error without print parameter.
and submit query just return url of /queries/{queryId}
without print type.
so I think it is better to set default print type when users don't pass print querystring.