### PR TITLE
TAJO-1848: ShutdownHook in TajoMaster can throw NPE if serviceInit() is failed.

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/TajoMaster.java
@@ -544,7 +544,8 @@ public class TajoMaster extends CompositeService {
         stop();
 
         // If embedded derby is used as catalog, shutdown it.
-        if (catalogServer.getStoreClassName().equals("org.apache.tajo.catalog.store.DerbyStore")
+        if (catalogServer != null &&
+            catalogServer.getStoreClassName().equals("org.apache.tajo.catalog.store.DerbyStore")
             && AbstractDBStore.needShutdown(catalogServer.getStoreUri())) {
           DerbyStore.shutdown();
         }


### PR DESCRIPTION
…is failed.