### PR TITLE
TAJO-1864: CatalogStore::getAllPartitions need to throw PartitionNotFoundException if there is no partitions on catalog.

### DIFF
--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
@@ -857,13 +857,7 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
     request.setTableName(tableName);
     request.setFilter("");
 
-    List<PartitionDescProto> partitions = getPartitionsByFilter(request.build());
-
-    if (partitions.size() == 0) {
-      throw new TajoInternalError(new PartitionNotFoundException(tableName));
-    } else {
-      return partitions;
-    }
+    return getPartitionsByFilter(request.build());
   }
 
   @Override
@@ -1161,8 +1155,6 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
     try {
       client = clientPool.getClient();
       for (CatalogProtos.PartitionDescProto partitionDescProto : partitions) {
-        existingPartition = getPartition(databaseName, tableName, partitionDescProto.getPartitionName());
-
         // Unfortunately, hive client add_partitions doesn't run as expected. The method never read the ifNotExists
         // parameter. So, if Tajo adds existing partition to Hive, it will threw AlreadyExistsException. To avoid
         // above error, we need to filter existing partitions before call add_partitions.

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
@@ -857,7 +857,13 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
     request.setTableName(tableName);
     request.setFilter("");
 
-    return getPartitionsByFilter(request.build());
+    List<PartitionDescProto> partitions = getPartitionsByFilter(request.build());
+
+    if (partitions.size() == 0) {
+      throw new TajoInternalError(new PartitionNotFoundException(tableName));
+    } else {
+      return partitions;
+    }
   }
 
   @Override

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -2203,10 +2203,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final int tableId = getTableId(databaseId, databaseName, tableName);
     ensurePartitionTable(tableName, tableId);
 
-    if (!existPartitionsOnCatalog(tableId)) {
-      throw new TajoInternalError(new PartitionNotFoundException(tableName));
-    }
-
     try {
       String sql = "SELECT PATH, PARTITION_NAME, " + COL_PARTITIONS_PK + " FROM "
         + TB_PARTTIONS +" WHERE " + COL_TABLES_PK + " = ?  ";

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -2203,6 +2203,10 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final int tableId = getTableId(databaseId, databaseName, tableName);
     ensurePartitionTable(tableName, tableId);
 
+    if (!existPartitionsOnCatalog(tableId)) {
+      throw new TajoInternalError(new PartitionNotFoundException(tableName));
+    }
+
     try {
       String sql = "SELECT PATH, PARTITION_NAME, " + COL_PARTITIONS_PK + " FROM "
         + TB_PARTTIONS +" WHERE " + COL_TABLES_PK + " = ?  ";

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
@@ -124,8 +124,25 @@ public class TestTablePartitions extends QueryTestCaseBase {
 
     TableDesc tableDesc = catalog.getTableDesc(DEFAULT_DATABASE_NAME, tableName);
     verifyPartitionDirectoryFromCatalog(DEFAULT_DATABASE_NAME, tableName, new String[]{"key"},
-        tableDesc.getStats().getNumRows());
+      tableDesc.getStats().getNumRows());
 
+    // Check if tajo can return list of partitions from file system in a situation that there is not partitions on
+    // catalog.
+    String externalTableName = "testCreateExternalColumnPartitionedTable";
+
+    executeString("create external table " + externalTableName + " (col1 int4, col2 int4) " +
+      " USING TEXT WITH ('text.delimiter'='|') PARTITION BY COLUMN (key float8) " +
+      " location '" + tableDesc.getUri().getPath() + "'").close();
+
+    res = executeString("SELECT COUNT(*) AS cnt FROM " + externalTableName);
+    String result = resultSetToString(res);
+    String expectedResult = "cnt\n" +
+      "-------------------------------\n" +
+      "5\n";
+    res.close();
+    assertEquals(expectedResult, result);
+
+    executeString("DROP TABLE " + externalTableName).close();
     executeString("DROP TABLE " + tableName + " PURGE").close();
   }
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
@@ -124,7 +124,7 @@ public class TestTablePartitions extends QueryTestCaseBase {
 
     TableDesc tableDesc = catalog.getTableDesc(DEFAULT_DATABASE_NAME, tableName);
     verifyPartitionDirectoryFromCatalog(DEFAULT_DATABASE_NAME, tableName, new String[]{"key"},
-      tableDesc.getStats().getNumRows());
+        tableDesc.getStats().getNumRows());
 
     // Check if tajo can return list of partitions from file system in a situation that there is not partitions on
     // catalog.
@@ -139,6 +139,14 @@ public class TestTablePartitions extends QueryTestCaseBase {
     String expectedResult = "cnt\n" +
       "-------------------------------\n" +
       "5\n";
+    res.close();
+    assertEquals(expectedResult, result);
+
+    res = executeString("SELECT COUNT(*) AS cnt FROM " + externalTableName + " WHERE key > 40.0");
+    result = resultSetToString(res);
+    expectedResult = "cnt\n" +
+      "-------------------------------\n" +
+      "2\n";
     res.close();
     assertEquals(expectedResult, result);
 


### PR DESCRIPTION
Currently, CatalogStore::getAllPartitions doesn't throw PartitionNotFoundException if there is not partitions on catalog. As a result, if users execute a select statement for partition table without filter, they can't get expected result.