### PR TITLE
TAJO-1346: Run ADD PARTITION after storing column partitioned table.

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
@@ -23,6 +23,8 @@ import com.google.common.collect.Maps;
 import org.apache.hadoop.fs.Path;
 import org.apache.tajo.DataTypeUtil;
 import org.apache.tajo.TajoConstants;
+import org.apache.tajo.catalog.partition.PartitionDesc;
+import org.apache.tajo.catalog.partition.PartitionKey;
 import org.apache.tajo.catalog.partition.PartitionMethodDesc;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.SchemaProto;
@@ -788,6 +790,15 @@ public class CatalogUtil {
     final AlterTableDesc alterTableDesc = new AlterTableDesc();
     alterTableDesc.setTableName(tableName);
     alterTableDesc.setProperties(params);
+    alterTableDesc.setAlterTableType(alterTableType);
+    return alterTableDesc;
+  }
+
+  public static AlterTableDesc addPartitionAndDropPartition(String tableName, PartitionDesc partitionDesc,
+                                                            AlterTableType alterTableType) {
+    final AlterTableDesc alterTableDesc = new AlterTableDesc();
+    alterTableDesc.setTableName(tableName);
+    alterTableDesc.setPartitionDesc(partitionDesc);
     alterTableDesc.setAlterTableType(alterTableType);
     return alterTableDesc;
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/StatisticsUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/StatisticsUtil.java
@@ -21,6 +21,7 @@ package org.apache.tajo.catalog.statistics;
 import com.google.common.collect.Lists;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.catalog.partition.PartitionDesc;
 
 import java.util.List;
 
@@ -49,7 +50,6 @@ public class StatisticsUtil {
    * @param stats The TableStats to be aggregated
    */
   public static void aggregateTableStat(TableStats result, TableStats stats) {
-
     if (stats.getColumnStats().size() > 0) {
       if (result.getColumnStats().size() == 0) {
         for (int i = 0; i < stats.getColumnStats().size(); i++) {
@@ -83,6 +83,14 @@ public class StatisticsUtil {
       }
     }
 
+    // If there is partitions
+    if (stats.getPartitions().size() > 0) {
+      // Aggregate partitions for each table
+      for (PartitionDesc partitionDesc : stats.getPartitions()) {
+        result.addPartition(partitionDesc);
+      }
+    }
+
     result.setNumRows(result.getNumRows() + stats.getNumRows());
     result.setNumBytes(result.getNumBytes() + stats.getNumBytes());
     result.setReadBytes(result.getReadBytes() + stats.getReadBytes());
@@ -112,6 +120,14 @@ public class StatisticsUtil {
     }
 
     for (TableStats ts : tableStatses) {
+      // If there is partitions
+      if (ts.getPartitions().size() > 0) {
+        // Aggregate partitions for each table
+        for (PartitionDesc partitionDesc : ts.getPartitions()) {
+          aggregated.addPartition(partitionDesc);
+        }
+      }
+
       // if there is empty stats
       if (ts.getColumnStats().size() > 0) {
         // aggregate column stats for each table

--- a/tajo-catalog/tajo-catalog-common/src/main/proto/CatalogProtos.proto
+++ b/tajo-catalog/tajo-catalog-common/src/main/proto/CatalogProtos.proto
@@ -233,6 +233,7 @@ message TableStatsProto {
   optional int64 readBytes = 7;
   repeated ColumnStatsProto colStat = 8;
   optional int32 tid = 9;
+  repeated PartitionDescProto partitions = 10;
 }
 
 message ColumnStatsProto {

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
@@ -621,7 +621,7 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
         partitionName = alterTableDescProto.getPartitionDesc().getPartitionName();
         partitionDesc = getPartition(databaseName, tableName, partitionName);
         if(partitionDesc != null) {
-          throw new AlreadyExistsPartitionException(databaseName, tableName, partitionName);
+          dropPartition(databaseName, tableName, partitionDesc);
         }
         addPartition(databaseName, tableName, alterTableDescProto.getPartitionDesc());
         break;
@@ -630,8 +630,9 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
         partitionDesc = getPartition(databaseName, tableName, partitionName);
         if(partitionDesc == null) {
           throw new NoSuchPartitionException(databaseName, tableName, partitionName);
+        } else {
+          dropPartition(databaseName, tableName, partitionDesc);
         }
-        dropPartition(databaseName, tableName, partitionDesc);
         break;
       case SET_PROPERTY:
         // TODO - not implemented yet

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -999,7 +999,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
           partitionName = alterTableDescProto.getPartitionDesc().getPartitionName();
           partitionDesc = getPartition(databaseName, tableName, partitionName);
           if(partitionDesc != null) {
-            throw new AlreadyExistsPartitionException(databaseName, tableName, partitionName);
+            dropPartition(tableId, alterTableDescProto.getPartitionDesc().getPartitionName());
           }
           addPartition(tableId, alterTableDescProto.getPartitionDesc());
           break;

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
@@ -31,6 +31,8 @@ import org.apache.tajo.catalog.CatalogService;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.TableDesc;
+import org.apache.tajo.catalog.partition.PartitionDesc;
+import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.engine.planner.global.DataChannel;
@@ -73,7 +75,7 @@ public class TestTablePartitions extends QueryTestCaseBase {
     return Arrays.asList(new Object[][] {
       //type
       {NodeType.INSERT},
-      {NodeType.CREATE_TABLE},
+//      {NodeType.CREATE_TABLE},
     });
   }
 

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
@@ -31,8 +31,6 @@ import org.apache.tajo.catalog.CatalogService;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.TableDesc;
-import org.apache.tajo.catalog.partition.PartitionDesc;
-import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.engine.planner.global.DataChannel;

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
@@ -75,7 +75,7 @@ public class TestTablePartitions extends QueryTestCaseBase {
     return Arrays.asList(new Object[][] {
       //type
       {NodeType.INSERT},
-//      {NodeType.CREATE_TABLE},
+      {NodeType.CREATE_TABLE},
     });
   }
 

--- a/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/TableStatistics.java
+++ b/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/TableStatistics.java
@@ -42,6 +42,8 @@ public class TableStatistics {
 
   private boolean [] comparable;
 
+  private TableStats stat;
+
   public TableStatistics(Schema schema) {
     this.schema = schema;
     minValues = new VTuple(schema.size());
@@ -59,6 +61,8 @@ public class TableStatistics {
         comparable[i] = true;
       }
     }
+
+    stat = new TableStats();
   }
 
   public Schema getSchema() {
@@ -105,8 +109,6 @@ public class TableStatistics {
   }
 
   public TableStats getTableStat() {
-    TableStats stat = new TableStats();
-
     for (int i = 0; i < schema.size(); i++) {
       Column column = schema.getColumn(i);
       ColumnStats columnStats = new ColumnStats(column);


### PR DESCRIPTION
Currently, If new partitions are added to HDFS by ColPartitionStoreExec, CatalogStore will not be aware of these partitions. So, Tajo need to run ALTER TABLE table_name ADD PARTITION on each of the newly added partitions automatically.
