### PR TITLE
TAJO-1677: Remove unnecessary messages for the Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_install: ulimit -t 514029
 install: ./dev-support/travis-install-dependencies.sh
 
 script: 
-  mvn clean install -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2
+  mvn clean install -B -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_install: ulimit -t 514029
 install: ./dev-support/travis-install-dependencies.sh
 
 script: 
-  mvn clean install -q -e -ff -Dsurefire.useFile=false -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2
+  mvn clean install -q -ff -Dsurefire.useFile=false -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_install: ulimit -t 514029
 install: ./dev-support/travis-install-dependencies.sh
 
 script: 
-  mvn clean install -B -e -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2
+  mvn clean install -q -e -Dsurefire.useFile=false -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_install: ulimit -t 514029
 install: ./dev-support/travis-install-dependencies.sh
 
 script: 
-  mvn clean install -B -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2
+  mvn clean install -B -e -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_install: ulimit -t 514029
 install: ./dev-support/travis-install-dependencies.sh
 
 script: 
-  mvn clean install -q -e -Dsurefire.useFile=false -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2
+  mvn clean install -q -e -ff -Dsurefire.useFile=false -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2

--- a/tajo-common/src/test/java/org/apache/tajo/util/graph/TestSimpleDirectedGraph.java
+++ b/tajo-common/src/test/java/org/apache/tajo/util/graph/TestSimpleDirectedGraph.java
@@ -18,6 +18,8 @@
 
 package org.apache.tajo.util.graph;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.util.graph.DirectedGraphVisitor;
 import org.apache.tajo.util.graph.SimpleDirectedGraph;
 import org.junit.Test;
@@ -29,6 +31,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestSimpleDirectedGraph {
+  private static final Log LOG = LogFactory.getLog(TestSimpleDirectedGraph.class);
 
   @Test
   public final void test() {
@@ -73,7 +76,9 @@ public class TestSimpleDirectedGraph {
 
     @Override
     public void visit(Stack<String> stack, String s) {
-      System.out.println("===> " + s);
+      if(LOG.isDebugEnabled()) {
+        LOG.debug("Element:" + s);
+      }
     }
   }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -173,7 +173,7 @@ public class TajoMaster extends CompositeService {
       RpcClientManager rpcManager = RpcClientManager.getInstance();
       rpcManager.setRetries(systemConf.getInt(RpcConstants.RPC_CLIENT_RETRY_MAX, RpcConstants.DEFAULT_RPC_RETRIES));
       rpcManager.setTimeoutSeconds(
-          systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
+        systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
 
       initResourceManager();
 
@@ -236,7 +236,7 @@ public class TajoMaster extends CompositeService {
 
   private void initResourceManager() throws Exception {
     Class<WorkerResourceManager>  resourceManagerClass = (Class<WorkerResourceManager>)
-        systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
+      systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
     Constructor<WorkerResourceManager> constructor = resourceManagerClass.getConstructor(MasterContext.class);
     resourceManager = constructor.newInstance(context);
     addIfService(resourceManager);
@@ -246,7 +246,7 @@ public class TajoMaster extends CompositeService {
     if (!systemConf.get(CommonTestingUtil.TAJO_TEST_KEY, "FALSE").equalsIgnoreCase("TRUE")) {
       InetSocketAddress address = systemConf.getSocketAddrVar(ConfVars.TAJO_MASTER_INFO_ADDRESS);
       webServer = StaticHttpServer.getInstance(this ,"admin", address.getHostName(), address.getPort(),
-          true, null, context.getConf(), null);
+        true, null, context.getConf(), null);
       webServer.addServlet("queryServlet", "/query_exec", QueryExecutorServlet.class);
       webServer.start();
     }
@@ -328,7 +328,7 @@ public class TajoMaster extends CompositeService {
 
     // Setting the system global configs
     systemConf.setSocketAddr(ConfVars.CATALOG_ADDRESS.varname,
-        NetUtils.getConnectAddress(catalogServer.getBindAddress()));
+      NetUtils.getConnectAddress(catalogServer.getBindAddress()));
 
     try {
       writeSystemConf();
@@ -531,7 +531,7 @@ public class TajoMaster extends CompositeService {
       stream.println("Thread " + getThreadTaskName(info.getThreadId(), info.getThreadName()) + ":");
       Thread.State state = info.getThreadState();
       stream.println("  State: " + state + ", Blocked count: " + info.getBlockedCount() +
-          ", Waited count: " + info.getWaitedCount());
+        ", Waited count: " + info.getWaitedCount());
       if (contention) {
         stream.println("  Blocked time: " + info.getBlockedTime() + ", Waited time: " + info.getWaitedTime());
       }
@@ -539,7 +539,7 @@ public class TajoMaster extends CompositeService {
         stream.println("  Waiting on " + info.getLockName());
       } else if (state == Thread.State.BLOCKED) {
         stream.println("  Blocked on " + info.getLockName() +
-            ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
+          ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
       }
       stream.println("  Stack:");
       for (StackTraceElement frame : info.getStackTrace()) {

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -173,7 +173,7 @@ public class TajoMaster extends CompositeService {
       RpcClientManager rpcManager = RpcClientManager.getInstance();
       rpcManager.setRetries(systemConf.getInt(RpcConstants.RPC_CLIENT_RETRY_MAX, RpcConstants.DEFAULT_RPC_RETRIES));
       rpcManager.setTimeoutSeconds(
-          systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
+        systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
 
       initResourceManager();
 
@@ -202,7 +202,7 @@ public class TajoMaster extends CompositeService {
 
       tajoMasterService = new QueryCoordinatorService(context);
       addIfService(tajoMasterService);
-      
+
       restServer = new TajoRestService(context);
       addIfService(restServer);
     } catch (Exception e) {
@@ -236,7 +236,7 @@ public class TajoMaster extends CompositeService {
 
   private void initResourceManager() throws Exception {
     Class<WorkerResourceManager>  resourceManagerClass = (Class<WorkerResourceManager>)
-        systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
+      systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
     Constructor<WorkerResourceManager> constructor = resourceManagerClass.getConstructor(MasterContext.class);
     resourceManager = constructor.newInstance(context);
     addIfService(resourceManager);
@@ -246,7 +246,7 @@ public class TajoMaster extends CompositeService {
     if (!systemConf.get(CommonTestingUtil.TAJO_TEST_KEY, "FALSE").equalsIgnoreCase("TRUE")) {
       InetSocketAddress address = systemConf.getSocketAddrVar(ConfVars.TAJO_MASTER_INFO_ADDRESS);
       webServer = StaticHttpServer.getInstance(this ,"admin", address.getHostName(), address.getPort(),
-          true, null, context.getConf(), null);
+        true, null, context.getConf(), null);
       webServer.addServlet("queryServlet", "/query_exec", QueryExecutorServlet.class);
       webServer.start();
     }
@@ -255,15 +255,15 @@ public class TajoMaster extends CompositeService {
   private void checkAndInitializeSystemDirectories() throws IOException {
     // Get Tajo root dir
     this.tajoRootPath = TajoConf.getTajoRootDir(systemConf);
+    LOG.info("Tajo Root Directory: " + tajoRootPath);
 
     // Check and Create Tajo root dir
     this.defaultFS = tajoRootPath.getFileSystem(systemConf);
     systemConf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, defaultFS.getUri().toString());
+    LOG.info("FileSystem (" + this.defaultFS.getUri() + ") is initialized.");
     if (!defaultFS.exists(tajoRootPath)) {
       defaultFS.mkdirs(tajoRootPath, new FsPermission(TAJO_ROOT_DIR_PERMISSION));
       LOG.info("Tajo Root Directory '" + tajoRootPath + "' is created.");
-    } else {
-      LOG.info("FileSystem (" + this.defaultFS.getUri() + ") is initialized.");
     }
 
     // Check and Create system and system resource dir
@@ -280,31 +280,29 @@ public class TajoMaster extends CompositeService {
 
     // Get Warehouse dir
     this.wareHousePath = TajoConf.getWarehouseDir(systemConf);
+    LOG.info("Tajo Warehouse dir: " + wareHousePath);
 
     // Check and Create Warehouse dir
     if (!defaultFS.exists(wareHousePath)) {
       defaultFS.mkdirs(wareHousePath, new FsPermission(WAREHOUSE_DIR_PERMISSION));
       LOG.info("Warehouse dir '" + wareHousePath + "' is created");
-    } else {
-      LOG.info("Tajo Warehouse dir: " + wareHousePath);
     }
 
     Path stagingPath = TajoConf.getDefaultRootStagingDir(systemConf);
+    LOG.info("Staging dir: " + wareHousePath);
     if (!defaultFS.exists(stagingPath)) {
       defaultFS.mkdirs(stagingPath, new FsPermission(STAGING_ROOTDIR_PERMISSION));
       LOG.info("Staging dir '" + stagingPath + "' is created");
-    } else {
-      LOG.info("Staging dir: " + wareHousePath);
     }
   }
-  
+
   private void diagnoseTajoMaster() throws EvaluationFailedException {
     SelfDiagnosisRuleEngine ruleEngine = SelfDiagnosisRuleEngine.getInstance();
     SelfDiagnosisRuleSession ruleSession = ruleEngine.newRuleSession();
     EvaluationContext context = new EvaluationContext();
-    
+
     context.addParameter(TajoConf.class.getName(), systemConf);
-    
+
     ruleSession.withCategoryNames("base", "master").fireRules(context);
   }
 
@@ -330,7 +328,7 @@ public class TajoMaster extends CompositeService {
 
     // Setting the system global configs
     systemConf.setSocketAddr(ConfVars.CATALOG_ADDRESS.varname,
-        NetUtils.getConnectAddress(catalogServer.getBindAddress()));
+      NetUtils.getConnectAddress(catalogServer.getBindAddress()));
 
     try {
       writeSystemConf();
@@ -401,7 +399,7 @@ public class TajoMaster extends CompositeService {
         LOG.error(e, e);
       }
     }
-    
+
     if (restServer != null) {
       try {
         restServer.stop();
@@ -504,7 +502,7 @@ public class TajoMaster extends CompositeService {
     public HistoryReader getHistoryReader() {
       return historyReader;
     }
-    
+
     public TajoRestService getRestServer() {
       return restServer;
     }
@@ -533,7 +531,7 @@ public class TajoMaster extends CompositeService {
       stream.println("Thread " + getThreadTaskName(info.getThreadId(), info.getThreadName()) + ":");
       Thread.State state = info.getThreadState();
       stream.println("  State: " + state + ", Blocked count: " + info.getBlockedCount() +
-          ", Waited count: " + info.getWaitedCount());
+        ", Waited count: " + info.getWaitedCount());
       if (contention) {
         stream.println("  Blocked time: " + info.getBlockedTime() + ", Waited time: " + info.getWaitedTime());
       }
@@ -541,7 +539,7 @@ public class TajoMaster extends CompositeService {
         stream.println("  Waiting on " + info.getLockName());
       } else if (state == Thread.State.BLOCKED) {
         stream.println("  Blocked on " + info.getLockName() +
-            ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
+          ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
       }
       stream.println("  Stack:");
       for (StackTraceElement frame : info.getStackTrace()) {

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -255,15 +255,15 @@ public class TajoMaster extends CompositeService {
   private void checkAndInitializeSystemDirectories() throws IOException {
     // Get Tajo root dir
     this.tajoRootPath = TajoConf.getTajoRootDir(systemConf);
-    LOG.info("Tajo Root Directory: " + tajoRootPath);
 
     // Check and Create Tajo root dir
     this.defaultFS = tajoRootPath.getFileSystem(systemConf);
     systemConf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, defaultFS.getUri().toString());
-    LOG.info("FileSystem (" + this.defaultFS.getUri() + ") is initialized.");
     if (!defaultFS.exists(tajoRootPath)) {
       defaultFS.mkdirs(tajoRootPath, new FsPermission(TAJO_ROOT_DIR_PERMISSION));
       LOG.info("Tajo Root Directory '" + tajoRootPath + "' is created.");
+    } else {
+      LOG.info("FileSystem (" + this.defaultFS.getUri() + ") is initialized.");
     }
 
     // Check and Create system and system resource dir
@@ -280,19 +280,21 @@ public class TajoMaster extends CompositeService {
 
     // Get Warehouse dir
     this.wareHousePath = TajoConf.getWarehouseDir(systemConf);
-    LOG.info("Tajo Warehouse dir: " + wareHousePath);
 
     // Check and Create Warehouse dir
     if (!defaultFS.exists(wareHousePath)) {
       defaultFS.mkdirs(wareHousePath, new FsPermission(WAREHOUSE_DIR_PERMISSION));
       LOG.info("Warehouse dir '" + wareHousePath + "' is created");
+    } else {
+      LOG.info("Tajo Warehouse dir: " + wareHousePath);
     }
 
     Path stagingPath = TajoConf.getDefaultRootStagingDir(systemConf);
-    LOG.info("Staging dir: " + wareHousePath);
     if (!defaultFS.exists(stagingPath)) {
       defaultFS.mkdirs(stagingPath, new FsPermission(STAGING_ROOTDIR_PERMISSION));
       LOG.info("Staging dir '" + stagingPath + "' is created");
+    } else {
+      LOG.info("Staging dir: " + wareHousePath);
     }
   }
   

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -173,7 +173,7 @@ public class TajoMaster extends CompositeService {
       RpcClientManager rpcManager = RpcClientManager.getInstance();
       rpcManager.setRetries(systemConf.getInt(RpcConstants.RPC_CLIENT_RETRY_MAX, RpcConstants.DEFAULT_RPC_RETRIES));
       rpcManager.setTimeoutSeconds(
-        systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
+          systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
 
       initResourceManager();
 
@@ -236,7 +236,7 @@ public class TajoMaster extends CompositeService {
 
   private void initResourceManager() throws Exception {
     Class<WorkerResourceManager>  resourceManagerClass = (Class<WorkerResourceManager>)
-      systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
+        systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
     Constructor<WorkerResourceManager> constructor = resourceManagerClass.getConstructor(MasterContext.class);
     resourceManager = constructor.newInstance(context);
     addIfService(resourceManager);
@@ -246,7 +246,7 @@ public class TajoMaster extends CompositeService {
     if (!systemConf.get(CommonTestingUtil.TAJO_TEST_KEY, "FALSE").equalsIgnoreCase("TRUE")) {
       InetSocketAddress address = systemConf.getSocketAddrVar(ConfVars.TAJO_MASTER_INFO_ADDRESS);
       webServer = StaticHttpServer.getInstance(this ,"admin", address.getHostName(), address.getPort(),
-        true, null, context.getConf(), null);
+          true, null, context.getConf(), null);
       webServer.addServlet("queryServlet", "/query_exec", QueryExecutorServlet.class);
       webServer.start();
     }
@@ -328,7 +328,7 @@ public class TajoMaster extends CompositeService {
 
     // Setting the system global configs
     systemConf.setSocketAddr(ConfVars.CATALOG_ADDRESS.varname,
-      NetUtils.getConnectAddress(catalogServer.getBindAddress()));
+        NetUtils.getConnectAddress(catalogServer.getBindAddress()));
 
     try {
       writeSystemConf();
@@ -531,7 +531,7 @@ public class TajoMaster extends CompositeService {
       stream.println("Thread " + getThreadTaskName(info.getThreadId(), info.getThreadName()) + ":");
       Thread.State state = info.getThreadState();
       stream.println("  State: " + state + ", Blocked count: " + info.getBlockedCount() +
-        ", Waited count: " + info.getWaitedCount());
+          ", Waited count: " + info.getWaitedCount());
       if (contention) {
         stream.println("  Blocked time: " + info.getBlockedTime() + ", Waited time: " + info.getWaitedTime());
       }
@@ -539,7 +539,7 @@ public class TajoMaster extends CompositeService {
         stream.println("  Waiting on " + info.getLockName());
       } else if (state == Thread.State.BLOCKED) {
         stream.println("  Blocked on " + info.getLockName() +
-          ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
+            ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
       }
       stream.println("  Stack:");
       for (StackTraceElement frame : info.getStackTrace()) {

--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -173,7 +173,7 @@ public class TajoMaster extends CompositeService {
       RpcClientManager rpcManager = RpcClientManager.getInstance();
       rpcManager.setRetries(systemConf.getInt(RpcConstants.RPC_CLIENT_RETRY_MAX, RpcConstants.DEFAULT_RPC_RETRIES));
       rpcManager.setTimeoutSeconds(
-        systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
+          systemConf.getInt(RpcConstants.RPC_CLIENT_TIMEOUT_SECS, RpcConstants.DEFAULT_RPC_TIMEOUT_SECONDS));
 
       initResourceManager();
 
@@ -202,7 +202,7 @@ public class TajoMaster extends CompositeService {
 
       tajoMasterService = new QueryCoordinatorService(context);
       addIfService(tajoMasterService);
-
+      
       restServer = new TajoRestService(context);
       addIfService(restServer);
     } catch (Exception e) {
@@ -236,7 +236,7 @@ public class TajoMaster extends CompositeService {
 
   private void initResourceManager() throws Exception {
     Class<WorkerResourceManager>  resourceManagerClass = (Class<WorkerResourceManager>)
-      systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
+        systemConf.getClass(ConfVars.RESOURCE_MANAGER_CLASS.varname, TajoWorkerResourceManager.class);
     Constructor<WorkerResourceManager> constructor = resourceManagerClass.getConstructor(MasterContext.class);
     resourceManager = constructor.newInstance(context);
     addIfService(resourceManager);
@@ -246,7 +246,7 @@ public class TajoMaster extends CompositeService {
     if (!systemConf.get(CommonTestingUtil.TAJO_TEST_KEY, "FALSE").equalsIgnoreCase("TRUE")) {
       InetSocketAddress address = systemConf.getSocketAddrVar(ConfVars.TAJO_MASTER_INFO_ADDRESS);
       webServer = StaticHttpServer.getInstance(this ,"admin", address.getHostName(), address.getPort(),
-        true, null, context.getConf(), null);
+          true, null, context.getConf(), null);
       webServer.addServlet("queryServlet", "/query_exec", QueryExecutorServlet.class);
       webServer.start();
     }
@@ -295,14 +295,14 @@ public class TajoMaster extends CompositeService {
       LOG.info("Staging dir '" + stagingPath + "' is created");
     }
   }
-
+  
   private void diagnoseTajoMaster() throws EvaluationFailedException {
     SelfDiagnosisRuleEngine ruleEngine = SelfDiagnosisRuleEngine.getInstance();
     SelfDiagnosisRuleSession ruleSession = ruleEngine.newRuleSession();
     EvaluationContext context = new EvaluationContext();
-
+    
     context.addParameter(TajoConf.class.getName(), systemConf);
-
+    
     ruleSession.withCategoryNames("base", "master").fireRules(context);
   }
 
@@ -328,7 +328,7 @@ public class TajoMaster extends CompositeService {
 
     // Setting the system global configs
     systemConf.setSocketAddr(ConfVars.CATALOG_ADDRESS.varname,
-      NetUtils.getConnectAddress(catalogServer.getBindAddress()));
+        NetUtils.getConnectAddress(catalogServer.getBindAddress()));
 
     try {
       writeSystemConf();
@@ -399,7 +399,7 @@ public class TajoMaster extends CompositeService {
         LOG.error(e, e);
       }
     }
-
+    
     if (restServer != null) {
       try {
         restServer.stop();
@@ -502,7 +502,7 @@ public class TajoMaster extends CompositeService {
     public HistoryReader getHistoryReader() {
       return historyReader;
     }
-
+    
     public TajoRestService getRestServer() {
       return restServer;
     }
@@ -531,7 +531,7 @@ public class TajoMaster extends CompositeService {
       stream.println("Thread " + getThreadTaskName(info.getThreadId(), info.getThreadName()) + ":");
       Thread.State state = info.getThreadState();
       stream.println("  State: " + state + ", Blocked count: " + info.getBlockedCount() +
-        ", Waited count: " + info.getWaitedCount());
+          ", Waited count: " + info.getWaitedCount());
       if (contention) {
         stream.println("  Blocked time: " + info.getBlockedTime() + ", Waited time: " + info.getWaitedTime());
       }
@@ -539,7 +539,7 @@ public class TajoMaster extends CompositeService {
         stream.println("  Waiting on " + info.getLockName());
       } else if (state == Thread.State.BLOCKED) {
         stream.println("  Blocked on " + info.getLockName() +
-          ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
+            ", Blocked by " + getThreadTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
       }
       stream.println("  Stack:");
       for (StackTraceElement frame : info.getStackTrace()) {

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestBSTIndexExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestBSTIndexExec.java
@@ -143,8 +143,8 @@ public class TestBSTIndexExec {
     writer.close();
 
     TableDesc desc = new TableDesc(
-        CatalogUtil.buildFQName(TajoConstants.DEFAULT_DATABASE_NAME, "employee"), schema, meta,
-        sm.getTableUri(TajoConstants.DEFAULT_DATABASE_NAME, "employee"));
+      CatalogUtil.buildFQName(TajoConstants.DEFAULT_DATABASE_NAME, "employee"), schema, meta,
+      tablePath.toUri());
     catalog.createTable(desc);
 
     analyzer = new SQLAnalyzer();

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
@@ -102,11 +102,6 @@ public class TestExternalSortExec {
     appender.flush();
     appender.close();
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(appender.getStats().getNumRows() + " rows (" + (appender.getStats().getNumBytes() / 1048576) +
-        " MB)");
-    }
-
     employee = new TableDesc("default.employee", schema, employeeMeta, employeePath.toUri());
     catalog.createTable(employee);
     analyzer = new SQLAnalyzer();

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
@@ -18,6 +18,8 @@
 
 package org.apache.tajo.engine.planner.physical;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
 import org.apache.tajo.LocalTajoTestingUtility;
 import org.apache.tajo.TajoConstants;
@@ -52,6 +54,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestExternalSortExec {
+  private static final Log LOG = LogFactory.getLog(TestExternalSortExec.class);
+
   private TajoConf conf;
   private TajoTestingCluster util;
   private final String TEST_PATH = TajoTestingCluster.DEFAULT_TEST_DIRECTORY + "/TestExternalSortExec";
@@ -98,8 +102,10 @@ public class TestExternalSortExec {
     appender.flush();
     appender.close();
 
-    System.out.println(appender.getStats().getNumRows() + " rows (" + (appender.getStats().getNumBytes() / 1048576) +
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(appender.getStats().getNumRows() + " rows (" + (appender.getStats().getNumBytes() / 1048576) +
         " MB)");
+    }
 
     employee = new TableDesc("default.employee", schema, employeeMeta, employeePath.toUri());
     catalog.createTable(employee);

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestExternalSortExec.java
@@ -18,8 +18,6 @@
 
 package org.apache.tajo.engine.planner.physical;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
 import org.apache.tajo.LocalTajoTestingUtility;
 import org.apache.tajo.TajoConstants;
@@ -54,8 +52,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestExternalSortExec {
-  private static final Log LOG = LogFactory.getLog(TestExternalSortExec.class);
-
   private TajoConf conf;
   private TajoTestingCluster util;
   private final String TEST_PATH = TajoTestingCluster.DEFAULT_TEST_DIRECTORY + "/TestExternalSortExec";

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
@@ -106,10 +106,6 @@ public class TestProgressExternalSortExec {
     appender.flush();
     appender.close();
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(appender.getStats().getNumRows() + " rows (" + appender.getStats().getNumBytes() + " Bytes)");
-    }
-
     testDataStats = appender.getStats();
     employee = new TableDesc(
         CatalogUtil.buildFQName(TajoConstants.DEFAULT_DATABASE_NAME, "employee"), schema, employeeMeta,

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
@@ -19,6 +19,8 @@
 package org.apache.tajo.engine.planner.physical;
 
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
 import org.apache.tajo.LocalTajoTestingUtility;
 import org.apache.tajo.TajoConstants;
@@ -55,6 +57,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestProgressExternalSortExec {
+  private static final Log LOG = LogFactory.getLog(TestProgressExternalSortExec.class);
+
   private TajoConf conf;
   private TajoTestingCluster util;
   private final String TEST_PATH = TajoTestingCluster.DEFAULT_TEST_DIRECTORY + "/TestProgressExternalSortExec";
@@ -102,7 +106,9 @@ public class TestProgressExternalSortExec {
     appender.flush();
     appender.close();
 
-    System.out.println(appender.getStats().getNumRows() + " rows (" + appender.getStats().getNumBytes() + " Bytes)");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(appender.getStats().getNumRows() + " rows (" + appender.getStats().getNumBytes() + " Bytes)");
+    }
 
     testDataStats = appender.getStats();
     employee = new TableDesc(

--- a/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/planner/physical/TestProgressExternalSortExec.java
@@ -19,8 +19,6 @@
 package org.apache.tajo.engine.planner.physical;
 
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
 import org.apache.tajo.LocalTajoTestingUtility;
 import org.apache.tajo.TajoConstants;
@@ -57,8 +55,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestProgressExternalSortExec {
-  private static final Log LOG = LogFactory.getLog(TestProgressExternalSortExec.class);
-
   private TajoConf conf;
   private TajoTestingCluster util;
   private final String TEST_PATH = TajoTestingCluster.DEFAULT_TEST_DIRECTORY + "/TestProgressExternalSortExec";

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestSortQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestSortQuery.java
@@ -24,7 +24,6 @@ import org.apache.tajo.TajoConstants;
 import org.apache.tajo.TajoTestingCluster;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.common.TajoDataTypes.Type;
-import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.conf.TajoConf.ConfVars;
 import org.apache.tajo.storage.StorageConstants;
 import org.apache.tajo.util.KeyValueSet;

--- a/tajo-core/src/test/java/org/apache/tajo/engine/query/TestSortQuery.java
+++ b/tajo-core/src/test/java/org/apache/tajo/engine/query/TestSortQuery.java
@@ -68,7 +68,6 @@ public class TestSortQuery extends QueryTestCaseBase {
   @Test
   public final void testSortWithAlias3() throws Exception {
     ResultSet res = executeQuery();
-    System.out.println(resultSetToString(res));
     cleanupQuery(res);
   }
 

--- a/tajo-core/src/test/java/org/apache/tajo/querymaster/TestTaskStatusUpdate.java
+++ b/tajo-core/src/test/java/org/apache/tajo/querymaster/TestTaskStatusUpdate.java
@@ -100,9 +100,6 @@ public class TestTaskStatusUpdate extends QueryTestCaseBase {
        */
       res = executeQuery();
 
-      String actualResult = resultSetToString(res);
-      System.out.println(actualResult);
-
       // in/out * stage(4)
       long[] expectedNumRows = new long[]{2, 2, 5, 5, 7, 2, 2, 2};
       long[] expectedNumBytes = new long[]{8, 34, 20, 75, 109, 34, 34, 18};

--- a/tajo-core/src/test/java/org/apache/tajo/storage/TestRowFile.java
+++ b/tajo-core/src/test/java/org/apache/tajo/storage/TestRowFile.java
@@ -19,6 +19,8 @@
 package org.apache.tajo.storage;
 
 import com.google.common.collect.Sets;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -45,6 +47,8 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 
 public class TestRowFile {
+  private static final Log LOG = LogFactory.getLog(TestRowFile.class);
+
   private TajoTestingCluster cluster;
   private TajoConf conf;
 
@@ -126,8 +130,8 @@ public class TestRowFile {
       scanner = new RowFile.RowFileScanner(conf, schema, meta, fragment);
       scanner.init();
       while ((tuple=scanner.next()) != null) {
-        if (!idSet.remove(tuple.getInt4(0))) {
-          System.out.println("duplicated! " + tuple.getInt4(0));
+        if (!idSet.remove(tuple.getInt4(0)) && LOG.isDebugEnabled()) {
+          LOG.debug("duplicated! " + tuple.getInt4(0));
         }
         tupleCnt++;
       }

--- a/tajo-core/src/test/java/org/apache/tajo/util/metrics/TestSystemMetrics.java
+++ b/tajo-core/src/test/java/org/apache/tajo/util/metrics/TestSystemMetrics.java
@@ -54,12 +54,15 @@ public class TestSystemMetrics {
     out.write("reporter.file=org.apache.tajo.util.metrics.reporter.MetricsFileScheduledReporter\n".getBytes());
     out.write("reporter.console=org.apache.tajo.util.metrics.reporter.MetricsConsoleScheduledReporter\n".getBytes());
 
+    out.write("test-file-group-jvm.reporters=console\n".getBytes());
     out.write("test-file-group.reporters=file\n".getBytes());
     out.write("test-console-group.reporters=console\n".getBytes());
     out.write("test-find-console-group.reporters=console,file\n".getBytes());
 
     out.write(("test-file-group.file.filename=" + metricsOutputFile.toUri().getPath() + "\n").getBytes());
     out.write("test-file-group.file.period=5\n".getBytes());
+
+    out.close();
   }
 
   @Test
@@ -71,7 +74,7 @@ public class TestSystemMetrics {
 
     Collection<TajoMetricsScheduledReporter> reporters = tajoSystemMetrics.getMetricsReporters();
 
-    assertEquals(1, reporters.size());
+    assertEquals(2, reporters.size());
 
     TajoMetricsScheduledReporter reporter = reporters.iterator().next();
     assertEquals(5, reporter.getPeriod());

--- a/tajo-core/src/test/java/org/apache/tajo/util/metrics/TestSystemMetrics.java
+++ b/tajo-core/src/test/java/org/apache/tajo/util/metrics/TestSystemMetrics.java
@@ -61,7 +61,6 @@ public class TestSystemMetrics {
 
     out.write(("test-file-group.file.filename=" + metricsOutputFile.toUri().getPath() + "\n").getBytes());
     out.write("test-file-group.file.period=5\n".getBytes());
-
     out.close();
   }
 

--- a/tajo-core/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
+++ b/tajo-core/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
@@ -19,8 +19,6 @@
 package org.apache.tajo.worker;
 
 import com.google.common.collect.Lists;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.yarn.event.AsyncDispatcher;
@@ -45,7 +43,6 @@ import static org.junit.Assert.*;
 
 import static org.apache.tajo.ipc.TajoWorkerProtocol.*;
 public class TestNodeResourceManager {
-  private static final Log LOG = LogFactory.getLog(TestNodeResourceManager.class);
 
   private MockNodeResourceManager resourceManager;
   private NodeStatusUpdater statusUpdater;

--- a/tajo-core/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
+++ b/tajo-core/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
@@ -256,9 +256,6 @@ public class TestNodeResourceManager {
                   fail(e.getMessage());
                 }
               }
-              if (LOG.isDebugEnabled()) {
-                LOG.debug(Thread.currentThread().getName() + " complete requests: " + complete);
-              }
               totalComplete.addAndGet(complete);
             }
           })
@@ -269,10 +266,6 @@ public class TestNodeResourceManager {
       future.get();
     }
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(parallelCount + " Thread, completed requests: " + totalComplete.get() + ", canceled requests:"
-        + totalCanceled.get() + ", " + +(System.currentTimeMillis() - startTime) + " ms elapsed");
-    }
     executor.shutdown();
     assertEquals(taskSize, totalComplete.get());
   }

--- a/tajo-core/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
+++ b/tajo-core/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
@@ -19,6 +19,8 @@
 package org.apache.tajo.worker;
 
 import com.google.common.collect.Lists;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.yarn.event.AsyncDispatcher;
@@ -43,6 +45,7 @@ import static org.junit.Assert.*;
 
 import static org.apache.tajo.ipc.TajoWorkerProtocol.*;
 public class TestNodeResourceManager {
+  private static final Log LOG = LogFactory.getLog(TestNodeResourceManager.class);
 
   private MockNodeResourceManager resourceManager;
   private NodeStatusUpdater statusUpdater;
@@ -253,7 +256,9 @@ public class TestNodeResourceManager {
                   fail(e.getMessage());
                 }
               }
-              System.out.println(Thread.currentThread().getName() + " complete requests: " + complete);
+              if (LOG.isDebugEnabled()) {
+                LOG.debug(Thread.currentThread().getName() + " complete requests: " + complete);
+              }
               totalComplete.addAndGet(complete);
             }
           })
@@ -264,8 +269,10 @@ public class TestNodeResourceManager {
       future.get();
     }
 
-    System.out.println(parallelCount + " Thread, completed requests: " + totalComplete.get() + ", canceled requests:"
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(parallelCount + " Thread, completed requests: " + totalComplete.get() + ", canceled requests:"
         + totalCanceled.get() + ", " + +(System.currentTimeMillis() - startTime) + " ms elapsed");
+    }
     executor.shutdown();
     assertEquals(taskSize, totalComplete.get());
   }

--- a/tajo-rpc/tajo-ws-rs/src/main/java/org/apache/tajo/ws/rs/netty/NettyRestHandlerContainer.java
+++ b/tajo-rpc/tajo-ws-rs/src/main/java/org/apache/tajo/ws/rs/netty/NettyRestHandlerContainer.java
@@ -75,6 +75,10 @@ public class NettyRestHandlerContainer extends ChannelDuplexHandler implements C
     lifecycleListener = ConfigHelper.getContainerLifecycleListener(applicationHandler);
   }
 
+  public ApplicationHandler getApplicationHandler() {
+    return applicationHandler;
+  }
+
   @Override
   public ResourceConfig getConfiguration() {
     return applicationHandler.getConfiguration();

--- a/tajo-rpc/tajo-ws-rs/src/main/java/org/apache/tajo/ws/rs/netty/NettyRestServerListener.java
+++ b/tajo-rpc/tajo-ws-rs/src/main/java/org/apache/tajo/ws/rs/netty/NettyRestServerListener.java
@@ -52,7 +52,7 @@ public class NettyRestServerListener implements RpcEventListener {
 
   @Override
   public void onAfterStart(Object obj) {
-    if (container instanceof NettyRestHandlerContainer) {
+    if (container instanceof NettyRestHandlerContainer) { 
       NettyRestHandlerContainer restHandlerContainer = ((NettyRestHandlerContainer) container);
       ApplicationHandler applicationHandler = restHandlerContainer.getApplicationHandler();
       ContainerLifecycleListener lifecycleListener = ConfigHelper.getContainerLifecycleListener(applicationHandler);

--- a/tajo-rpc/tajo-ws-rs/src/main/java/org/apache/tajo/ws/rs/netty/NettyRestServerListener.java
+++ b/tajo-rpc/tajo-ws-rs/src/main/java/org/apache/tajo/ws/rs/netty/NettyRestServerListener.java
@@ -42,16 +42,22 @@ public class NettyRestServerListener implements RpcEventListener {
 
   @Override
   public void onAfterShutdown(Object obj) {
-    ApplicationHandler applicationHandler = new ApplicationHandler(container.getConfiguration());
-    ContainerLifecycleListener lifecycleListener = ConfigHelper.getContainerLifecycleListener(applicationHandler);
-    lifecycleListener.onShutdown(container);
+    if (container instanceof NettyRestHandlerContainer) {
+      NettyRestHandlerContainer restHandlerContainer = ((NettyRestHandlerContainer) container);
+      ApplicationHandler applicationHandler = restHandlerContainer.getApplicationHandler();
+      ContainerLifecycleListener lifecycleListener = ConfigHelper.getContainerLifecycleListener(applicationHandler);
+      lifecycleListener.onShutdown(container);
+    }
   }
 
   @Override
   public void onAfterStart(Object obj) {
-    ApplicationHandler applicationHandler = new ApplicationHandler(container.getConfiguration());
-    ContainerLifecycleListener lifecycleListener = ConfigHelper.getContainerLifecycleListener(applicationHandler);
-    lifecycleListener.onStartup(container);
+    if (container instanceof NettyRestHandlerContainer) {
+      NettyRestHandlerContainer restHandlerContainer = ((NettyRestHandlerContainer) container);
+      ApplicationHandler applicationHandler = restHandlerContainer.getApplicationHandler();
+      ContainerLifecycleListener lifecycleListener = ConfigHelper.getContainerLifecycleListener(applicationHandler);
+      lifecycleListener.onStartup(container);
+    }
   }
 
   @Override

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestDelimitedTextFile.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestDelimitedTextFile.java
@@ -19,6 +19,8 @@
 package org.apache.tajo.storage;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -41,6 +43,7 @@ import java.net.URL;
 import static org.junit.Assert.*;
 
 public class TestDelimitedTextFile {
+  private static final Log LOG = LogFactory.getLog(TestDelimitedTextFile.class);
 
   private static Schema schema = new Schema();
 
@@ -133,7 +136,7 @@ public class TestDelimitedTextFile {
     try {
       scanner.next();
     } catch (IOException ioe) {
-      System.out.println(ioe);
+      LOG.error(ioe);
       return;
     } finally {
       scanner.close();


### PR DESCRIPTION
Enable -B (batch) mode on the build. This will make the logs shorter since it avoids the dependency download progress logging.