### PR TITLE
TAJO-1712: querytasks.jsp throws NPE occasionally when tasks are running.

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/master/QueryManager.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/QueryManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.master;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.collections.map.LRUMap;
@@ -44,10 +45,7 @@ import org.apache.tajo.session.Session;
 import org.apache.tajo.util.history.HistoryReader;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -119,17 +117,51 @@ public class QueryManager extends CompositeService {
     return Collections.unmodifiableCollection(runningQueries.values());
   }
 
+  @Deprecated
   public Collection<QueryInfo> getFinishedQueries() {
     Set<QueryInfo> result = Sets.newTreeSet();
+
     synchronized (historyCache) {
       result.addAll(historyCache.values());
     }
 
     try {
       synchronized (this) {
-        result.addAll(this.masterContext.getHistoryReader().getQueries(null));
+        result.addAll(this.masterContext.getHistoryReader().getQueriesInHistory());
       }
       return result;
+    } catch (Throwable e) {
+      LOG.error(e, e);
+      return result;
+    }
+  }
+
+  /**
+   * Get query history in cache or persistent storage
+   */
+  public Collection<QueryInfo> getFinishedQueries(int page, int size) {
+    TreeSet<QueryInfo> result = Sets.newTreeSet();
+    if(page <= 0 || size <= 0) {
+      return result;
+    }
+
+    List<QueryInfo> cacheList = Lists.newArrayList();
+    synchronized (historyCache) {
+      if (page == 1 && size <= historyCache.size()) {
+        cacheList.addAll(historyCache.values());
+      }
+    }
+
+    // request size fits in cache
+    if (cacheList.size() > 0) {
+      result.addAll(cacheList.subList(0, size));
+      return result;
+    }
+
+    try {
+      synchronized (this) {
+        return this.masterContext.getHistoryReader().getQueriesInHistory(page, size);
+      }
     } catch (Throwable e) {
       LOG.error(e, e);
       return result;
@@ -144,7 +176,7 @@ public class QueryManager extends CompositeService {
       }
       if (queryInfo == null) {
         synchronized (this) {
-          queryInfo = this.masterContext.getHistoryReader().getQueryInfo(queryId.toString());
+          queryInfo = this.masterContext.getHistoryReader().getQueryByQueryId(queryId);
         }
       }
       return queryInfo;

--- a/tajo-core/src/main/java/org/apache/tajo/master/QueryManager.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/QueryManager.java
@@ -147,12 +147,12 @@ public class QueryManager extends CompositeService {
 
     List<QueryInfo> cacheList = Lists.newArrayList();
     synchronized (historyCache) {
+      // request size fits in cache
       if (page == 1 && size <= historyCache.size()) {
         cacheList.addAll(historyCache.values());
       }
     }
 
-    // request size fits in cache
     if (cacheList.size() > 0) {
       result.addAll(cacheList.subList(0, size));
       return result;

--- a/tajo-core/src/main/java/org/apache/tajo/util/JSPUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/util/JSPUtil.java
@@ -355,6 +355,25 @@ public class JSPUtil {
     return sb.toString();
   }
 
+  public static String getPageNavigation(int currentPage, boolean next, String url) {
+    StringBuilder sb = new StringBuilder();
+    if (currentPage > 1) {
+      sb.append("<a href='").append(url)
+          .append("&page=").append(currentPage - 1).append("'>")
+          .append("&lt;prev</a>");
+      sb.append("&nbsp;&nbsp;");
+    }
+
+    sb.append(currentPage);
+
+    if(next) {
+      sb.append("&nbsp;&nbsp;").append("<a href='").append(url)
+          .append("&page=").append(currentPage + 1).append("'>")
+          .append("next&gt;</a>");
+    }
+    return sb.toString();
+  }
+
   public static <T extends Object> List<T> getPageNavigationList(List<T> originList, int page, int pageSize) {
     if (originList == null) {
       return new ArrayList<T>();

--- a/tajo-core/src/main/resources/webapps/admin/query.jsp
+++ b/tajo-core/src/main/resources/webapps/admin/query.jsp
@@ -59,14 +59,9 @@
     }
   }
 
-  List<QueryInfo> allFinishedQueries = new ArrayList<QueryInfo>(master.getContext().getQueryJobManager().getFinishedQueries());
-  Collections.sort(allFinishedQueries, java.util.Collections.reverseOrder());
-
-  int numOfFinishedQueries = allFinishedQueries.size();
-  int totalPage = numOfFinishedQueries % pageSize == 0 ?
-      numOfFinishedQueries / pageSize : numOfFinishedQueries / pageSize + 1;
-
-  List<QueryInfo> finishedQueries = JSPUtil.getPageNavigationList(allFinishedQueries, currentPage, pageSize);
+  List<QueryInfo> finishedQueries = new ArrayList<QueryInfo>(
+          master.getContext().getQueryJobManager().getFinishedQueries(currentPage, pageSize));
+  Collections.sort(finishedQueries, java.util.Collections.reverseOrder());
 
   SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
@@ -220,7 +215,7 @@
     %>
   </table>
   <div align="center">
-    <%=JSPUtil.getPageNavigation(currentPage, totalPage, "query.jsp?pageSize=" + pageSize)%>
+      <%=JSPUtil.getPageNavigation(currentPage, finishedQueries.size() == pageSize, "query.jsp?pageSize=" + pageSize)%>
   </div>
   <p/>
 <%

--- a/tajo-core/src/main/resources/webapps/worker/querytasks.jsp
+++ b/tajo-core/src/main/resources/webapps/worker/querytasks.jsp
@@ -111,16 +111,18 @@
 
   float totalProgress = 0.0f;
   for(Task eachTask : allTasks) {
-    totalProgress += eachTask.getLastAttempt() != null ? eachTask.getLastAttempt().getProgress(): 0.0f;
+
     numShuffles = eachTask.getShuffleOutpuNum();
-    if (eachTask.getLastAttempt() != null) {
-      TableStats inputStats = eachTask.getLastAttempt().getInputStats();
+    TaskAttempt lastAttempt = eachTask.getLastAttempt();
+    if (lastAttempt != null) {
+      totalProgress +=  lastAttempt.getProgress();
+      TableStats inputStats = lastAttempt.getInputStats();
       if (inputStats != null) {
         totalInputBytes += inputStats.getNumBytes();
         totalReadBytes += inputStats.getReadBytes();
         totalReadRows += inputStats.getNumRows();
       }
-      TableStats outputStats = eachTask.getLastAttempt().getResultStats();
+      TableStats outputStats = lastAttempt.getResultStats();
       if (outputStats != null) {
         totalWriteBytes += outputStats.getNumBytes();
         totalWriteRows += outputStats.getNumRows();
@@ -231,18 +233,20 @@
             "&taskSeq=" + taskSeq + "&sort=" + sort + "&sortOrder=" + sortOrder;
 
     TaskAttempt lastAttempt = eachTask.getLastAttempt();
-    String taskHost = lastAttempt == null ? "-" : lastAttempt.getWorkerConnectionInfo().getHost();
-    if(lastAttempt != null) {
+    String taskHost = "-";
+    float progress = 0.0f;
+    if(lastAttempt != null && lastAttempt.getWorkerConnectionInfo() != null) {
       WorkerConnectionInfo conn = lastAttempt.getWorkerConnectionInfo();
       TaskAttemptId lastAttemptId = lastAttempt.getId();
       taskHost = "<a href='http://" + conn.getHost() + ":" + conn.getHttpInfoPort() + "/taskdetail.jsp?taskAttemptId=" + lastAttemptId + "'>" + conn.getHost() + "</a>";
+      progress = eachTask.getLastAttempt().getProgress();
     }
 %>
     <tr>
       <td align='center'><%=rowNo%></td>
       <td><a href="<%=taskDetailUrl%>"><%=eachTask.getId()%></a></td>
       <td align='center'><%=eachTask.getLastAttemptStatus()%></td>
-      <td align='center'><%=JSPUtil.percentFormat(eachTask.getLastAttempt().getProgress())%>%</td>
+      <td align='center'><%=JSPUtil.percentFormat(progress)%>%</td>
       <td align='center'><%=eachTask.getLaunchTime() == 0 ? "-" : df.format(eachTask.getLaunchTime())%></td>
       <td align='right'><%=eachTask.getLaunchTime() == 0 ? "-" : eachTask.getRunningTime() + " ms"%></td>
       <td align='center'><%=eachTask.getRetryCount()%></td>

--- a/tajo-core/src/test/java/org/apache/tajo/util/history/TestHistoryWriterReader.java
+++ b/tajo-core/src/test/java/org/apache/tajo/util/history/TestHistoryWriterReader.java
@@ -90,7 +90,7 @@ public class TestHistoryWriterReader extends QueryTestCaseBase {
       assertTrue(histFiles[0].getPath().getName().endsWith(".hist"));
 
       HistoryReader reader = new HistoryReader("127.0.0.1:28090", tajoConf);
-      List<QueryInfo> queryInfos = reader.getQueries(null);
+      List<QueryInfo> queryInfos = reader.getQueriesInHistory(1, 2);
       assertNotNull(queryInfos);
       assertEquals(2, queryInfos.size());
 
@@ -99,7 +99,17 @@ public class TestHistoryWriterReader extends QueryTestCaseBase {
       assertEquals(queryInfo2.getQueryState(), foundQueryInfo.getQueryState());
       assertEquals(queryInfo2.getProgress(), foundQueryInfo.getProgress(), 0);
 
+      foundQueryInfo = reader.getQueryByQueryId(queryInfo2.getQueryId());
+      assertEquals(queryInfo2.getQueryId(), foundQueryInfo.getQueryId());
+      assertEquals(queryInfo2.getQueryState(), foundQueryInfo.getQueryState());
+      assertEquals(queryInfo2.getProgress(), foundQueryInfo.getProgress(), 0);
+
       foundQueryInfo = queryInfos.get(1);
+      assertEquals(queryInfo1.getQueryId(), foundQueryInfo.getQueryId());
+      assertEquals(queryInfo1.getQueryState(), foundQueryInfo.getQueryState());
+      assertEquals(queryInfo1.getProgress(), foundQueryInfo.getProgress(), 0);
+
+      foundQueryInfo = reader.getQueryByQueryId(queryInfo1.getQueryId());
       assertEquals(queryInfo1.getQueryId(), foundQueryInfo.getQueryId());
       assertEquals(queryInfo1.getQueryState(), foundQueryInfo.getQueryState());
       assertEquals(queryInfo1.getProgress(), foundQueryInfo.getProgress(), 0);


### PR DESCRIPTION
Current implementation opens the all file in order to get the total size.
So I've remove the pagination in query page and add to the next link  