### PR TITLE
TAJO-1679: Client APIs should validate identifiers for database object names.

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
@@ -51,6 +51,37 @@ import static org.apache.tajo.common.TajoDataTypes.Type;
 public class CatalogUtil {
 
   public static final String TEXTFILE_NAME = "TEXT";
+
+  public static boolean isValidQualifiedIdentifier(String identifier) {
+    return isValidIdentifier(identifier, true);
+  }
+
+  public static boolean isValidSimplIdentifier(String identifier) {
+    return isValidIdentifier(identifier, false);
+  }
+
+  private static boolean isValidIdentifier(String identifier, boolean inclusiveDot) {
+    Preconditions.checkNotNull("isValidIdentifier cannot null value");
+
+    boolean valid = identifier.length() > 0;
+    valid &= StringUtils.isValidFirstIdentifierChar(identifier.charAt(0));
+
+    for (int i = 0; i < identifier.length(); i++) {
+      if (inclusiveDot) {
+        valid &= StringUtils.isPartOfAnsiSQLIdentifier(identifier.charAt(i)) ||
+            identifier.charAt(i) == CatalogConstants.IDENTIFIER_DELIMITER_REGEXP.charAt(0);
+      } else {
+        valid &= StringUtils.isPartOfAnsiSQLIdentifier(identifier.charAt(i));
+      }
+
+      if (!valid) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   /**
    * Normalize an identifier. Normalization means a translation from a identifier to be a refined identifier name.
    *

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/exception/InvalidNameException.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/exception/InvalidNameException.java
@@ -1,0 +1,28 @@
+/*
+ * Lisensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.catalog.exception;
+
+
+public class InvalidNameException extends CatalogException {
+	public InvalidNameException() {}
+
+	public InvalidNameException(String databaseName) {
+		super("ERROR: invalid name \"" + databaseName + "\"");
+	}
+}

--- a/tajo-common/src/main/java/org/apache/tajo/util/StringUtils.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/StringUtils.java
@@ -92,6 +92,10 @@ public class StringUtils {
     return "\"" + str + "\"";
   }
 
+  public static boolean isValidFirstIdentifierChar(char character) {
+    return isLowerCaseAlphabet(character) || isUpperCaseAlphabet(character) || isUndersscore(character);
+  }
+
   public static boolean isPartOfAnsiSQLIdentifier(char character) {
     return
         isLowerCaseAlphabet(character) ||

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
@@ -145,6 +145,10 @@ public class DDLExecutor {
       tablespaceName = tablespace;
     }
 
+    if (!CatalogUtil.isValidSimplIdentifier(databaseName)) {
+      throw new InvalidNameException(databaseName);
+    }
+
     // CREATE DATABASE IF NOT EXISTS
     boolean exists = catalog.existDatabase(databaseName);
     if (exists) {
@@ -192,8 +196,8 @@ public class DDLExecutor {
   //--------------------------------------------------------------------------
   private TableDesc createTable(QueryContext queryContext, CreateTableNode createTable, boolean ifNotExists)
       throws IOException {
-    TableMeta meta;
 
+    TableMeta meta;
     if (createTable.hasOptions()) {
       meta = CatalogUtil.newTableMeta(createTable.getStorageType(), createTable.getOptions());
     } else {
@@ -226,6 +230,17 @@ public class DDLExecutor {
                                boolean isExternal,
                                @Nullable PartitionMethodDesc partitionDesc,
                                boolean ifNotExists) throws IOException {
+
+    // Validate identifiers
+    if (!CatalogUtil.isValidQualifiedIdentifier(tableName)) {
+      throw new InvalidNameException(tableName);
+    }
+    for (Column c :schema.getAllColumns()) {
+      if (!CatalogUtil.isValidQualifiedIdentifier(c.getQualifiedName())) {
+        throw new InvalidNameException(tableName);
+      }
+    }
+
     String databaseName;
     String simpleTableName;
     if (CatalogUtil.isFQTableName(tableName)) {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/TAJO-1679.

For example, the current API accepts wrong object names as follows:
```java
client.createDatabase("12345");
```

This patch does not include the unit tests because the current error propagation system just causes exceptions in TajoMaster and cannot catch this kind of errors. This problem will be solved in TAJO-1670 and failure unit tests will be added in that jira too.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/tajo/627)
<!-- Reviewable:end -->
