### PR TITLE
TAJO-1634 REST API: fix error when offset is zero

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
@@ -366,7 +366,7 @@ public class QueryResultResource {
     }
 
     private void skipOffsetRow(NonForwardQueryResultScanner queryResultScanner, int offset) throws IOException {
-      if (offset < 0) {
+      if (offset <= 0) {
         return;
       }
 


### PR DESCRIPTION
when offset is 0, /databases/{database-name}/queries/q000/results/0000
cause 500 error.