### PR TITLE
TAJO-1672 Removing rest api to create table POST /databases/{database-name}/tables interface

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/responses/GetSubmitQueryResponse.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/responses/GetSubmitQueryResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.ws.rs.responses;
+
+import com.google.gson.annotations.Expose;
+import org.apache.tajo.ipc.ClientProtos;
+
+import java.net.URI;
+
+public class GetSubmitQueryResponse {
+  @Expose private ClientProtos.ResultCode resultCode;
+  @Expose private String query;
+  @Expose private URI uri;
+
+  public ClientProtos.ResultCode getResultCode() {
+    return resultCode;
+  }
+
+  public void setResultCode(ClientProtos.ResultCode resultCode) {
+    this.resultCode = resultCode;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+
+  public URI getUri() {
+    return uri;
+  }
+
+  public void setUri(URI uri) {
+    this.uri = uri;
+  }
+}

--- a/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResource.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResource.java
@@ -27,6 +27,7 @@ import org.apache.tajo.master.QueryInfo;
 import org.apache.tajo.ws.rs.netty.gson.GsonFeature;
 import org.apache.tajo.ws.rs.requests.NewSessionRequest;
 import org.apache.tajo.ws.rs.requests.SubmitQueryRequest;
+import org.apache.tajo.ws.rs.responses.GetSubmitQueryResponse;
 import org.apache.tajo.ws.rs.responses.NewSessionResponse;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.filter.LoggingFilter;
@@ -105,17 +106,18 @@ public class TestQueryResource extends QueryTestCaseBase {
     String sessionId = generateNewSessionAndGetId();
     SubmitQueryRequest queryRequest = createNewQueryRequest("select * from lineitem");
 
-    Response response = restClient.target(queriesURI)
+    GetSubmitQueryResponse response = restClient.target(queriesURI)
         .request().header(tajoSessionIdHeaderName, sessionId)
-        .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON));
-    
+        .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON),
+            new GenericType<GetSubmitQueryResponse>(GetSubmitQueryResponse.class));
+
     assertNotNull(response);
-    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
-    String locationHeader = response.getHeaderString("Location");
-    assertTrue(locationHeader != null && !locationHeader.isEmpty());
+    assertEquals(ResultCode.OK, response.getResultCode());
+    String location = response.getUri().toString();
+    assertTrue(location != null && !location.isEmpty());
     
-    String queryId = locationHeader.lastIndexOf('/') >= 0?
-        locationHeader.substring(locationHeader.lastIndexOf('/')+1):null;
+    String queryId = location.lastIndexOf('/') >= 0?
+			location.substring(location.lastIndexOf('/')+1):null;
         
     assertTrue(queryId != null && !queryId.isEmpty());
     
@@ -142,17 +144,18 @@ public class TestQueryResource extends QueryTestCaseBase {
     String sessionId = generateNewSessionAndGetId();
     SubmitQueryRequest queryRequest = createNewQueryRequest("select * from lineitem");
 
-    Response response = restClient.target(queriesURI)
+    GetSubmitQueryResponse response = restClient.target(queriesURI)
         .request().header(tajoSessionIdHeaderName, sessionId)
-        .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON));
-    
+        .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON),
+            new GenericType<GetSubmitQueryResponse>(GetSubmitQueryResponse.class));
+
     assertNotNull(response);
-    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
-    String locationHeader = response.getHeaderString("Location");
-    assertTrue(locationHeader != null && !locationHeader.isEmpty());
+    assertEquals(ResultCode.OK, response.getResultCode());
+    String location = response.getUri().toString();
+    assertTrue(location != null && !location.isEmpty());
     
-    String queryId = locationHeader.lastIndexOf('/') >= 0?
-        locationHeader.substring(locationHeader.lastIndexOf('/')+1):null;
+    String queryId = location.lastIndexOf('/') >= 0?
+			location.substring(location.lastIndexOf('/')+1):null;
         
     assertTrue(queryId != null && !queryId.isEmpty());
     
@@ -171,17 +174,18 @@ public class TestQueryResource extends QueryTestCaseBase {
     String sessionId = generateNewSessionAndGetId();
     SubmitQueryRequest queryRequest = createNewQueryRequest("select * from lineitem");
 
-    Response response = restClient.target(queriesURI)
+    GetSubmitQueryResponse response = restClient.target(queriesURI)
       .request().header(tajoSessionIdHeaderName, sessionId)
-      .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON));
+      .post(Entity.entity(queryRequest, MediaType.APPLICATION_JSON),
+          new GenericType<GetSubmitQueryResponse>(GetSubmitQueryResponse.class));
 
     assertNotNull(response);
-    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
-    String locationHeader = response.getHeaderString("Location");
-    assertTrue(locationHeader != null && !locationHeader.isEmpty());
+    assertEquals(ResultCode.OK, response.getResultCode());
+    String location = response.getUri().toString();
+    assertTrue(location != null && !location.isEmpty());
 
-    String queryId = locationHeader.lastIndexOf('/') >= 0?
-      locationHeader.substring(locationHeader.lastIndexOf('/')+1):null;
+    String queryId = location.lastIndexOf('/') >= 0?
+			location.substring(location.lastIndexOf('/')+1):null;
 
     assertTrue(queryId != null && !queryId.isEmpty());
 

--- a/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
+++ b/tajo-core/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
@@ -30,6 +30,7 @@ import org.apache.tajo.ws.rs.netty.gson.GsonFeature;
 import org.apache.tajo.ws.rs.requests.NewSessionRequest;
 import org.apache.tajo.ws.rs.requests.SubmitQueryRequest;
 import org.apache.tajo.ws.rs.responses.GetQueryResultDataResponse;
+import org.apache.tajo.ws.rs.responses.GetSubmitQueryResponse;
 import org.apache.tajo.ws.rs.responses.NewSessionResponse;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.filter.LoggingFilter;
@@ -110,16 +111,17 @@ public class TestQueryResultResource extends QueryTestCaseBase {
     SubmitQueryRequest request = new SubmitQueryRequest();
     request.setQuery(query);
 
-    Response response = restClient.target(queriesURI)
+    GetSubmitQueryResponse response = restClient.target(queriesURI)
         .request().header(tajoSessionIdHeaderName, sessionId)
-        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+        .post(Entity.entity(request, MediaType.APPLICATION_JSON),
+					new GenericType<GetSubmitQueryResponse>(GetSubmitQueryResponse.class));
 
     assertNotNull(response);
-    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
-    String locationHeader = response.getHeaderString("Location");
-    assertTrue(locationHeader != null && !locationHeader.isEmpty());
+    assertEquals(ResultCode.OK, response.getResultCode());
+    String location = response.getUri().toString();
+    assertTrue(location != null && !location.isEmpty());
 
-    URI queryIdURI = new URI(locationHeader);
+    URI queryIdURI = new URI(location);
 
     assertNotNull(queryIdURI);
 


### PR DESCRIPTION
Currently, POST /databases/{database-name}
/tables interface is too hard to use. Because it just serialize TableDesc Class. so I think just using query interface is better than create table interface
and for them, changed result of query interface
removing location header, and add response body has query, and ResultCode
and url.(if query is finished directlry, uri isn't)