### PR TITLE
TAJO-1642: CatalogServer need to check meta table first.

### DIFF
--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -254,7 +254,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.error("| You might downgrade or upgrade Apache Tajo. Downgrading or upgrading |");
       LOG.error("| Tajo without migration process is only available in some versions. |");
       LOG.error("| In order to learn how to migration Apache Tajo instance, |");
-      LOG.error("| please refer http://s.apache.org/0_8_migration. |");
+      LOG.error("| please refer http://tajo.apache.org/docs/current/backup_and_restore/catalog.html |");
       LOG.error("=========================================================================");
       throw new CatalogException("Migration Needed. Please refer http://s.apache.org/0_8_migration.");
     }

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
@@ -55,6 +55,7 @@ import org.apache.tajo.catalog.CatalogConstants;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.exception.CatalogException;
 import org.apache.tajo.catalog.store.object.*;
+import org.apache.tajo.util.TUtil;
 
 public class XMLCatalogSchemaManager {
   protected final Log LOG = LogFactory.getLog(getClass());
@@ -348,11 +349,25 @@ public class XMLCatalogSchemaManager {
   public boolean catalogAlreadyExists(Connection conn) throws CatalogException {
     boolean result = false;
     try {
-      for (DatabaseObjectType objectType : DatabaseObjectType.values()) {
-        if (checkExistence(conn, objectType, CatalogConstants.TB_META)) {
+      List<String> constants = TUtil.newList();
+      constants.add(CatalogConstants.TB_META);
+      constants.add(CatalogConstants.TB_SPACES);
+      constants.add(CatalogConstants.TB_DATABASES);
+      constants.add(CatalogConstants.TB_TABLES);
+      constants.add(CatalogConstants.TB_COLUMNS);
+      constants.add(CatalogConstants.TB_OPTIONS);
+      constants.add(CatalogConstants.TB_INDEXES);
+      constants.add(CatalogConstants.TB_STATISTICS);
+      constants.add(CatalogConstants.TB_PARTITION_METHODS);
+      constants.add(CatalogConstants.TB_PARTTIONS);
+      constants.add(CatalogConstants.TB_PARTTION_KEYS);
+
+      for (String constant : constants) {
+        if (checkExistence(conn, DatabaseObjectType.TABLE, constant)) {
           return true;
         }
       }
+
     } catch (SQLException e) {
       throw new CatalogException(e.getMessage(), e);
     }

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
@@ -51,6 +51,7 @@ import javax.xml.stream.XMLStreamReader;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.catalog.CatalogConstants;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.exception.CatalogException;
 import org.apache.tajo.catalog.store.object.*;
@@ -342,6 +343,16 @@ public class XMLCatalogSchemaManager {
     }
 
     CatalogUtil.closeQuietly(stmt);
+  }
+
+  public boolean catalogAlreadyExists(Connection conn) throws CatalogException {
+    boolean result = false;
+    try {
+      result = checkExistence(conn, DatabaseObjectType.TABLE, CatalogConstants.TB_META);
+    } catch (SQLException e) {
+      throw new CatalogException(e.getMessage(), e);
+    }
+    return result;
   }
 
   public boolean isInitialized(Connection conn) throws CatalogException {

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
@@ -348,7 +348,11 @@ public class XMLCatalogSchemaManager {
   public boolean catalogAlreadyExists(Connection conn) throws CatalogException {
     boolean result = false;
     try {
-      result = checkExistence(conn, DatabaseObjectType.TABLE, CatalogConstants.TB_META);
+      for (DatabaseObjectType objectType : DatabaseObjectType.values()) {
+        if (checkExistence(conn, objectType, CatalogConstants.TB_META)) {
+          return true;
+        }
+      }
     } catch (SQLException e) {
       throw new CatalogException(e.getMessage(), e);
     }


### PR DESCRIPTION
I tested this patch on my laptop. When I tried to start up tajo-0.11.0-SNAPSHOT with the catalog-site.xml file for tajo-0.10.1-SNAPSHOT, TajoMaster printed following messages.

```
15/06/09 11:38:11 INFO store.MySQLStore: The meta table of CatalogServer already is created.
15/06/09 11:38:11 ERROR store.MySQLStore: Catalog version (2) and current driver version (4) are mismatch to each other
15/06/09 11:38:11 ERROR store.MySQLStore: =========================================================================
15/06/09 11:38:11 ERROR store.MySQLStore: | Catalog Store Migration Is Needed |
15/06/09 11:38:11 ERROR store.MySQLStore: =========================================================================
15/06/09 11:38:11 ERROR store.MySQLStore: | You might downgrade or upgrade Apache Tajo. Downgrading or upgrading |
15/06/09 11:38:11 ERROR store.MySQLStore: | Tajo without migration process is only available in some versions. |
15/06/09 11:38:11 ERROR store.MySQLStore: | In order to learn how to migration Apache Tajo instance, |
15/06/09 11:38:11 ERROR store.MySQLStore: | please refer http://s.apache.org/0_8_migration. |
15/06/09 11:38:11 ERROR store.MySQLStore: =========================================================================
```

And I found that existing column informations exists normally. For the reference, I succeed to test with only tajo-0.11.0-SNAPSHOT.