### PR TITLE
TAJO-1716: Repartitioner.makeEvenDistributedFetchImpl() does not distribute fetches evenly

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -914,8 +914,9 @@ public class Repartitioner {
     // algorithm.
     Iterator<FetchGroupMeta> iterator = fetchGroupMetaList.iterator();
 
-    int p = 0;
+    int p;
     while(iterator.hasNext()) {
+      p = 0;
       while (p < num && iterator.hasNext()) {
         FetchGroupMeta fetchGroupMeta = iterator.next();
         assignedVolumes[p] += fetchGroupMeta.getVolume();
@@ -925,13 +926,13 @@ public class Repartitioner {
       }
 
       p = num - 1;
-      while (p > 0 && iterator.hasNext()) {
+      while (p >= 0 && iterator.hasNext()) {
         FetchGroupMeta fetchGroupMeta = iterator.next();
         assignedVolumes[p] += fetchGroupMeta.getVolume();
         TUtil.putCollectionToNestedList(fetchesArray[p], tableName, fetchGroupMeta.fetchUrls);
 
         // While the current one is smaller than next one, it adds additional fetches to current one.
-        while(iterator.hasNext() && assignedVolumes[p - 1] > assignedVolumes[p]) {
+        while(iterator.hasNext() && (p > 0 && assignedVolumes[p - 1] > assignedVolumes[p])) {
           FetchGroupMeta additionalFetchGroup = iterator.next();
           assignedVolumes[p] += additionalFetchGroup.getVolume();
           TUtil.putCollectionToNestedList(fetchesArray[p], tableName, additionalFetchGroup.fetchUrls);

--- a/tajo-core/src/test/java/org/apache/tajo/master/TestRepartitioner.java
+++ b/tajo-core/src/test/java/org/apache/tajo/master/TestRepartitioner.java
@@ -136,7 +136,7 @@ public class TestRepartitioner {
     assertFetchImpl(fetches, results.getSecond());
 
     results = Repartitioner.makeEvenDistributedFetchImpl(fetchGroups, tableName, 2);
-    long expected0 [] = {130, 165};
+    long expected0 [] = {140, 155};
     assertFetchVolumes(expected0, results.getFirst());
     assertFetchImpl(fetches, results.getSecond());
 


### PR DESCRIPTION
Here is the evaluation result.
* # of samples: 1000
 * The sample size follows the zipf distribution in the range [1, 100].
* # of fetches: 2000

### Before patch
```
# of partitions: 10
std dev: 7239.203108077597
# of partitions: 20
std dev: 2507.946123823235
# of partitions: 30
std dev: 1337.669359578645
# of partitions: 40
std dev: 847.1299428068963
# of partitions: 50
std dev: 590.6100520648041
# of partitions: 60
std dev: 441.75456483838553
# of partitions: 70
std dev: 340.5741442844647
# of partitions: 80
std dev: 270.92110936581224
# of partitions: 90
std dev: 221.5819175222533
# of partitions: 100
std dev: 184.4234215060522
```
### After patch
```
# of partitions: 10
std dev: 13.61763562654033
# of partitions: 20
std dev: 21.6693331706813
# of partitions: 30
std dev: 15.134361197689614
# of partitions: 40
std dev: 13.04185569631777
# of partitions: 50
std dev: 14.063911262269487
# of partitions: 60
std dev: 12.51514637879624
# of partitions: 70
std dev: 12.309312883565598
# of partitions: 80
std dev: 29.554991118293103
# of partitions: 90
std dev: 37.39714123885218
# of partitions: 100
std dev: 11.820253804288662
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/tajo/659)
<!-- Reviewable:end -->
