### PR TITLE
TAJO-1630: Test failure after TAJO-1130

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/MasterPlan.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/MasterPlan.java
@@ -237,13 +237,13 @@ public class MasterPlan {
     sb.append("Order of Execution\n");
     sb.append("-------------------------------------------------------------------------------");
     int order = 1;
-    for (ExecutionBlock currentEB : cursor) {
+    for (ExecutionBlock currentEB : executionOrderCursor) {
       sb.append("\n").append(order).append(": ").append(currentEB.getId());
       order++;
     }
     sb.append("\n-------------------------------------------------------------------------------\n");
 
-    for (ExecutionBlock block : cursor) {
+    for (ExecutionBlock block : executionOrderCursor) {
 
       boolean terminal = false;
       sb.append("\n");

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestOuterJoinQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestOuterJoinQuery.java
@@ -285,7 +285,7 @@ public class TestOuterJoinQuery extends TestJoinQuery {
   }
 
   @Test
-  @Option(withExplain = true, withExplainGlobal = true, parameterized = true)
+  @Option(withExplain = true, withExplainGlobal = true, parameterized = true, sort = true)
   @SimpleTest(queries = {
       @QuerySpec("select t1.id, t1.name, t2.id, t3.id\n" +
           "from jointable11 t1\n" +

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestOuterJoinQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestOuterJoinQuery.java
@@ -220,7 +220,7 @@ public class TestOuterJoinQuery extends TestJoinQuery {
   }
 
   @Test
-  @Option(withExplain = true, withExplainGlobal = true, parameterized = true)
+  @Option(withExplain = true, withExplainGlobal = true, parameterized = true, sort = true)
   @SimpleTest(queries = {
       @QuerySpec("select t1.id, t1.name, t2.id, t3.id\n" +
           "from jointable11 t1\n" +
@@ -269,7 +269,7 @@ public class TestOuterJoinQuery extends TestJoinQuery {
   }
 
   @Test
-  @Option(withExplain = true, withExplainGlobal = true, parameterized = true)
+  @Option(withExplain = true, withExplainGlobal = true, parameterized = true, sort = true)
   @SimpleTest(queries = {
       @QuerySpec("select t1.id, t1.name, t2.id, t3.id\n" +
           "from jointable11 t1\n" +
@@ -301,7 +301,7 @@ public class TestOuterJoinQuery extends TestJoinQuery {
   }
 
   @Test
-  @Option(withExplain = true, withExplainGlobal = true, parameterized = true)
+  @Option(withExplain = true, withExplainGlobal = true, parameterized = true, sort = true)
   @SimpleTest(queries = {
       @QuerySpec("select t1.id, t1.name, t2.id, t3.id\n" +
           "from jointable11 t1\n" +
@@ -335,7 +335,7 @@ public class TestOuterJoinQuery extends TestJoinQuery {
   }
 
   @Test
-  @Option(withExplain = true, withExplainGlobal = true, parameterized = true)
+  @Option(withExplain = true, withExplainGlobal = true, parameterized = true, sort = true)
   @SimpleTest(queries = {
       @QuerySpec("select t1.id, t1.name, t2.id\n" +
           "from jointable11 t1\n" +
@@ -399,7 +399,7 @@ public class TestOuterJoinQuery extends TestJoinQuery {
 
   // TODO: this test is disabled due to a bug in broadcast join. It will be enabled after TAJO-1553
   @Test
-  @Option(withExplain = true, withExplainGlobal = true, parameterized = true)
+  @Option(withExplain = true, withExplainGlobal = true, parameterized = true, sort = true)
   @SimpleTest(queries = {
       @QuerySpec("select t1.id, t1.name, t3.id, t4.id\n" +
           "from jointable11 t1\n" +

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Hash_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(2) on default.part
   => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.lineitem.l_partkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.orders.o_custkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.lineitem.l_partkey (INT4) = default.part.p_partkey (INT4)
-  => target list: default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)
-  => out schema: {(3) default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)}
-  => in schema: {(5) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT), default.part.p_partkey (INT4)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
-     => in schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
-     => in schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(3) on default.customer
   => target list: default.customer.c_custkey (INT4), default.customer.c_nationkey (INT4)
   => out schema: {(2) default.customer.c_custkey (INT4), default.customer.c_nationkey (INT4)}
   => in schema: {(8) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.lineitem.l_partkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.orders.o_custkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.lineitem.l_partkey (INT4) = default.part.p_partkey (INT4)
+  => target list: default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)
+  => out schema: {(3) default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)}
+  => in schema: {(5) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT), default.part.p_partkey (INT4)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
+     => in schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
+     => in schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Sort_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(2) on default.part
   => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.lineitem.l_partkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.orders.o_custkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.lineitem.l_partkey (INT4) = default.part.p_partkey (INT4)
-  => target list: default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)
-  => out schema: {(3) default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)}
-  => in schema: {(5) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT), default.part.p_partkey (INT4)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
-     => in schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
-     => in schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(3) on default.customer
   => target list: default.customer.c_custkey (INT4), default.customer.c_nationkey (INT4)
   => out schema: {(2) default.customer.c_custkey (INT4), default.customer.c_nationkey (INT4)}
   => in schema: {(8) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.lineitem.l_partkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.orders.o_custkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.lineitem.l_partkey (INT4) = default.part.p_partkey (INT4)
+  => target list: default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)
+  => out schema: {(3) default.lineitem.l_orderkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT)}
+  => in schema: {(5) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4), default.part.p_name (TEXT), default.part.p_partkey (INT4)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
+     => in schema: {(2) default.part.p_name (TEXT), default.part.p_partkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
+     => in schema: {(3) default.lineitem.l_orderkey (INT4), default.lineitem.l_partkey (INT4), default.orders.o_custkey (INT4)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Hash_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(4) on default.region
   => in schema: {(3) default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.nation.n_regionkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.region.r_regionkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=joins.supplier_.s_suppkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
-  => target list: default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)
-  => out schema: {(7) default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-  => in schema: {(9) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(1) default.region.r_regionkey (INT4)}
-     => in schema: {(1) default.region.r_regionkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-     => in schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(2) on default.partsupp
   => target list: default.partsupp.ps_partkey (INT4), default.partsupp.ps_suppkey (INT4)
   => out schema: {(2) default.partsupp.ps_partkey (INT4), default.partsupp.ps_suppkey (INT4)}
   => in schema: {(5) default.partsupp.ps_availqty (INT4), default.partsupp.ps_comment (TEXT), default.partsupp.ps_partkey (INT4), default.partsupp.ps_suppkey (INT4), default.partsupp.ps_supplycost (FLOAT8)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.nation.n_regionkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.region.r_regionkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=joins.supplier_.s_suppkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
+  => target list: default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)
+  => out schema: {(7) default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
+  => in schema: {(9) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(1) default.region.r_regionkey (INT4)}
+     => in schema: {(1) default.region.r_regionkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
+     => in schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Sort_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(4) on default.region
   => in schema: {(3) default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.nation.n_regionkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.region.r_regionkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=joins.supplier_.s_suppkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
-  => target list: default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)
-  => out schema: {(7) default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-  => in schema: {(9) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(1) default.region.r_regionkey (INT4)}
-     => in schema: {(1) default.region.r_regionkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-     => in schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(2) on default.partsupp
   => target list: default.partsupp.ps_partkey (INT4), default.partsupp.ps_suppkey (INT4)
   => out schema: {(2) default.partsupp.ps_partkey (INT4), default.partsupp.ps_suppkey (INT4)}
   => in schema: {(5) default.partsupp.ps_availqty (INT4), default.partsupp.ps_comment (TEXT), default.partsupp.ps_partkey (INT4), default.partsupp.ps_suppkey (INT4), default.partsupp.ps_supplycost (FLOAT8)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.nation.n_regionkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.region.r_regionkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=joins.supplier_.s_suppkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
+  => target list: default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)
+  => out schema: {(7) default.nation.n_name (TEXT), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
+  => in schema: {(9) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(1) default.region.r_regionkey (INT4)}
+     => in schema: {(1) default.region.r_regionkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
+     => in schema: {(8) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT), joins.supplier_.s_suppkey (INT4)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Hash_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(7) on default.part as p
   => in schema: {(9) default.p.p_brand (TEXT), default.p.p_comment (TEXT), default.p.p_container (TEXT), default.p.p_mfgr (TEXT), default.p.p_name (TEXT), default.p.p_partkey (INT4), default.p.p_retailprice (FLOAT8), default.p.p_size (INT4), default.p.p_type (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.ps.ps_partkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.p.p_partkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), default.s.s_nationkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.p.p_partkey (INT4) = default.ps.ps_partkey (INT4)
-  => target list: default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)
-  => out schema: {(9) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-  => in schema: {(10) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
-     => in schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-     => in schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(1) on default.region as r
   => target list: default.r.r_regionkey (INT4)
   => out schema: {(1) default.r.r_regionkey (INT4)}
   => in schema: {(3) default.r.r_comment (TEXT), default.r.r_name (TEXT), default.r.r_regionkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.ps.ps_partkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.p.p_partkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), default.s.s_nationkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.p.p_partkey (INT4) = default.ps.ps_partkey (INT4)
+  => target list: default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)
+  => out schema: {(9) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
+  => in schema: {(10) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
+     => in schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
+     => in schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Sort_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(7) on default.part as p
   => in schema: {(9) default.p.p_brand (TEXT), default.p.p_comment (TEXT), default.p.p_container (TEXT), default.p.p_mfgr (TEXT), default.p.p_name (TEXT), default.p.p_partkey (INT4), default.p.p_retailprice (FLOAT8), default.p.p_size (INT4), default.p.p_type (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.ps.ps_partkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.p.p_partkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), default.s.s_nationkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.p.p_partkey (INT4) = default.ps.ps_partkey (INT4)
-  => target list: default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)
-  => out schema: {(9) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-  => in schema: {(10) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
-     => in schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-     => in schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(1) on default.region as r
   => target list: default.r.r_regionkey (INT4)
   => out schema: {(1) default.r.r_regionkey (INT4)}
   => in schema: {(3) default.r.r_comment (TEXT), default.r.r_name (TEXT), default.r.r_regionkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.ps.ps_partkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.p.p_partkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), default.s.s_nationkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.p.p_partkey (INT4) = default.ps.ps_partkey (INT4)
+  => target list: default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)
+  => out schema: {(9) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
+  => in schema: {(10) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
+     => in schema: {(2) default.p.p_mfgr (TEXT), default.p.p_partkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
+     => in schema: {(8) default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Hash_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(0) on default.part
   => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.partsupp.ps_partkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
-  => target list: default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)
-  => out schema: {(8) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-  => in schema: {(9) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
-     => in schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-     => in schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(4) on default.region
   => target list: default.region.r_regionkey (INT4)
   => out schema: {(1) default.region.r_regionkey (INT4)}
   => in schema: {(3) default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.partsupp.ps_partkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
+  => target list: default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)
+  => out schema: {(8) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+  => in schema: {(9) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
+     => in schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+     => in schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Sort_NoBroadcast.plan
@@ -134,29 +134,6 @@ SCAN(0) on default.part
   => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.partsupp.ps_partkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
-
-JOIN(14)(INNER)
-  => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
-  => target list: default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)
-  => out schema: {(8) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-  => in schema: {(9) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-   SCAN(21) on eb_0000000000000_0000_000004
-     => out schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
-     => in schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
-   SCAN(20) on eb_0000000000000_0000_000003
-     => out schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-     => in schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(4) on default.region
   => target list: default.region.r_regionkey (INT4)
   => out schema: {(1) default.region.r_regionkey (INT4)}
   => in schema: {(3) default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.partsupp.ps_partkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
+
+JOIN(14)(INNER)
+  => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
+  => target list: default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)
+  => out schema: {(8) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+  => in schema: {(9) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+   SCAN(21) on eb_0000000000000_0000_000004
+     => out schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
+     => in schema: {(2) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4)}
+   SCAN(20) on eb_0000000000000_0000_000003
+     => out schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+     => in schema: {(7) default.partsupp.ps_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery2.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery2.Hash_NoBroadcast.plan
@@ -160,6 +160,30 @@ GROUP_BY(27)(l_orderkey)
               => in schema: {(3) default.a.l_orderkey (INT4), default.a.l_partkey (INT4), default.a.l_quantity (FLOAT8)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000005 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 7 (type=HASH_SHUFFLE, key=default.d.l_partkey (INT4), num=32)
+
+SCAN(7) on default.lineitem as d
+  => target list: default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)
+  => out schema: {(3) default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)}
+  => in schema: {(16) default.d.l_comment (TEXT), default.d.l_commitdate (TEXT), default.d.l_discount (FLOAT8), default.d.l_extendedprice (FLOAT8), default.d.l_linenumber (INT4), default.d.l_linestatus (TEXT), default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8), default.d.l_receiptdate (TEXT), default.d.l_returnflag (TEXT), default.d.l_shipdate (TEXT), default.d.l_shipinstruct (TEXT), default.d.l_shipmode (TEXT), default.d.l_suppkey (INT4), default.d.l_tax (FLOAT8)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000006 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 6 => 7 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
+
+SCAN(8) on default.part
+  => target list: default.part.p_partkey (INT4)
+  => out schema: {(1) default.part.p_partkey (INT4)}
+  => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 =======================================================
 
@@ -185,30 +209,6 @@ TABLE_SUBQUERY(14) as default.f
          SCAN(28) on eb_0000000000000_0000_000003
            => out schema: {(2) default.e.l_orderkey (INT4), ?avg_11 (PROTOBUF)}
            => in schema: {(2) default.e.l_orderkey (INT4), ?avg_11 (PROTOBUF)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000005 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 7 (type=HASH_SHUFFLE, key=default.d.l_partkey (INT4), num=32)
-
-SCAN(7) on default.lineitem as d
-  => target list: default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)
-  => out schema: {(3) default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)}
-  => in schema: {(16) default.d.l_comment (TEXT), default.d.l_commitdate (TEXT), default.d.l_discount (FLOAT8), default.d.l_extendedprice (FLOAT8), default.d.l_linenumber (INT4), default.d.l_linestatus (TEXT), default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8), default.d.l_receiptdate (TEXT), default.d.l_returnflag (TEXT), default.d.l_shipdate (TEXT), default.d.l_shipinstruct (TEXT), default.d.l_shipmode (TEXT), default.d.l_suppkey (INT4), default.d.l_tax (FLOAT8)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000006 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 6 => 7 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
-
-SCAN(8) on default.part
-  => target list: default.part.p_partkey (INT4)
-  => out schema: {(1) default.part.p_partkey (INT4)}
-  => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery2.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery2.Sort_NoBroadcast.plan
@@ -160,6 +160,30 @@ GROUP_BY(27)(l_orderkey)
               => in schema: {(3) default.a.l_orderkey (INT4), default.a.l_partkey (INT4), default.a.l_quantity (FLOAT8)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000005 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 7 (type=HASH_SHUFFLE, key=default.d.l_partkey (INT4), num=32)
+
+SCAN(7) on default.lineitem as d
+  => target list: default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)
+  => out schema: {(3) default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)}
+  => in schema: {(16) default.d.l_comment (TEXT), default.d.l_commitdate (TEXT), default.d.l_discount (FLOAT8), default.d.l_extendedprice (FLOAT8), default.d.l_linenumber (INT4), default.d.l_linestatus (TEXT), default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8), default.d.l_receiptdate (TEXT), default.d.l_returnflag (TEXT), default.d.l_shipdate (TEXT), default.d.l_shipinstruct (TEXT), default.d.l_shipmode (TEXT), default.d.l_suppkey (INT4), default.d.l_tax (FLOAT8)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000006 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 6 => 7 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
+
+SCAN(8) on default.part
+  => target list: default.part.p_partkey (INT4)
+  => out schema: {(1) default.part.p_partkey (INT4)}
+  => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 =======================================================
 
@@ -185,30 +209,6 @@ TABLE_SUBQUERY(14) as default.f
          SCAN(28) on eb_0000000000000_0000_000003
            => out schema: {(2) default.e.l_orderkey (INT4), ?avg_11 (PROTOBUF)}
            => in schema: {(2) default.e.l_orderkey (INT4), ?avg_11 (PROTOBUF)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000005 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 7 (type=HASH_SHUFFLE, key=default.d.l_partkey (INT4), num=32)
-
-SCAN(7) on default.lineitem as d
-  => target list: default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)
-  => out schema: {(3) default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8)}
-  => in schema: {(16) default.d.l_comment (TEXT), default.d.l_commitdate (TEXT), default.d.l_discount (FLOAT8), default.d.l_extendedprice (FLOAT8), default.d.l_linenumber (INT4), default.d.l_linestatus (TEXT), default.d.l_orderkey (INT4), default.d.l_partkey (INT4), default.d.l_quantity (FLOAT8), default.d.l_receiptdate (TEXT), default.d.l_returnflag (TEXT), default.d.l_shipdate (TEXT), default.d.l_shipinstruct (TEXT), default.d.l_shipmode (TEXT), default.d.l_suppkey (INT4), default.d.l_tax (FLOAT8)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000006 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 6 => 7 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
-
-SCAN(8) on default.part
-  => target list: default.part.p_partkey (INT4)
-  => out schema: {(1) default.part.p_partkey (INT4)}
-  => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual3.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual3.Hash_NoBroadcast.plan
@@ -88,6 +88,30 @@ SCAN(1) on default.region as r
   => in schema: {(3) default.r.r_comment (TEXT), default.r.r_name (TEXT), default.r.r_regionkey (INT4)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000004 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
+
+SCAN(5) on default.supplier as s
+  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
+  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
+  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
+
+SCAN(7) on default.partsupp as ps
+  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
+  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
+  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 =======================================================
 
@@ -117,30 +141,6 @@ TABLE_SUBQUERY(4) as default.t
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
            => in schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000004 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
-
-SCAN(5) on default.supplier as s
-  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
-  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
-  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000005 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
-
-SCAN(7) on default.partsupp as ps
-  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
-  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
-  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual3.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual3.Sort_NoBroadcast.plan
@@ -88,6 +88,30 @@ SCAN(1) on default.region as r
   => in schema: {(3) default.r.r_comment (TEXT), default.r.r_name (TEXT), default.r.r_regionkey (INT4)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000004 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
+
+SCAN(5) on default.supplier as s
+  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
+  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
+  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
+
+SCAN(7) on default.partsupp as ps
+  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
+  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
+  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 =======================================================
 
@@ -117,30 +141,6 @@ TABLE_SUBQUERY(4) as default.t
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
            => in schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000004 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
-
-SCAN(5) on default.supplier as s
-  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
-  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
-  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000005 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
-
-SCAN(7) on default.partsupp as ps
-  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
-  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
-  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual4.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual4.Hash_NoBroadcast.plan
@@ -90,6 +90,30 @@ SCAN(1) on default.region as r
   => in schema: {(3) default.r.r_comment (TEXT), default.r.r_name (TEXT), default.r.r_regionkey (INT4)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000004 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
+
+SCAN(5) on default.supplier as s
+  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
+  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
+  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
+
+SCAN(7) on default.partsupp as ps
+  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
+  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
+  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 =======================================================
 
@@ -119,30 +143,6 @@ TABLE_SUBQUERY(4) as default.t
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
            => in schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000004 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
-
-SCAN(5) on default.supplier as s
-  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
-  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
-  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000005 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
-
-SCAN(7) on default.partsupp as ps
-  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
-  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
-  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual4.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestInnerJoinWithSubQuery/testJoinWithMultipleJoinQual4.Sort_NoBroadcast.plan
@@ -90,6 +90,30 @@ SCAN(1) on default.region as r
   => in schema: {(3) default.r.r_comment (TEXT), default.r.r_name (TEXT), default.r.r_regionkey (INT4)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000004 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
+
+SCAN(5) on default.supplier as s
+  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
+  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
+  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
+
+SCAN(7) on default.partsupp as ps
+  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
+  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
+  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 =======================================================
 
@@ -119,30 +143,6 @@ TABLE_SUBQUERY(4) as default.t
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
            => in schema: {(4) default.n.n_comment (TEXT), default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000004 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 4 => 6 (type=HASH_SHUFFLE, key=default.s.s_suppkey (INT4), num=32)
-
-SCAN(5) on default.supplier as s
-  => target list: default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)
-  => out schema: {(2) default.s.s_nationkey (INT4), default.s.s_suppkey (INT4)}
-  => in schema: {(7) default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_nationkey (INT4), default.s.s_phone (TEXT), default.s.s_suppkey (INT4)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000005 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 6 (type=HASH_SHUFFLE, key=default.ps.ps_suppkey (INT4), num=32)
-
-SCAN(7) on default.partsupp as ps
-  => target list: default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)
-  => out schema: {(2) default.ps.ps_availqty (INT4), default.ps.ps_suppkey (INT4)}
-  => in schema: {(5) default.ps.ps_availqty (INT4), default.ps.ps_comment (TEXT), default.ps.ps_partkey (INT4), default.ps.ps_suppkey (INT4), default.ps.ps_supplycost (FLOAT8)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.result
+++ b/tajo-core/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.result
@@ -1,9 +1,9 @@
 id,name,id,id
 -------------------------------
-null,null,null,1
+1,table11-1,null,null
 2,table11-2,2,2
 3,table11-3,3,3
-null,null,null,4
-1,table11-1,null,null
 4,table11-4,null,null
 5,table11-5,null,null
+null,null,null,1
+null,null,null,4

--- a/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Hash.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Hash.plan
@@ -95,22 +95,6 @@ GROUP_BY(17)()
         => in schema: {(8) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000004 [ROOT]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
-
-GROUP_BY(9)()
-  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
-  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
-  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
-  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-   SCAN(18) on eb_0000000000000_0000_000003
-     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000007 [LEAF]
 =======================================================
 
@@ -138,6 +122,22 @@ GROUP_BY(21)()
         => target list: default.customer.c_custkey (INT4)
         => out schema: {(1) default.customer.c_custkey (INT4)}
         => in schema: {(8) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000004 [ROOT]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
+
+GROUP_BY(9)()
+  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
+  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
+  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
+  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+   SCAN(18) on eb_0000000000000_0000_000003
+     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [ROOT]

--- a/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Hash_NoBroadcast.plan
@@ -126,22 +126,6 @@ GROUP_BY(17)()
         => in schema: {(1) default.customer.c_custkey (INT4)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000004 [ROOT]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
-
-GROUP_BY(9)()
-  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
-  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
-  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
-  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-   SCAN(18) on eb_0000000000000_0000_000003
-     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000005 [LEAF]
 =======================================================
 
@@ -164,6 +148,22 @@ SCAN(5) on default.empty_orders
   => target list: default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
   => out schema: {(3) default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}
   => in schema: {(9) default.empty_orders.o_clerk (TEXT), default.empty_orders.o_comment (TEXT), default.empty_orders.o_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderpriority (TEXT), default.empty_orders.o_orderstatus (TEXT), default.empty_orders.o_shippriority (INT4), default.empty_orders.o_totalprice (FLOAT8)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000004 [ROOT]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
+
+GROUP_BY(9)()
+  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
+  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
+  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
+  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+   SCAN(18) on eb_0000000000000_0000_000003
+     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Sort.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Sort.plan
@@ -95,22 +95,6 @@ GROUP_BY(17)()
         => in schema: {(8) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000004 [ROOT]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
-
-GROUP_BY(9)()
-  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
-  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
-  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
-  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-   SCAN(18) on eb_0000000000000_0000_000003
-     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000007 [LEAF]
 =======================================================
 
@@ -138,6 +122,22 @@ GROUP_BY(21)()
         => target list: default.customer.c_custkey (INT4)
         => out schema: {(1) default.customer.c_custkey (INT4)}
         => in schema: {(8) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000004 [ROOT]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
+
+GROUP_BY(9)()
+  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
+  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
+  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
+  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+   SCAN(18) on eb_0000000000000_0000_000003
+     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [ROOT]

--- a/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable4.Sort_NoBroadcast.plan
@@ -126,22 +126,6 @@ GROUP_BY(17)()
         => in schema: {(1) default.customer.c_custkey (INT4)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000004 [ROOT]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
-
-GROUP_BY(9)()
-  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
-  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
-  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
-  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-   SCAN(18) on eb_0000000000000_0000_000003
-     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000005 [LEAF]
 =======================================================
 
@@ -164,6 +148,22 @@ SCAN(5) on default.empty_orders
   => target list: default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
   => out schema: {(3) default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}
   => in schema: {(9) default.empty_orders.o_clerk (TEXT), default.empty_orders.o_comment (TEXT), default.empty_orders.o_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderpriority (TEXT), default.empty_orders.o_orderstatus (TEXT), default.empty_orders.o_shippriority (INT4), default.empty_orders.o_totalprice (FLOAT8)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000004 [ROOT]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=, num=1)
+
+GROUP_BY(9)()
+  => exprs: (max(?max_12 (INT4)),sum(?sum_13 (INT8)),max(?max_14 (TEXT)),max(?max_15 (TEXT)))
+  => target list: ?max (INT4), ?sum_1 (INT8), ?max_2 (TEXT), ?max_3 (TEXT)
+  => out schema:{(4) ?max (INT4), ?max_2 (TEXT), ?max_3 (TEXT), ?sum_1 (INT8)}
+  => in schema:{(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+   SCAN(18) on eb_0000000000000_0000_000003
+     => out schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
+     => in schema: {(4) ?max_12 (INT4), ?sum_13 (INT8), ?max_14 (TEXT), ?max_15 (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Hash.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Hash.plan
@@ -79,6 +79,24 @@ GROUP_BY(15)(id)
      => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000003 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
+
+GROUP_BY(17)(id)
+  => exprs: (count())
+  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
+  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
+  => in schema:{(1) default.jointable_large.id (INT4)}
+   SCAN(4) on default.jointable_large
+     => filter: default.jointable_large.id (INT4) < 200
+     => target list: default.jointable_large.id (INT4)
+     => out schema: {(1) default.jointable_large.id (INT4)}
+     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000002 [INTERMEDIATE]
 =======================================================
 
@@ -104,24 +122,6 @@ TABLE_SUBQUERY(3) as default.a
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
            => in schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000003 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
-
-GROUP_BY(17)(id)
-  => exprs: (count())
-  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
-  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
-  => in schema:{(1) default.jointable_large.id (INT4)}
-   SCAN(4) on default.jointable_large
-     => filter: default.jointable_large.id (INT4) < 200
-     => target list: default.jointable_large.id (INT4)
-     => out schema: {(1) default.jointable_large.id (INT4)}
-     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Hash_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Hash_NoBroadcast.plan
@@ -79,6 +79,24 @@ GROUP_BY(15)(id)
      => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000003 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
+
+GROUP_BY(17)(id)
+  => exprs: (count())
+  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
+  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
+  => in schema:{(1) default.jointable_large.id (INT4)}
+   SCAN(4) on default.jointable_large
+     => filter: default.jointable_large.id (INT4) < 200
+     => target list: default.jointable_large.id (INT4)
+     => out schema: {(1) default.jointable_large.id (INT4)}
+     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000002 [INTERMEDIATE]
 =======================================================
 
@@ -104,24 +122,6 @@ TABLE_SUBQUERY(3) as default.a
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
            => in schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000003 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
-
-GROUP_BY(17)(id)
-  => exprs: (count())
-  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
-  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
-  => in schema:{(1) default.jointable_large.id (INT4)}
-   SCAN(4) on default.jointable_large
-     => filter: default.jointable_large.id (INT4) < 200
-     => target list: default.jointable_large.id (INT4)
-     => out schema: {(1) default.jointable_large.id (INT4)}
-     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Sort.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Sort.plan
@@ -79,6 +79,24 @@ GROUP_BY(15)(id)
      => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000003 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
+
+GROUP_BY(17)(id)
+  => exprs: (count())
+  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
+  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
+  => in schema:{(1) default.jointable_large.id (INT4)}
+   SCAN(4) on default.jointable_large
+     => filter: default.jointable_large.id (INT4) < 200
+     => target list: default.jointable_large.id (INT4)
+     => out schema: {(1) default.jointable_large.id (INT4)}
+     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000002 [INTERMEDIATE]
 =======================================================
 
@@ -104,24 +122,6 @@ TABLE_SUBQUERY(3) as default.a
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
            => in schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000003 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
-
-GROUP_BY(17)(id)
-  => exprs: (count())
-  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
-  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
-  => in schema:{(1) default.jointable_large.id (INT4)}
-   SCAN(4) on default.jointable_large
-     => filter: default.jointable_large.id (INT4) < 200
-     => target list: default.jointable_large.id (INT4)
-     => out schema: {(1) default.jointable_large.id (INT4)}
-     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Sort_NoBroadcast.plan
+++ b/tajo-core/src/test/resources/results/TestOuterJoinWithSubQuery/testJoinWithDifferentShuffleKey.1.Sort_NoBroadcast.plan
@@ -79,6 +79,24 @@ GROUP_BY(15)(id)
      => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
+Block Id: eb_0000000000000_0000_000003 [LEAF]
+=======================================================
+
+[Outgoing]
+[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
+
+GROUP_BY(17)(id)
+  => exprs: (count())
+  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
+  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
+  => in schema:{(1) default.jointable_large.id (INT4)}
+   SCAN(4) on default.jointable_large
+     => filter: default.jointable_large.id (INT4) < 200
+     => target list: default.jointable_large.id (INT4)
+     => out schema: {(1) default.jointable_large.id (INT4)}
+     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
+
+=======================================================
 Block Id: eb_0000000000000_0000_000002 [INTERMEDIATE]
 =======================================================
 
@@ -104,24 +122,6 @@ TABLE_SUBQUERY(3) as default.a
          SCAN(16) on eb_0000000000000_0000_000001
            => out schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
            => in schema: {(2) default.jointable_large.id (INT4), ?count_4 (INT8)}
-
-=======================================================
-Block Id: eb_0000000000000_0000_000003 [LEAF]
-=======================================================
-
-[Outgoing]
-[q_0000000000000_0000] 3 => 4 (type=HASH_SHUFFLE, key=default.jointable_large.id (INT4), num=32)
-
-GROUP_BY(17)(id)
-  => exprs: (count())
-  => target list: default.jointable_large.id (INT4), ?count_5 (INT8)
-  => out schema:{(2) default.jointable_large.id (INT4), ?count_5 (INT8)}
-  => in schema:{(1) default.jointable_large.id (INT4)}
-   SCAN(4) on default.jointable_large
-     => filter: default.jointable_large.id (INT4) < 200
-     => target list: default.jointable_large.id (INT4)
-     => out schema: {(1) default.jointable_large.id (INT4)}
-     => in schema: {(2) default.jointable_large.id (INT4), default.jointable_large.name (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestTPCH/testQ2FourJoins.plan
+++ b/tajo-core/src/test/resources/results/TestTPCH/testQ2FourJoins.plan
@@ -133,29 +133,6 @@ SCAN(7) on default.part
   => in schema: {(9) default.part.p_brand (TEXT), default.part.p_comment (TEXT), default.part.p_container (TEXT), default.part.p_mfgr (TEXT), default.part.p_name (TEXT), default.part.p_partkey (INT4), default.part.p_retailprice (FLOAT8), default.part.p_size (INT4), default.part.p_type (TEXT)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.partsupp.ps_partkey (INT4), num=32)
-[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
-
-JOIN(12)(INNER)
-  => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
-  => target list: default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)
-  => out schema: {(11) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-  => in schema: {(12) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT), default.partsupp.ps_partkey (INT4), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-   SCAN(19) on eb_0000000000000_0000_000004
-     => out schema: {(4) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT)}
-     => in schema: {(4) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT)}
-   SCAN(18) on eb_0000000000000_0000_000003
-     => out schema: {(8) default.partsupp.ps_partkey (INT4), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-     => in schema: {(8) default.partsupp.ps_partkey (INT4), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000006 [LEAF]
 =======================================================
 
@@ -179,6 +156,29 @@ SCAN(0) on default.region
   => target list: default.region.r_name (TEXT), default.region.r_regionkey (INT4)
   => out schema: {(2) default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
   => in schema: {(3) default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 5 (type=HASH_SHUFFLE, key=default.partsupp.ps_partkey (INT4), num=32)
+[q_0000000000000_0000] 4 => 5 (type=HASH_SHUFFLE, key=default.part.p_partkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 5 => 9 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
+
+JOIN(12)(INNER)
+  => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
+  => target list: default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)
+  => out schema: {(11) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+  => in schema: {(12) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT), default.partsupp.ps_partkey (INT4), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+   SCAN(19) on eb_0000000000000_0000_000004
+     => out schema: {(4) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT)}
+     => in schema: {(4) default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.part.p_size (INT4), default.part.p_type (TEXT)}
+   SCAN(18) on eb_0000000000000_0000_000003
+     => out schema: {(8) default.partsupp.ps_partkey (INT4), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
+     => in schema: {(8) default.partsupp.ps_partkey (INT4), default.partsupp.ps_supplycost (FLOAT8), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_nationkey (INT4), default.supplier.s_phone (TEXT)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000008 [INTERMEDIATE]

--- a/tajo-core/src/test/resources/results/TestTPCH/testTPCHQ5.plan
+++ b/tajo-core/src/test/resources/results/TestTPCH/testTPCHQ5.plan
@@ -122,29 +122,6 @@ SCAN(1) on default.orders
   => in schema: {(9) default.orders.o_clerk (TEXT), default.orders.o_comment (TEXT), default.orders.o_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderpriority (TEXT), default.orders.o_orderstatus (TEXT), default.orders.o_shippriority (INT4), default.orders.o_totalprice (FLOAT8)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 1 => 3 (type=HASH_SHUFFLE, key=default.lineitem.l_orderkey (INT4), num=32)
-[q_0000000000000_0000] 2 => 3 (type=HASH_SHUFFLE, key=default.orders.o_orderkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 3 => 7 (type=HASH_SHUFFLE, key=default.lineitem.l_suppkey (INT4), num=32)
-
-JOIN(16)(INNER)
-  => Join Cond: default.lineitem.l_orderkey (INT4) = default.orders.o_orderkey (INT4)
-  => target list: ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)
-  => out schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)}
-  => in schema: {(6) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_orderkey (INT4), default.lineitem.l_suppkey (INT4), default.orders.o_orderkey (INT4)}
-   SCAN(23) on eb_0000000000000_0000_000002
-     => out schema: {(1) default.orders.o_orderkey (INT4)}
-     => in schema: {(1) default.orders.o_orderkey (INT4)}
-   SCAN(22) on eb_0000000000000_0000_000001
-     => out schema: {(5) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_orderkey (INT4), default.lineitem.l_suppkey (INT4)}
-     => in schema: {(5) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_orderkey (INT4), default.lineitem.l_suppkey (INT4)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000004 [LEAF]
 =======================================================
 
@@ -167,6 +144,29 @@ SCAN(0) on default.customer
   => target list: default.customer.c_nationkey (INT4)
   => out schema: {(1) default.customer.c_nationkey (INT4)}
   => in schema: {(8) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 1 => 3 (type=HASH_SHUFFLE, key=default.lineitem.l_orderkey (INT4), num=32)
+[q_0000000000000_0000] 2 => 3 (type=HASH_SHUFFLE, key=default.orders.o_orderkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 3 => 7 (type=HASH_SHUFFLE, key=default.lineitem.l_suppkey (INT4), num=32)
+
+JOIN(16)(INNER)
+  => Join Cond: default.lineitem.l_orderkey (INT4) = default.orders.o_orderkey (INT4)
+  => target list: ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)
+  => out schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)}
+  => in schema: {(6) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_orderkey (INT4), default.lineitem.l_suppkey (INT4), default.orders.o_orderkey (INT4)}
+   SCAN(23) on eb_0000000000000_0000_000002
+     => out schema: {(1) default.orders.o_orderkey (INT4)}
+     => in schema: {(1) default.orders.o_orderkey (INT4)}
+   SCAN(22) on eb_0000000000000_0000_000001
+     => out schema: {(5) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_orderkey (INT4), default.lineitem.l_suppkey (INT4)}
+     => in schema: {(5) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_orderkey (INT4), default.lineitem.l_suppkey (INT4)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]
@@ -192,29 +192,6 @@ JOIN(17)(INNER)
      => in schema: {(2) default.supplier.s_nationkey (INT4), default.supplier.s_suppkey (INT4)}
 
 =======================================================
-Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]
-=======================================================
-
-[Incoming]
-[q_0000000000000_0000] 3 => 7 (type=HASH_SHUFFLE, key=default.lineitem.l_suppkey (INT4), num=32)
-[q_0000000000000_0000] 6 => 7 (type=HASH_SHUFFLE, key=default.supplier.s_suppkey (INT4), num=32)
-
-[Outgoing]
-[q_0000000000000_0000] 7 => 11 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
-
-JOIN(18)(INNER)
-  => Join Cond: default.lineitem.l_suppkey (INT4) = default.supplier.s_suppkey (INT4)
-  => target list: ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.supplier.s_nationkey (INT4)
-  => out schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.supplier.s_nationkey (INT4)}
-  => in schema: {(6) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4), default.supplier.s_nationkey (INT4), default.supplier.s_suppkey (INT4)}
-   SCAN(27) on eb_0000000000000_0000_000006
-     => out schema: {(2) default.supplier.s_nationkey (INT4), default.supplier.s_suppkey (INT4)}
-     => in schema: {(2) default.supplier.s_nationkey (INT4), default.supplier.s_suppkey (INT4)}
-   SCAN(26) on eb_0000000000000_0000_000003
-     => out schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)}
-     => in schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)}
-
-=======================================================
 Block Id: eb_0000000000000_0000_000008 [LEAF]
 =======================================================
 
@@ -238,6 +215,29 @@ SCAN(5) on default.region
   => target list: default.region.r_regionkey (INT4)
   => out schema: {(1) default.region.r_regionkey (INT4)}
   => in schema: {(3) default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
+
+=======================================================
+Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]
+=======================================================
+
+[Incoming]
+[q_0000000000000_0000] 3 => 7 (type=HASH_SHUFFLE, key=default.lineitem.l_suppkey (INT4), num=32)
+[q_0000000000000_0000] 6 => 7 (type=HASH_SHUFFLE, key=default.supplier.s_suppkey (INT4), num=32)
+
+[Outgoing]
+[q_0000000000000_0000] 7 => 11 (type=HASH_SHUFFLE, key=default.supplier.s_nationkey (INT4), num=32)
+
+JOIN(18)(INNER)
+  => Join Cond: default.lineitem.l_suppkey (INT4) = default.supplier.s_suppkey (INT4)
+  => target list: ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.supplier.s_nationkey (INT4)
+  => out schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.supplier.s_nationkey (INT4)}
+  => in schema: {(6) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4), default.supplier.s_nationkey (INT4), default.supplier.s_suppkey (INT4)}
+   SCAN(27) on eb_0000000000000_0000_000006
+     => out schema: {(2) default.supplier.s_nationkey (INT4), default.supplier.s_suppkey (INT4)}
+     => in schema: {(2) default.supplier.s_nationkey (INT4), default.supplier.s_suppkey (INT4)}
+   SCAN(26) on eb_0000000000000_0000_000003
+     => out schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)}
+     => in schema: {(4) ?multiply (FLOAT8), default.lineitem.l_discount (FLOAT8), default.lineitem.l_extendedprice (FLOAT8), default.lineitem.l_suppkey (INT4)}
 
 =======================================================
 Block Id: eb_0000000000000_0000_000010 [INTERMEDIATE]


### PR DESCRIPTION
I've changed only two lines as follows. Everything else is related to unit tests.
```
diff --git a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/MasterPlan.java b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/MasterPlan.java
index 22c3751..f8cd1e9 100644
--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/MasterPlan.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/MasterPlan.java
@@ -237,13 +237,13 @@ public class MasterPlan {
     sb.append("Order of Execution\n");
     sb.append("-------------------------------------------------------------------------------");
     int order = 1;
-    for (ExecutionBlock currentEB : cursor) {
+    for (ExecutionBlock currentEB : executionOrderCursor) {
       sb.append("\n").append(order).append(": ").append(currentEB.getId());
       order++;
     }
     sb.append("\n-------------------------------------------------------------------------------\n");
 
-    for (ExecutionBlock block : cursor) {
+    for (ExecutionBlock block : executionOrderCursor) {
 
       boolean terminal = false;
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/tajo/592)
<!-- Reviewable:end -->
