### PR TITLE
TAJO-1636 query rest api uri should change from /databases/{database_name}/queies to /queries

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
@@ -58,13 +58,10 @@ public class QueryResultResource {
   
   private Application application;
   
-  private String databaseName;
-
   private String queryId;
   
   private JerseyResourceDelegateContext context;
   
-  private static final String databaseNameKeyName = "databaseName";
   private static final String queryIdKeyName = "queryId";
   private static final String sessionIdKeyName = "sessionId";
   private static final String cacheIdKeyName = "cacheId";
@@ -89,14 +86,6 @@ public class QueryResultResource {
     this.application = application;
   }
   
-  public String getDatabaseName() {
-    return databaseName;
-  }
-  
-  public void setDatabaseName(String databaseName) {
-    this.databaseName = databaseName;
-  }
-
   public String getQueryId() {
     return queryId;
   }
@@ -110,9 +99,6 @@ public class QueryResultResource {
     JerseyResourceDelegateContextKey<UriInfo> uriInfoKey =
         JerseyResourceDelegateContextKey.valueOf(JerseyResourceDelegateUtil.UriInfoKey, UriInfo.class);
     context.put(uriInfoKey, uriInfo);
-    JerseyResourceDelegateContextKey<String> databaseNameKey =
-        JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
-    context.put(databaseNameKey, databaseName);
     JerseyResourceDelegateContextKey<String> queryIdKey =
         JerseyResourceDelegateContextKey.valueOf(queryIdKeyName, String.class);
     context.put(queryIdKey, queryId);
@@ -200,10 +186,7 @@ public class QueryResultResource {
       JerseyResourceDelegateContextKey<UriInfo> uriInfoKey =
           JerseyResourceDelegateContextKey.valueOf(JerseyResourceDelegateUtil.UriInfoKey, UriInfo.class);
       UriInfo uriInfo = context.get(uriInfoKey);
-      JerseyResourceDelegateContextKey<String> databaseNameKey =
-          JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
-      String databaseName = context.get(databaseNameKey);
-      
+
       try {
         masterContext.getSessionManager().touch(sessionId);
         Session session = masterContext.getSessionManager().getSession(sessionId);
@@ -234,7 +217,7 @@ public class QueryResultResource {
             .path(QueryResource.class)
             .path(QueryResource.class, "getQueryResult")
             .path(QueryResultResource.class, "getQueryResultSet")
-            .build(databaseName, queryId, cacheId);
+            .build(queryId, cacheId);
         ResultSetInfoResponse resultSetInfoResponse = new ResultSetInfoResponse();
         resultSetInfoResponse.setId(cacheId);
         resultSetInfoResponse.setLink(resultSetCacheUri);

--- a/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResource.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResource.java
@@ -65,7 +65,7 @@ public class TestQueryResource extends QueryTestCaseBase {
     int restPort = testBase.getTestingCluster().getConfiguration().getIntVar(ConfVars.REST_SERVICE_PORT);
     restServiceURI = new URI("http", null, "127.0.0.1", restPort, "/rest", null, null);
     sessionsURI = new URI(restServiceURI + "/sessions");
-    queriesURI = new URI(restServiceURI + "/databases/" + TajoConstants.DEFAULT_DATABASE_NAME + "/queries");
+    queriesURI = new URI(restServiceURI + "/queries");
     restClient = ClientBuilder.newBuilder()
         .register(new GsonFeature(RestTestUtils.registerTypeAdapterMap()))
         .register(LoggingFilter.class)

--- a/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
@@ -73,7 +73,7 @@ public class TestQueryResultResource extends QueryTestCaseBase {
     int restPort = testBase.getTestingCluster().getConfiguration().getIntVar(ConfVars.REST_SERVICE_PORT);
     restServiceURI = new URI("http", null, "127.0.0.1", restPort, "/rest", null, null);
     sessionsURI = new URI(restServiceURI + "/sessions");
-    queriesURI = new URI(restServiceURI + "/databases/" + TajoConstants.DEFAULT_DATABASE_NAME + "/queries");
+    queriesURI = new URI(restServiceURI + "/queries");
     restClient = ClientBuilder.newBuilder()
         .register(new GsonFeature(RestTestUtils.registerTypeAdapterMap()))
         .register(LoggingFilter.class)


### PR DESCRIPTION
currently, "databases" Rest Api uri has too many meaning.
1. for query
2. to manage databases info
and databases/
{database_name}/queries is not proper for queries 

so I suggest change from "/databases/{database_name}
/queries" to
"/queries/", it is more clear to understand.
below apis will changed.
POST /databases/{databaseName}/queries -> POST /queries
GET /databases/{databaseName}/queries -> GET /queries
GET /databases/{databaseName}/queries/{queryId} -> GET /queries/{queryId}
GET /databases/{databaseName}/queries/{queryId}/result -> GET /queries/{queryId}/result
GET /databases/{databaseName}/queries/{queryId}/result/{cacheId} -> GET /queries/{queryId}/result/{cacheId}