### PR TITLE
TAJO-1715: Precompute the hash value of various kinds of ids

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/TaskAttemptId.java
+++ b/tajo-common/src/main/java/org/apache/tajo/TaskAttemptId.java
@@ -25,6 +25,7 @@ public class TaskAttemptId implements Comparable<TaskAttemptId> {
 
   private TaskId taskId;
   private int id;
+  private final int hashValue;
 
   public TaskId getTaskId() {
     return taskId;
@@ -41,6 +42,7 @@ public class TaskAttemptId implements Comparable<TaskAttemptId> {
   public TaskAttemptId(TaskId taskId, int id) {
     this.taskId = taskId;
     this.id = id;
+    this.hashValue = Objects.hashCode(taskId, id);
   }
 
   public TaskAttemptId(TajoIdProtos.TaskAttemptIdProto proto) {
@@ -80,7 +82,7 @@ public class TaskAttemptId implements Comparable<TaskAttemptId> {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(taskId, id);
+    return hashValue;
   }
 
   @Override

--- a/tajo-common/src/main/java/org/apache/tajo/TaskId.java
+++ b/tajo-common/src/main/java/org/apache/tajo/TaskId.java
@@ -25,10 +25,12 @@ public class TaskId implements Comparable<TaskId> {
 
   private ExecutionBlockId executionBlockId;
   private int id;
+  private final int hashValue;
 
   public TaskId(ExecutionBlockId executionBlockId, int id) {
     this.executionBlockId = executionBlockId;
     this.id = id;
+    this.hashValue = Objects.hashCode(executionBlockId, id);
   }
 
   public TaskId(TajoIdProtos.TaskIdProto proto) {
@@ -76,7 +78,7 @@ public class TaskId implements Comparable<TaskId> {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(executionBlockId, id);
+    return hashValue;
   }
 
   @Override

--- a/tajo-common/src/main/java/org/apache/tajo/storage/VTuple.java
+++ b/tajo-common/src/main/java/org/apache/tajo/storage/VTuple.java
@@ -221,8 +221,8 @@ public class VTuple implements Tuple, Cloneable {
   public VTuple clone() throws CloneNotSupportedException {
     VTuple tuple = (VTuple) super.clone();
 
-    tuple.values = new Datum[size()];
-    System.arraycopy(values, 0, tuple.values, 0, size()); //shallow copy
+    tuple.values = new Datum[values.length];
+    System.arraycopy(values, 0, tuple.values, 0, values.length); //shallow copy
     return tuple;
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/KeyTuple.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/KeyTuple.java
@@ -27,7 +27,7 @@ import org.apache.tajo.storage.VTuple;
  * Datum.hashCode() uses MurmurHash, so its cost is not so cheap.
  *
  */
-public class KeyTuple extends VTuple {
+public class KeyTuple extends VTuple implements Cloneable {
   private int hashCode;
 
   public KeyTuple(int size) {
@@ -71,6 +71,11 @@ public class KeyTuple extends VTuple {
   public void put(Datum [] values) {
     super.put(values);
     updateHashCode();
+  }
+
+  @Override
+  public KeyTuple clone() throws CloneNotSupportedException {
+    return (KeyTuple) super.clone();
   }
 
   @Override

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/TupleMap.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/TupleMap.java
@@ -54,7 +54,11 @@ public class TupleMap<E> extends HashMap<KeyTuple, E> {
   @Override
   public E put(@Nullable KeyTuple key, E value) {
     if (key != null) {
-      return super.put(new KeyTuple(key.getValues()), value);
+      try {
+        return super.put(key.clone(), value);
+      } catch (CloneNotSupportedException e) {
+        throw new RuntimeException(e);
+      }
     } else {
       return super.put(null, value);
     }


### PR DESCRIPTION
Changes are:
* Statically maintaining the hash value in TaskId and TaskAttemptId
 * This is because, unlike QueryId and ExecutionBlockId, it is expected there are many tasks and their attempts.
* Improving TupleMap.put()
 * Copying tuple is expensive, so I implemented the clone() method for KeyTuple.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/tajo/658)
<!-- Reviewable:end -->
