### PR TITLE
TAJO-1627 Rest API should support this type of query "select 1"

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/responses/GetDirectQueryResultResponse.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/responses/GetDirectQueryResultResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.ws.rs.responses;
+
+import com.google.gson.annotations.Expose;
+import org.apache.tajo.catalog.Schema;
+import org.apache.tajo.ipc.ClientProtos;
+
+import java.util.List;
+
+public class GetDirectQueryResultResponse {
+  @Expose private ClientProtos.ResultCode resultCode;
+  @Expose private Schema schema;
+  @Expose private List<String> serializedTupes;
+
+  public ClientProtos.ResultCode getResultCode() {
+    return resultCode;
+  }
+
+  public void setResultCode(ClientProtos.ResultCode resultCode) {
+    this.resultCode = resultCode;
+  }
+
+  public Schema getSchema() {
+    return schema;
+  }
+
+  public void setSchema(Schema schema) {
+    this.schema = schema;
+  }
+
+  public List<String> getSerializedTupes() {
+    return serializedTupes;
+  }
+
+  public void setSerializedTupes(List<String> serializedTupes) {
+    this.serializedTupes = serializedTupes;
+  }
+}


### PR DESCRIPTION
Currently, Tajo Rest API supports well "select * from table" or "select count from table" <-- normal type
but, Tajo Rest API couldn't support this type of query like "select 1" <-- direct return type
to solve this, queries api should support resultset also.
so I suggest this.
queries return 201 Created when it is normal type of query
and query is direct query type and return 200 with result
like this (direct return type)
{"resultCode":"OK","schema":{"fields":[{"name":"?number","typeDesc":{"dataType":
{"type":"INT4"}
}}],"fieldsByQualifiedName":
{"?number":0}
,"fieldsByName":{"?number":[0]}},"serializedTupes":["AAAAAAE\u003d"]}