### PR TITLE
TAJO-1657: Tajo Rest API /database/{database-name]/tables should return table names only without invalid external table info

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/TablesResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/TablesResource.java
@@ -19,9 +19,7 @@
 package org.apache.tajo.ws.rs.resources;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -64,7 +62,8 @@ public class TablesResource {
   String databaseName;
   
   JerseyResourceDelegateContext context;
-  
+
+	private static final String tablesKeyName = "tables";
   private static final String databaseNameKeyName = "databaseName";
   private static final String tableNameKeyName = "tableName";
   private static final String tableDescKeyName = "tableDesc";
@@ -206,15 +205,11 @@ public class TablesResource {
       if (!catalogService.existDatabase(databaseName)) {
         return Response.status(Status.NOT_FOUND).build();
       }
-      
+
       Collection<String> tableNames = catalogService.getAllTableNames(databaseName);
-      List<TableDesc> tables = new ArrayList<TableDesc>();
-      
-      for (String tableName: tableNames) {
-        tables.add(new TableDesc(tableName, null, null, null));
-      }
-      
-      return Response.ok(tables).build();
+			Map<String, Collection<String>> tableNamesMap = new HashMap<String, Collection<String>>();
+			tableNamesMap.put(tablesKeyName, tableNames);
+			return Response.ok(tableNamesMap).build();
     }
     
   }

--- a/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestTablesResource.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestTablesResource.java
@@ -17,7 +17,6 @@
  */
 package org.apache.tajo.ws.rs.resources;
 
-import com.google.gson.internal.StringMap;
 import org.apache.tajo.QueryTestCaseBase;
 import org.apache.tajo.catalog.*;
 import org.apache.tajo.common.TajoDataTypes;
@@ -39,7 +38,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -103,16 +104,17 @@ public class TestTablesResource extends QueryTestCaseBase {
     
     assertNotNull(response);
     assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
-    
-    List<StringMap<String>> tables = restClient.target(tablesURI)
-        .request().get(new GenericType<List<StringMap<String>>>(List.class));
-    
-    assertNotNull(tables);
-    assertTrue(!tables.isEmpty());
+
+		Map<String, Collection<String>> tables = restClient.target(tablesURI)
+        .request().get(new GenericType<Map<String, Collection<String>>>(Map.class));
+
+		List<String> tableNames = (List<String>)tables.get("tables");
+    assertNotNull(tableNames);
+    assertTrue(!tableNames.isEmpty());
     
     boolean tableFound = false;
-    for (StringMap<String> table: tables) {
-      if (tableName.equals(CatalogUtil.extractSimpleName(table.get("tableName")))) {
+    for (String table: tableNames) {
+      if (tableName.equals(CatalogUtil.extractSimpleName(table))) {
         tableFound = true;
         break;
       }


### PR DESCRIPTION
Duplicated of #610 

Tajo Rest API GET /databases/{database-name}/tables should return table name only without invalid external table info.
current tables API return table name and external table info but, it always return false.