### PR TITLE
TAJO-1647: Change Create Database Tajo Rest API address from POST /databases to POST /databases/{database_name}

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/DatabasesResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/DatabasesResource.java
@@ -18,26 +18,6 @@
 
 package org.apache.tajo.ws.rs.resources;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.TajoConstants;
@@ -45,13 +25,18 @@ import org.apache.tajo.catalog.CatalogService;
 import org.apache.tajo.catalog.proto.CatalogProtos.DatabaseProto;
 import org.apache.tajo.catalog.proto.CatalogProtos.TablespaceProto;
 import org.apache.tajo.master.TajoMaster.MasterContext;
-import org.apache.tajo.ws.rs.JerseyResourceDelegate;
-import org.apache.tajo.ws.rs.JerseyResourceDelegateContext;
-import org.apache.tajo.ws.rs.JerseyResourceDelegateContextKey;
-import org.apache.tajo.ws.rs.JerseyResourceDelegateUtil;
-import org.apache.tajo.ws.rs.ResourcesUtil;
+import org.apache.tajo.ws.rs.*;
 import org.apache.tajo.ws.rs.requests.NewDatabaseRequest;
 import org.apache.tajo.ws.rs.responses.DatabaseInfoResponse;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Deals with Database Management
@@ -131,8 +116,8 @@ public class DatabasesResource {
    * @return
    */
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
-  public Response createNewDatabase(NewDatabaseRequest request) {
+	@Path("/{databaseName}")
+  public Response createNewDatabase(@PathParam("databaseName") String databaseName) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Client sent a new database creation request");
     }
@@ -140,9 +125,9 @@ public class DatabasesResource {
     Response response = null;
     try {
       initializeContext();
-      JerseyResourceDelegateContextKey<NewDatabaseRequest> newDatabaseRequestKey =
-          JerseyResourceDelegateContextKey.valueOf(newDatabaseRequestKeyName, NewDatabaseRequest.class);
-      context.put(newDatabaseRequestKey, request);
+			JerseyResourceDelegateContextKey<String> databaseNameKey =
+				JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
+			context.put(databaseNameKey, databaseName);
       
       response = JerseyResourceDelegateUtil.runJerseyResourceDelegate(
           new CreateNewDatabaseDelegate(),
@@ -162,9 +147,9 @@ public class DatabasesResource {
 
     @Override
     public Response run(JerseyResourceDelegateContext context) {
-      JerseyResourceDelegateContextKey<NewDatabaseRequest> newDatabaseRequestKey =
-          JerseyResourceDelegateContextKey.valueOf(newDatabaseRequestKeyName, NewDatabaseRequest.class);
-      NewDatabaseRequest request = context.get(newDatabaseRequestKey);
+			JerseyResourceDelegateContextKey<String> databaseNameKey =
+				JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
+			String databaseName = context.get(databaseNameKey);
       JerseyResourceDelegateContextKey<MasterContext> masterContextKey =
           JerseyResourceDelegateContextKey.valueOf(JerseyResourceDelegateUtil.MasterContextKey, MasterContext.class);
       MasterContext masterContext = context.get(masterContextKey);
@@ -172,19 +157,19 @@ public class DatabasesResource {
           JerseyResourceDelegateContextKey.valueOf(JerseyResourceDelegateUtil.UriInfoKey, UriInfo.class);
       UriInfo uriInfo = context.get(uriInfoKey);
       
-      if (request.getDatabaseName() == null || request.getDatabaseName().isEmpty()) {
+      if (databaseName == null || databaseName.isEmpty()) {
         return ResourcesUtil.createBadRequestResponse(LOG, "databaseName is null or empty.");
       }
       
       boolean databaseCreated =
-          masterContext.getCatalog().createDatabase(request.getDatabaseName(), 
+          masterContext.getCatalog().createDatabase(databaseName,
               TajoConstants.DEFAULT_TABLESPACE_NAME);
       
       if (databaseCreated) {
         URI newDatabaseURI = uriInfo.getBaseUriBuilder()
             .path(DatabasesResource.class)
             .path(DatabasesResource.class, "getDatabase")
-            .build(request.getDatabaseName());
+            .build(databaseName);
         return Response.created(newDatabaseURI).build();
       } else {
         return ResourcesUtil.createExceptionResponse(LOG, "Failed to create a new database.");

--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/DatabasesResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/DatabasesResource.java
@@ -116,7 +116,7 @@ public class DatabasesResource {
    * @return
    */
   @POST
-	@Path("/{databaseName}")
+  @Path("/{databaseName}")
   public Response createNewDatabase(@PathParam("databaseName") String databaseName) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Client sent a new database creation request");
@@ -125,9 +125,9 @@ public class DatabasesResource {
     Response response = null;
     try {
       initializeContext();
-			JerseyResourceDelegateContextKey<String> databaseNameKey =
-				JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
-			context.put(databaseNameKey, databaseName);
+      JerseyResourceDelegateContextKey<String> databaseNameKey =
+        JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
+      context.put(databaseNameKey, databaseName);
       
       response = JerseyResourceDelegateUtil.runJerseyResourceDelegate(
           new CreateNewDatabaseDelegate(),
@@ -147,9 +147,9 @@ public class DatabasesResource {
 
     @Override
     public Response run(JerseyResourceDelegateContext context) {
-			JerseyResourceDelegateContextKey<String> databaseNameKey =
-				JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
-			String databaseName = context.get(databaseNameKey);
+      JerseyResourceDelegateContextKey<String> databaseNameKey =
+        JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
+      String databaseName = context.get(databaseNameKey);
       JerseyResourceDelegateContextKey<MasterContext> masterContextKey =
           JerseyResourceDelegateContextKey.valueOf(JerseyResourceDelegateUtil.MasterContextKey, MasterContext.class);
       MasterContext masterContext = context.get(masterContextKey);
@@ -194,7 +194,7 @@ public class DatabasesResource {
     try {
       initializeContext();
       JerseyResourceDelegateContextKey<String> databaseNameKey =
-          JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
+        JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);
       context.put(databaseNameKey, databaseName);
       
       response = JerseyResourceDelegateUtil.runJerseyResourceDelegate(
@@ -216,7 +216,7 @@ public class DatabasesResource {
     @Override
     public Response run(JerseyResourceDelegateContext context) {
       JerseyResourceDelegateContextKey<MasterContext> masterContextKey =
-          JerseyResourceDelegateContextKey.valueOf(JerseyResourceDelegateUtil.MasterContextKey, MasterContext.class);
+        JerseyResourceDelegateContextKey.valueOf(JerseyResourceDelegateUtil.MasterContextKey, MasterContext.class);
       MasterContext masterContext = context.get(masterContextKey);
       JerseyResourceDelegateContextKey<String> databaseNameKey =
           JerseyResourceDelegateContextKey.valueOf(databaseNameKeyName, String.class);

--- a/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestDatabasesResource.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestDatabasesResource.java
@@ -18,29 +18,26 @@
 
 package org.apache.tajo.ws.rs.resources;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.Map;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.apache.tajo.QueryTestCaseBase;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.conf.TajoConf.ConfVars;
 import org.apache.tajo.ws.rs.netty.gson.GsonFeature;
-import org.apache.tajo.ws.rs.requests.NewDatabaseRequest;
 import org.apache.tajo.ws.rs.responses.DatabaseInfoResponse;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.filter.LoggingFilter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -89,12 +86,11 @@ public class TestDatabasesResource extends QueryTestCaseBase {
   @Test
   public void testCreateDatabase() throws Exception {
     String databaseName = "TestDatabasesResource";
-    NewDatabaseRequest request = new NewDatabaseRequest();
-    
-    request.setDatabaseName(databaseName);
-    
-    Response response = restClient.target(databasesURI)
-        .request().post(Entity.entity(request, MediaType.APPLICATION_JSON));
+		URI datbaseCreateURI = new URI(restServiceURI + "/databases/" + databaseName);
+
+		Entity<Object> entity = Entity.entity(null, "application/x-ample");
+		Response response = restClient.target(datbaseCreateURI)
+        .request().post(entity);
     
     assertNotNull(response);
     assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
@@ -113,13 +109,14 @@ public class TestDatabasesResource extends QueryTestCaseBase {
   
   @Test
   public void testCreateDatabaseBadRequest() throws Exception {
-    NewDatabaseRequest request = new NewDatabaseRequest();
-    
+    URI datbaseCreateURI = new URI(restServiceURI + "/databases");
+		Entity<Object> entity = Entity.entity(null, "application/x-ample");
+
     Response response = restClient.target(databasesURI)
-        .request().post(Entity.entity(request, MediaType.APPLICATION_JSON));
+        .request().post(entity);
     
     assertNotNull(response);
-    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    assertEquals(Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
   }
 
   @Test
@@ -148,12 +145,11 @@ public class TestDatabasesResource extends QueryTestCaseBase {
   @Test
   public void testDropDatabase() throws Exception {
     String databaseName = "TestDropDatabase";
-    NewDatabaseRequest request = new NewDatabaseRequest();
-    
-    request.setDatabaseName(databaseName);
-    
-    Response response = restClient.target(databasesURI)
-        .request().post(Entity.entity(request, MediaType.APPLICATION_JSON));
+		URI datbaseCreateURI = new URI(restServiceURI + "/databases/" + databaseName);
+
+		Entity<Object> entity = Entity.entity(null, "application/x-ample");
+		Response response = restClient.target(datbaseCreateURI)
+			.request().post(entity);
     
     assertNotNull(response);
     assertEquals(Status.CREATED.getStatusCode(), response.getStatus());


### PR DESCRIPTION
in Rest API
POST /databases/{database_name} is more understandable
comparing to POST /databases with database_name parameter