### PR TITLE
TAJO-1877: Adopt try-resource statement to AbstractDBStore

### DIFF
--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -657,8 +657,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
     String sql = "SELECT DB_ID, DB_NAME, SPACE_ID FROM " + TB_DATABASES;
 
-    try (Connection conn = getConnection();
-         Statement stmt = conn.createStatement();
+    try (Statement stmt = getConnection().createStatement();
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         DatabaseProto.Builder builder = DatabaseProto.newBuilder();

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -239,9 +239,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   }
 
   private int getSchemaVersion() {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
-    ResultSet result = null;
     int schemaVersion = -1;
     
     String sql = "SELECT version FROM META";
@@ -249,18 +246,14 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql.toString());
     }
 
-    try {
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
-      result = pstmt.executeQuery();
-
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql);
+         ResultSet result = pstmt.executeQuery()) {
       if (result.next()) {
         schemaVersion = result.getInt("VERSION");
       }
     } catch (SQLException e) {
       throw new TajoInternalError(e);
-    } finally {
-      CatalogUtil.closeQuietly(pstmt, result);
     }
     
     return schemaVersion;
@@ -293,28 +286,21 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
    * Insert the version of the current catalog schema
    */
   protected void insertSchemaVersion() {
-    Connection conn;
-    PreparedStatement pstmt = null;
-    try {
-      conn = getConnection();
-      pstmt = conn.prepareStatement("INSERT INTO META VALUES (?)");
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement("INSERT INTO META VALUES (?)")) {
       pstmt.setInt(1, getDriverVersion());
       pstmt.executeUpdate();
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(pstmt);
     }
   }
 
   @Override
   public void createTablespace(String spaceName, String spaceUri) throws DuplicateTablespaceException {
-    Connection conn = null;
     PreparedStatement pstmt = null;
     ResultSet res = null;
 
-    try {
-      conn = getConnection();
+    try (Connection conn = getConnection()) {
       conn.setAutoCommit(false);
 
       String sql = String.format("SELECT SPACE_ID FROM %s WHERE SPACE_NAME=(?)", TB_SPACES);
@@ -355,27 +341,24 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   @Override
   public boolean existTablespace(String tableSpaceName) {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
     boolean exist = false;
 
-    try {
-      StringBuilder sql = new StringBuilder();
-      sql.append("SELECT SPACE_NAME FROM " + TB_SPACES + " WHERE SPACE_NAME = ?");
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql.toString());
-      }
+    StringBuilder sql = new StringBuilder();
+    sql.append("SELECT SPACE_NAME FROM " + TB_SPACES + " WHERE SPACE_NAME = ?");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql.toString());
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql.toString());
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
       pstmt.setString(1, tableSpaceName);
       res = pstmt.executeQuery();
       exist = res.next();
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return exist;
@@ -384,13 +367,11 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   @Override
   public void dropTablespace(String tableSpaceName) throws UndefinedTablespaceException {
 
-    Connection conn = null;
     PreparedStatement pstmt = null;
-    try {
+    try (Connection conn = getConnection()) {
       TableSpaceInternal tableSpace = getTableSpaceInfo(tableSpaceName);
       Collection<String> databaseNames = getAllDatabaseNamesInternal(COL_TABLESPACE_PK + " = " + tableSpace.spaceId);
 
-      conn = getConnection();
       conn.setAutoCommit(false);
 
       for (String databaseName : databaseNames) {
@@ -427,29 +408,22 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   }
 
   private Collection<String> getAllTablespaceNamesInternal(@Nullable String whereCondition) {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
-    ResultSet resultSet = null;
-
     List<String> tablespaceNames = new ArrayList<>();
 
-    try {
-      String sql = "SELECT SPACE_NAME FROM " + TB_SPACES;
+    String sql = "SELECT SPACE_NAME FROM " + TB_SPACES;
 
-      if (whereCondition != null) {
-        sql += " WHERE " + whereCondition;
-      }
+    if (whereCondition != null) {
+      sql += " WHERE " + whereCondition;
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
-      resultSet = pstmt.executeQuery();
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql);
+         ResultSet resultSet = pstmt.executeQuery()) {
       while (resultSet.next()) {
         tablespaceNames.add(resultSet.getString(1));
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(pstmt, resultSet);
     }
 
     return tablespaceNames;
@@ -457,17 +431,12 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   
   @Override
   public List<TablespaceProto> getTablespaces() {
-    Connection conn = null;
-    Statement stmt = null;
-    ResultSet resultSet = null;
     List<TablespaceProto> tablespaces = TUtil.newList();
+    String sql = "SELECT SPACE_ID, SPACE_NAME, SPACE_HANDLER, SPACE_URI FROM " + TB_SPACES ;
 
-    try {
-      String sql = "SELECT SPACE_ID, SPACE_NAME, SPACE_HANDLER, SPACE_URI FROM " + TB_SPACES ;
-      conn = getConnection();
-      stmt = conn.createStatement();
-      resultSet = stmt.executeQuery(sql);
-
+    try (Connection conn = getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TablespaceProto.Builder builder = TablespaceProto.newBuilder();
         builder.setId(resultSet.getInt("SPACE_ID"));
@@ -481,21 +450,16 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(stmt, resultSet);
     }
   }
 
   @Override
   public TablespaceProto getTablespace(String spaceName) throws UndefinedTablespaceException {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet resultSet = null;
+    String sql = "SELECT * FROM " + TB_SPACES + " WHERE SPACE_NAME=?";
 
-    try {
-      String sql = "SELECT * FROM " + TB_SPACES + " WHERE SPACE_NAME=?";
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setString(1, spaceName);
       resultSet = pstmt.executeQuery();
 
@@ -515,11 +479,10 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
           setUri(uri).
           build();
 
-
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, resultSet);
+      CatalogUtil.closeQuietly(resultSet);
     }
   }
 
@@ -609,27 +572,24 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   @Override
   public boolean existDatabase(String databaseName) {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
     boolean exist = false;
 
-    try {
-      StringBuilder sql = new StringBuilder();
-      sql.append("SELECT DB_NAME FROM " + TB_DATABASES + " WHERE DB_NAME = ?");
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql.toString());
-      }
+    StringBuilder sql = new StringBuilder();
+    sql.append("SELECT DB_NAME FROM " + TB_DATABASES + " WHERE DB_NAME = ?");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql.toString());
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql.toString());
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
       pstmt.setString(1, databaseName);
       res = pstmt.executeQuery();
       exist = res.next();
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return exist;
@@ -678,29 +638,22 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   }
 
   private Collection<String> getAllDatabaseNamesInternal(@Nullable String whereCondition) {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
-    ResultSet resultSet = null;
-
     List<String> databaseNames = new ArrayList<>();
 
-    try {
-      String sql = "SELECT DB_NAME FROM " + TB_DATABASES;
+    String sql = "SELECT DB_NAME FROM " + TB_DATABASES;
 
-      if (whereCondition != null) {
-        sql += " WHERE " + whereCondition;
-      }
+    if (whereCondition != null) {
+      sql += " WHERE " + whereCondition;
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
-      resultSet = pstmt.executeQuery();
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql);
+         ResultSet resultSet = pstmt.executeQuery()) {
       while (resultSet.next()) {
         databaseNames.add(resultSet.getString(1));
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(pstmt, resultSet);
     }
 
     return databaseNames;
@@ -708,18 +661,13 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   
   @Override
   public List<DatabaseProto> getAllDatabases() {
-    Connection conn = null;
-    Statement stmt = null;
-    ResultSet resultSet = null;
-
     List<DatabaseProto> databases = new ArrayList<>();
 
-    try {
-      String sql = "SELECT DB_ID, DB_NAME, SPACE_ID FROM " + TB_DATABASES;
+    String sql = "SELECT DB_ID, DB_NAME, SPACE_ID FROM " + TB_DATABASES;
 
-      conn = getConnection();
-      stmt = conn.createStatement();
-      resultSet = stmt.executeQuery(sql);
+    try (Connection conn = getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         DatabaseProto.Builder builder = DatabaseProto.newBuilder();
         
@@ -731,8 +679,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(stmt, resultSet);
     }
     
     return databases;
@@ -763,14 +709,11 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   }
 
   private TableSpaceInternal getTableSpaceInfo(String spaceName) throws UndefinedTablespaceException {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
+    String sql = "SELECT SPACE_ID, SPACE_URI, SPACE_HANDLER from " + TB_SPACES + " WHERE SPACE_NAME = ?";
 
-    try {
-      String sql = "SELECT SPACE_ID, SPACE_URI, SPACE_HANDLER from " + TB_SPACES + " WHERE SPACE_NAME = ?";
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setString(1, spaceName);
       res = pstmt.executeQuery();
       if (!res.next()) {
@@ -780,19 +723,16 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
   private int getTableId(int databaseId, String databaseName, String tableName) throws UndefinedTableException {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
+    String tidSql = "SELECT TID from TABLES WHERE db_id = ? AND " + COL_TABLES_NAME + "=?";
 
-    try {
-      String tidSql = "SELECT TID from TABLES WHERE db_id = ? AND " + COL_TABLES_NAME + "=?";
-      conn = getConnection();
-      pstmt = conn.prepareStatement(tidSql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(tidSql)) {
       pstmt.setInt(1, databaseId);
       pstmt.setString(2, tableName);
       res = pstmt.executeQuery();
@@ -803,7 +743,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
@@ -1105,16 +1045,12 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   }
 
   private Map<String, String> getTableOptions(final int tableId) {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
     Map<String, String> options = TUtil.newHashMap();
+    String tidSql = "SELECT key_, value_ FROM " + TB_OPTIONS + " WHERE TID=?";
 
-    try {
-      String tidSql = "SELECT key_, value_ FROM " + TB_OPTIONS + " WHERE TID=?";
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(tidSql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(tidSql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -1124,7 +1060,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return options;
@@ -1134,13 +1070,11 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final String updateSql = "UPDATE " + TB_OPTIONS + " SET VALUE_=? WHERE TID=? AND KEY_=?";
     final String insertSql = "INSERT INTO " + TB_OPTIONS + " (TID, KEY_, VALUE_) VALUES(?, ?, ?)";
 
-    Connection conn;
     PreparedStatement pstmt = null;
 
     Map<String, String> oldProperties = getTableOptions(tableId);
 
-    try {
-      conn = getConnection();
+    try (Connection conn = getConnection()) {
       conn.setAutoCommit(false);
 
       for (KeyValueProto entry : properties.getKeyvalList()) {
@@ -1181,21 +1115,15 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(updtaeRenameTableSql);
     }
 
-    Connection conn;
-    PreparedStatement pstmt = null;
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(updtaeRenameTableSql)) {
 
-    try {
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(updtaeRenameTableSql);
       pstmt.setString(1, tableName);
       pstmt.setInt(2, tableId);
       pstmt.executeUpdate();
 
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(pstmt);
     }
   }
 
@@ -1208,13 +1136,9 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(updtaeRenameTableSql);
     }
 
-    Connection conn;
-    PreparedStatement pstmt = null;
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(updtaeRenameTableSql)) {
 
-    try {
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(updtaeRenameTableSql);
       pstmt.setString(1, tableName);
       pstmt.setString(2, newTablePath);
       pstmt.setInt(3, tableId);
@@ -1222,8 +1146,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(pstmt);
     }
   }
 
@@ -1245,13 +1167,11 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(insertNewColumnSql);
     }
 
-    Connection conn;
     PreparedStatement pstmt = null;
     ResultSet resultSet = null;
 
-    try {
+    try (Connection conn = getConnection()) {
 
-      conn = getConnection();
       conn.setAutoCommit(false);
 
       String tableName = CatalogUtil.extractQualifier(alterColumnProto.getOldColumnName());
@@ -1316,7 +1236,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   private void addNewColumn(int tableId, CatalogProtos.ColumnProto columnProto) throws DuplicateColumnException {
 
-    Connection conn;
     PreparedStatement pstmt = null;
     ResultSet resultSet = null;
 
@@ -1329,8 +1248,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final String columnCountSql =
         "SELECT MAX(ORDINAL_POSITION) AS POSITION FROM " + TB_COLUMNS + " WHERE TID = ?";
 
-    try {
-      conn = getConnection();
+    try (Connection conn = getConnection()) {
       pstmt = conn.prepareStatement(existColumnSql);
       pstmt.setInt(1, tableId);
       pstmt.setString(2, CatalogUtil.extractSimpleName(columnProto.getName()));
@@ -1459,13 +1377,10 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
 
-    try {
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setString(1, databaseName);
       res = pstmt.executeQuery();
       if (!res.next()) {
@@ -1476,28 +1391,24 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException e) {
       throw new TajoInternalError(e);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
   @Override
   public boolean existTable(String databaseName, final String tableName) throws UndefinedDatabaseException {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
     boolean exist = false;
 
-    try {
+    String sql = "SELECT TID FROM TABLES WHERE DB_ID = ? AND " + COL_TABLES_NAME + "=?";
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql.toString());
+    }
+
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
       int dbid = getDatabaseId(databaseName);
-
-      String sql = "SELECT TID FROM TABLES WHERE DB_ID = ? AND " + COL_TABLES_NAME + "=?";
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql.toString());
-      }
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql.toString());
 
       pstmt.setInt(1, dbid);
       pstmt.setString(2, tableName);
@@ -1506,7 +1417,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return exist;
@@ -1637,13 +1548,10 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
 
-    try {
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setString(1, databaseName);
       res = pstmt.executeQuery();
       if (!res.next()) {
@@ -1654,7 +1562,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException e) {
       throw new TajoInternalError(e);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
@@ -1662,7 +1570,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public CatalogProtos.TableDescProto getTable(String databaseName, String tableName)
       throws UndefinedDatabaseException, UndefinedTableException {
 
-    Connection conn;
+//    Connection conn;
     ResultSet res = null;
     PreparedStatement pstmt = null;
     CatalogProtos.TableDescProto.Builder tableBuilder = null;
@@ -1670,7 +1578,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
     Pair<Integer, String> databaseIdAndUri = getDatabaseIdAndUri(databaseName);
 
-    try {
+    try (Connection conn = getConnection()) {
       tableBuilder = CatalogProtos.TableDescProto.newBuilder();
 
       //////////////////////////////////////////
@@ -1684,7 +1592,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
         LOG.debug(sql);
       }
 
-      conn = getConnection();
+//      conn = getConnection();
       pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, databaseIdAndUri.getFirst());
       pstmt.setString(2, tableName);
@@ -1814,24 +1722,19 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   @Override
   public List<String> getAllTableNames(String databaseName) throws UndefinedDatabaseException {
-    Connection conn = null;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
-
     List<String> tables = new ArrayList<>();
 
-    try {
+    String sql = "SELECT " + COL_TABLES_NAME + " FROM TABLES WHERE DB_ID = ?";
 
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
+
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       int dbid = getDatabaseId(databaseName);
 
-      String sql = "SELECT " + COL_TABLES_NAME + " FROM TABLES WHERE DB_ID = ?";
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, dbid);
       res = pstmt.executeQuery();
       while (res.next()) {
@@ -1840,27 +1743,22 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
     return tables;
   }
   
   @Override
   public List<TableDescriptorProto> getAllTables() {
-    Connection conn = null;
-    Statement stmt = null;
-    ResultSet resultSet = null;
-
     List<TableDescriptorProto> tables = new ArrayList<>();
 
-    try {
-      String sql = "SELECT t.TID, t.DB_ID, t." + COL_TABLES_NAME + ", t.TABLE_TYPE, t.PATH, t.DATA_FORMAT, " +
-          " s.SPACE_URI FROM " + TB_TABLES + " t, " + TB_DATABASES + " d, " + TB_SPACES +
-          " s WHERE t.DB_ID = d.DB_ID AND d.SPACE_ID = s.SPACE_ID";
+    String sql = "SELECT t.TID, t.DB_ID, t." + COL_TABLES_NAME + ", t.TABLE_TYPE, t.PATH, t.STORE_TYPE, " +
+            " s.SPACE_URI FROM " + TB_TABLES + " t, " + TB_DATABASES + " d, " + TB_SPACES +
+            " s WHERE t.DB_ID = d.DB_ID AND d.SPACE_ID = s.SPACE_ID";
 
-      conn = getConnection();
-      stmt = conn.createStatement();
-      resultSet = stmt.executeQuery(sql);
+    try (Connection conn = getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TableDescriptorProto.Builder builder = TableDescriptorProto.newBuilder();
         
@@ -1887,8 +1785,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(stmt, resultSet);
     }
     
     return tables;
@@ -1896,18 +1792,12 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   
   @Override
   public List<TableOptionProto> getAllTableProperties() {
-    Connection conn = null;
-    Statement stmt = null;
-    ResultSet resultSet = null;
-
     List<TableOptionProto> options = new ArrayList<>();
+    String sql = "SELECT tid, key_, value_ FROM " + TB_OPTIONS;
 
-    try {
-      String sql = "SELECT tid, key_, value_ FROM " + TB_OPTIONS;
-
-      conn = getConnection();
-      stmt = conn.createStatement();
-      resultSet = stmt.executeQuery(sql);
+    try (Connection conn = getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TableOptionProto.Builder builder = TableOptionProto.newBuilder();
         
@@ -1922,27 +1812,19 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(stmt, resultSet);
     }
-    
+
     return options;
   }
   
   @Override
   public List<TableStatsProto> getAllTableStats() {
-    Connection conn = null;
-    Statement stmt = null;
-    ResultSet resultSet = null;
-
     List<TableStatsProto> stats = new ArrayList<>();
+    String sql = "SELECT tid, num_rows, num_bytes FROM " + TB_STATISTICS;
 
-    try {
-      String sql = "SELECT tid, num_rows, num_bytes FROM " + TB_STATISTICS;
-
-      conn = getConnection();
-      stmt = conn.createStatement();
-      resultSet = stmt.executeQuery(sql);
+    try (Connection conn = getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TableStatsProto.Builder builder = TableStatsProto.newBuilder();
         
@@ -1954,8 +1836,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(stmt, resultSet);
     }
     
     return stats;
@@ -1963,20 +1843,14 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   
   @Override
   public List<ColumnProto> getAllColumns() {
-    Connection conn = null;
-    Statement stmt = null;
-    ResultSet resultSet = null;
-
     List<ColumnProto> columns = new ArrayList<>();
+    String sql =
+            "SELECT TID, COLUMN_NAME, ORDINAL_POSITION, NESTED_FIELD_NUM, DATA_TYPE, TYPE_LENGTH FROM " + TB_COLUMNS +
+                    " ORDER BY TID ASC, ORDINAL_POSITION ASC";
 
-    try {
-      String sql =
-          "SELECT TID, COLUMN_NAME, ORDINAL_POSITION, NESTED_FIELD_NUM, DATA_TYPE, TYPE_LENGTH FROM " + TB_COLUMNS +
-          " ORDER BY TID ASC, ORDINAL_POSITION ASC";
-
-      conn = getConnection();
-      stmt = conn.createStatement();
-      resultSet = stmt.executeQuery(sql);
+    try (Connection conn = getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         ColumnProto.Builder builder = ColumnProto.newBuilder();
 
@@ -2003,8 +1877,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(stmt, resultSet);
     }
     
     return columns;
@@ -2014,24 +1886,21 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public CatalogProtos.PartitionMethodProto getPartitionMethod(String databaseName, String tableName) throws
       UndefinedDatabaseException, UndefinedTableException, UndefinedPartitionMethodException {
 
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
 
     final int databaseId = getDatabaseId(databaseName);
     final int tableId = getTableId(databaseId, databaseName, tableName);
     ensurePartitionTable(tableName, tableId);
 
-    try {
-      String sql = "SELECT partition_type, expression, expression_schema FROM " + TB_PARTITION_METHODS +
-          " WHERE " + COL_TABLES_PK + " = ? ";
+    String sql = "SELECT partition_type, expression, expression_schema FROM " + TB_PARTITION_METHODS +
+            " WHERE " + COL_TABLES_PK + " = ? ";
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -2044,7 +1913,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (Throwable se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
@@ -2052,24 +1921,22 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public boolean existPartitionMethod(String databaseName, String tableName)
       throws UndefinedDatabaseException, UndefinedTableException {
 
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
     boolean exist = false;
 
-    try {
-      String sql = "SELECT partition_type, expression, expression_schema FROM " + TB_PARTITION_METHODS +
-          " WHERE " + COL_TABLES_PK + "= ?";
+    String sql = "SELECT partition_type, expression, expression_schema FROM " + TB_PARTITION_METHODS +
+            " WHERE " + COL_TABLES_PK + "= ?";
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
+
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
 
       int databaseId = getDatabaseId(databaseName);
       int tableId = getTableId(databaseId, databaseName, tableName);
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -2077,7 +1944,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
     return exist;
   }
@@ -2094,20 +1961,17 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   private void ensurePartitionTable(String tbName, int tableId)
       throws UndefinedTableException, UndefinedDatabaseException, UndefinedPartitionMethodException {
 
-    Connection conn;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
 
-    try {
-      String sql = "SELECT partition_type, expression, expression_schema FROM " + TB_PARTITION_METHODS +
-          " WHERE " + COL_TABLES_PK + "= ?";
+    String sql = "SELECT partition_type, expression, expression_schema FROM " + TB_PARTITION_METHODS +
+            " WHERE " + COL_TABLES_PK + "= ?";
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -2117,7 +1981,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
@@ -2131,21 +1995,18 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final int tableId = getTableId(databaseId, databaseName, tableName);
     ensurePartitionTable(tableName, tableId);
 
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
     PartitionDescProto.Builder builder = null;
 
-    try {
-      String sql = "SELECT PATH, " + COL_PARTITIONS_PK  + ", " + COL_PARTITION_BYTES + " FROM " + TB_PARTTIONS +
-        " WHERE " + COL_TABLES_PK + " = ? AND PARTITION_NAME = ? ";
+    String sql = "SELECT PATH, " + COL_PARTITIONS_PK + " FROM " + TB_PARTTIONS +
+            " WHERE " + COL_TABLES_PK + " = ? AND PARTITION_NAME = ? ";
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       pstmt.setString(2, partitionName);
       res = pstmt.executeQuery();
@@ -2163,22 +2024,19 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
     return builder.build();
   }
 
   private void setPartitionKeys(int pid, PartitionDescProto.Builder partitionDesc) {
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
 
-    try {
-      String sql = "SELECT "+ COL_COLUMN_NAME  + " , "+ COL_PARTITION_VALUE
-        + " FROM " + TB_PARTTION_KEYS + " WHERE " + COL_PARTITIONS_PK + " = ? ";
+    String sql = "SELECT "+ COL_COLUMN_NAME  + " , "+ COL_PARTITION_VALUE
+            + " FROM " + TB_PARTTION_KEYS + " WHERE " + COL_PARTITIONS_PK + " = ? ";
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setInt(1, pid);
       res = pstmt.executeQuery();
 
@@ -2191,16 +2049,15 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
   @Override
   public List<PartitionDescProto> getPartitionsOfTable(String databaseName, String tableName)
       throws UndefinedDatabaseException, UndefinedTableException, UndefinedPartitionMethodException {
-    Connection conn = null;
+
     ResultSet res = null;
-    PreparedStatement pstmt = null;
     PartitionDescProto.Builder builder = null;
     List<PartitionDescProto> partitions = new ArrayList<>();
 
@@ -2208,16 +2065,15 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final int tableId = getTableId(databaseId, databaseName, tableName);
     ensurePartitionTable(tableName, tableId);
 
-    try {
-      String sql = "SELECT PATH, PARTITION_NAME, " + COL_PARTITIONS_PK + ", " + COL_PARTITION_BYTES
-        + " FROM " + TB_PARTTIONS +" WHERE " + COL_TABLES_PK + " = ?  ";
+    String sql = "SELECT PATH, PARTITION_NAME, " + COL_PARTITIONS_PK + " FROM "
+            + TB_PARTTIONS +" WHERE " + COL_TABLES_PK + " = ?  ";
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
 
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -2232,7 +2088,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
     return partitions;
   }
@@ -2489,19 +2345,14 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   @Override
   public List<TablePartitionProto> getAllPartitions() {
-    Connection conn = null;
-    Statement stmt = null;
-    ResultSet resultSet = null;
-
     List<TablePartitionProto> partitions = new ArrayList<>();
 
-    try {
-      String sql = "SELECT " + COL_PARTITIONS_PK + ", " + COL_TABLES_PK + ", PARTITION_NAME, " +
-        " PATH FROM " + TB_PARTTIONS;
+    String sql = "SELECT " + COL_PARTITIONS_PK + ", " + COL_TABLES_PK + ", PARTITION_NAME, " +
+            " PATH FROM " + TB_PARTTIONS;
 
-      conn = getConnection();
-      stmt = conn.createStatement();
-      resultSet = stmt.executeQuery(sql);
+    try (Connection conn = getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TablePartitionProto.Builder builder = TablePartitionProto.newBuilder();
 
@@ -2514,8 +2365,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
-    } finally {
-      CatalogUtil.closeQuietly(stmt, resultSet);
     }
 
     return partitions;
@@ -2529,7 +2378,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final int databaseId = getDatabaseId(databaseName);
     final int tableId = getTableId(databaseId, databaseName, tableName);
     ensurePartitionTable(tableName, tableId);
-
 
     Connection conn = null;
     // To delete existing partition keys
@@ -2640,13 +2488,12 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   @Override
   public void createIndex(final IndexDescProto proto)
       throws UndefinedDatabaseException, UndefinedTableException, DuplicateIndexException {
-    Connection conn = null;
     PreparedStatement pstmt = null;
 
     final String databaseName = proto.getTableIdentifier().getDatabaseName();
     final String tableName = CatalogUtil.extractSimpleName(proto.getTableIdentifier().getTableName());
 
-    try {
+    try (Connection conn = getConnection()) {
 
       // indexes table
       int databaseId = getDatabaseId(databaseName);
@@ -2654,7 +2501,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
       String sql = String.format("SELECT INDEX_NAME FROM %s WHERE DB_ID=? AND INDEX_NAME=?", TB_INDEXES);
 
-      conn = getConnection();
       conn.setAutoCommit(false);
 
       pstmt = conn.prepareStatement(sql);
@@ -2722,15 +2568,13 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   @Override
   public void dropIndex(String databaseName, final String indexName)
       throws UndefinedDatabaseException, UndefinedIndexException {
-    Connection conn;
     PreparedStatement pstmt = null;
 
-    try {
+    try (Connection conn = getConnection()) {
       int databaseId = getDatabaseId(databaseName);
 
       String sql = String.format("SELECT INDEX_NAME FROM %s WHERE %s=? AND INDEX_NAME=?", TB_INDEXES, COL_DATABASES_PK);
 
-      conn = getConnection();
       pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, databaseId);
       pstmt.setString(2, indexName);
@@ -2761,11 +2605,9 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   public static String getTableName(Connection conn, int tableId) throws SQLException {
     ResultSet res = null;
-    PreparedStatement pstmt = null;
 
-    try {
-      pstmt =
-          conn.prepareStatement("SELECT " + COL_TABLES_NAME + " FROM " + TB_TABLES + " WHERE " + COL_TABLES_PK + "=?");
+    try (PreparedStatement pstmt =
+                 conn.prepareStatement("SELECT " + COL_TABLES_NAME + " FROM " + TB_TABLES + " WHERE " + COL_TABLES_PK + "=?")) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
       if (!res.next()) {
@@ -2773,7 +2615,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       }
       return res.getString(1);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
   }
 
@@ -2813,22 +2655,19 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public IndexDescProto getIndexByName(String databaseName, final String indexName)
       throws UndefinedDatabaseException, UndefinedIndexException {
 
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
     IndexDescProto proto = null;
 
-    try {
+    String sql = GET_INDEXES_SQL + " WHERE " + COL_DATABASES_PK + "=? AND INDEX_NAME=?";
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
+
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
 
-      String sql = GET_INDEXES_SQL + " WHERE " + COL_DATABASES_PK + "=? AND INDEX_NAME=?";
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, databaseId);
       pstmt.setString(2, indexName);
       res = pstmt.executeQuery();
@@ -2851,7 +2690,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return proto;
@@ -2861,29 +2700,26 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public IndexDescProto getIndexByColumns(String databaseName, String tableName, String[] columnNames)
       throws UndefinedDatabaseException, UndefinedTableException, UndefinedIndexException {
 
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
     IndexDescProto proto = null;
 
-    try {
+    String sql = GET_INDEXES_SQL + " WHERE " + COL_DATABASES_PK + "=? AND " +
+            COL_TABLES_PK + "=? AND COLUMN_NAMES=?";
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
+
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
       int tableId = getTableId(databaseId, databaseName, tableName);
       TableDescProto tableDescProto = getTable(databaseName, tableName);
-
-      String sql = GET_INDEXES_SQL + " WHERE " + COL_DATABASES_PK + "=? AND " +
-          COL_TABLES_PK + "=? AND COLUMN_NAMES=?";
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
 
       // Since the column names in the unified name are always sorted
       // in order of occurrence position in the relation schema,
       // they can be uniquely identified.
       String unifiedName = CatalogUtil.getUnifiedSimpleColumnName(new Schema(tableDescProto.getSchema()), columnNames);
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, databaseId);
       pstmt.setInt(2, tableId);
       pstmt.setString(3, unifiedName);
@@ -2900,7 +2736,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return proto;
@@ -2908,24 +2744,20 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   @Override
   public boolean existIndexByName(String databaseName, final String indexName) throws UndefinedDatabaseException {
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
-
     boolean exist = false;
 
-    try {
+    String sql =
+            "SELECT INDEX_NAME FROM " + TB_INDEXES + " WHERE " + COL_DATABASES_PK + "=? AND INDEX_NAME=?";
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
+
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
 
-      String sql =
-          "SELECT INDEX_NAME FROM " + TB_INDEXES + " WHERE " + COL_DATABASES_PK + "=? AND INDEX_NAME=?";
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, databaseId);
       pstmt.setString(2, indexName);
       res = pstmt.executeQuery();
@@ -2933,7 +2765,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return exist;
@@ -2943,31 +2775,27 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public boolean existIndexByColumns(String databaseName, String tableName, String[] columnNames)
       throws UndefinedDatabaseException, UndefinedTableException {
 
-    Connection conn = null;
     ResultSet res = null;
-    PreparedStatement pstmt = null;
-
     boolean exist = false;
 
-    try {
+    String sql =
+            "SELECT " + COL_INDEXES_PK + " FROM " + TB_INDEXES +
+                    " WHERE " + COL_DATABASES_PK + "=? AND " + COL_TABLES_PK + "=? AND COLUMN_NAMES=?";
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql);
+    }
+
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
       int tableId = getTableId(databaseId, databaseName, tableName);
       Schema relationSchema = new Schema(getTable(databaseName, tableName).getSchema());
-
-      String sql =
-          "SELECT " + COL_INDEXES_PK + " FROM " + TB_INDEXES +
-              " WHERE " + COL_DATABASES_PK + "=? AND " + COL_TABLES_PK + "=? AND COLUMN_NAMES=?";
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql);
-      }
 
       // Since the column names in the unified name are always sorted
       // in order of occurrence position in the relation schema,
       // they can be uniquely identified.
       String unifiedName = CatalogUtil.getUnifiedSimpleColumnName(new Schema(relationSchema), columnNames);
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, databaseId);
       pstmt.setInt(2, tableId);
       pstmt.setString(3, unifiedName);
@@ -2976,7 +2804,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
     return exist;
   }
@@ -3179,30 +3007,25 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   }
 
   private boolean existColumn(final int tableId, final String columnName) {
-    Connection conn ;
-    PreparedStatement pstmt = null;
     ResultSet res = null;
     boolean exist = false;
 
-    try {
+    String sql = "SELECT COLUMN_NAME FROM " + TB_COLUMNS + " WHERE TID = ? AND COLUMN_NAME = ?";
 
-      String sql = "SELECT COLUMN_NAME FROM " + TB_COLUMNS + " WHERE TID = ? AND COLUMN_NAME = ?";
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(sql.toString());
+    }
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(sql.toString());
-      }
-
-      conn = getConnection();
-      pstmt = conn.prepareStatement(sql.toString());
-
-      pstmt.setInt(1, tableId);
+    try (Connection conn = getConnection();
+         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+     pstmt.setInt(1, tableId);
       pstmt.setString(2, columnName);
       res = pstmt.executeQuery();
       exist = res.next();
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     } finally {
-      CatalogUtil.closeQuietly(pstmt, res);
+      CatalogUtil.closeQuietly(res);
     }
 
     return exist;

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -1731,12 +1731,12 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     }
     return tables;
   }
-  
+
   @Override
   public List<TableDescriptorProto> getAllTables() {
     List<TableDescriptorProto> tables = new ArrayList<>();
 
-    String sql = "SELECT t.TID, t.DB_ID, t." + COL_TABLES_NAME + ", t.TABLE_TYPE, t.PATH, t.STORE_TYPE, " +
+    String sql = "SELECT t.TID, t.DB_ID, t." + COL_TABLES_NAME + ", t.TABLE_TYPE, t.PATH, t.DATA_FORMAT, " +
             " s.SPACE_URI FROM " + TB_TABLES + " t, " + TB_DATABASES + " d, " + TB_SPACES +
             " s WHERE t.DB_ID = d.DB_ID AND d.SPACE_ID = s.SPACE_ID";
 
@@ -1744,7 +1744,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TableDescriptorProto.Builder builder = TableDescriptorProto.newBuilder();
-        
+
         builder.setTid(resultSet.getInt("TID"));
         builder.setDbId(resultSet.getInt("DB_ID"));
         String tableName = resultSet.getString(COL_TABLES_NAME);
@@ -1763,13 +1763,13 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
           dataFormat = dataFormat.trim();
           builder.setDataFormat(dataFormat);
         }
-        
+
         tables.add(builder.build());
       }
     } catch (SQLException se) {
       throw new TajoInternalError(se);
     }
-    
+
     return tables;
   }
   

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -1222,6 +1222,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   private void addNewColumn(int tableId, CatalogProtos.ColumnProto columnProto) throws DuplicateColumnException {
 
+    Connection conn;
     PreparedStatement pstmt = null;
     ResultSet resultSet = null;
 
@@ -1234,7 +1235,8 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final String columnCountSql =
         "SELECT MAX(ORDINAL_POSITION) AS POSITION FROM " + TB_COLUMNS + " WHERE TID = ?";
 
-    try (Connection conn = getConnection()) {
+    try {
+      conn = getConnection();
       pstmt = conn.prepareStatement(existColumnSql);
       pstmt.setInt(1, tableId);
       pstmt.setString(2, CatalogUtil.extractSimpleName(columnProto.getName()));

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -246,8 +246,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql.toString());
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql);
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql);
          ResultSet result = pstmt.executeQuery()) {
       if (result.next()) {
         schemaVersion = result.getInt("VERSION");
@@ -286,8 +285,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
    * Insert the version of the current catalog schema
    */
   protected void insertSchemaVersion() {
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement("INSERT INTO META VALUES (?)")) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement("INSERT INTO META VALUES (?)")) {
       pstmt.setInt(1, getDriverVersion());
       pstmt.executeUpdate();
     } catch (SQLException se) {
@@ -350,8 +348,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql.toString());
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql.toString())) {
       pstmt.setString(1, tableSpaceName);
       res = pstmt.executeQuery();
       exist = res.next();
@@ -416,8 +413,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       sql += " WHERE " + whereCondition;
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql);
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql);
          ResultSet resultSet = pstmt.executeQuery()) {
       while (resultSet.next()) {
         tablespaceNames.add(resultSet.getString(1));
@@ -434,8 +430,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     List<TablespaceProto> tablespaces = TUtil.newList();
     String sql = "SELECT SPACE_ID, SPACE_NAME, SPACE_HANDLER, SPACE_URI FROM " + TB_SPACES ;
 
-    try (Connection conn = getConnection();
-         Statement stmt = conn.createStatement();
+    try (Statement stmt = getConnection().createStatement();
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TablespaceProto.Builder builder = TablespaceProto.newBuilder();
@@ -458,8 +453,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     ResultSet resultSet = null;
     String sql = "SELECT * FROM " + TB_SPACES + " WHERE SPACE_NAME=?";
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setString(1, spaceName);
       resultSet = pstmt.executeQuery();
 
@@ -581,8 +575,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql.toString());
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql.toString())) {
       pstmt.setString(1, databaseName);
       res = pstmt.executeQuery();
       exist = res.next();
@@ -646,8 +639,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       sql += " WHERE " + whereCondition;
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql);
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql);
          ResultSet resultSet = pstmt.executeQuery()) {
       while (resultSet.next()) {
         databaseNames.add(resultSet.getString(1));
@@ -712,8 +704,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     ResultSet res = null;
     String sql = "SELECT SPACE_ID, SPACE_URI, SPACE_HANDLER from " + TB_SPACES + " WHERE SPACE_NAME = ?";
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setString(1, spaceName);
       res = pstmt.executeQuery();
       if (!res.next()) {
@@ -731,8 +722,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     ResultSet res = null;
     String tidSql = "SELECT TID from TABLES WHERE db_id = ? AND " + COL_TABLES_NAME + "=?";
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(tidSql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(tidSql)) {
       pstmt.setInt(1, databaseId);
       pstmt.setString(2, tableName);
       res = pstmt.executeQuery();
@@ -1049,8 +1039,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     Map<String, String> options = TUtil.newHashMap();
     String tidSql = "SELECT key_, value_ FROM " + TB_OPTIONS + " WHERE TID=?";
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(tidSql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(tidSql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -1115,8 +1104,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(updtaeRenameTableSql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(updtaeRenameTableSql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(updtaeRenameTableSql)) {
 
       pstmt.setString(1, tableName);
       pstmt.setInt(2, tableId);
@@ -1136,8 +1124,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(updtaeRenameTableSql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(updtaeRenameTableSql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(updtaeRenameTableSql)) {
 
       pstmt.setString(1, tableName);
       pstmt.setString(2, newTablePath);
@@ -1379,8 +1366,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
     ResultSet res = null;
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setString(1, databaseName);
       res = pstmt.executeQuery();
       if (!res.next()) {
@@ -1406,8 +1392,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql.toString());
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql.toString())) {
       int dbid = getDatabaseId(databaseName);
 
       pstmt.setInt(1, dbid);
@@ -1550,8 +1535,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
     ResultSet res = null;
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setString(1, databaseName);
       res = pstmt.executeQuery();
       if (!res.next()) {
@@ -1570,7 +1554,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public CatalogProtos.TableDescProto getTable(String databaseName, String tableName)
       throws UndefinedDatabaseException, UndefinedTableException {
 
-//    Connection conn;
+    Connection conn;
     ResultSet res = null;
     PreparedStatement pstmt = null;
     CatalogProtos.TableDescProto.Builder tableBuilder = null;
@@ -1578,7 +1562,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
     Pair<Integer, String> databaseIdAndUri = getDatabaseIdAndUri(databaseName);
 
-    try (Connection conn = getConnection()) {
+    try {
       tableBuilder = CatalogProtos.TableDescProto.newBuilder();
 
       //////////////////////////////////////////
@@ -1592,7 +1576,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
         LOG.debug(sql);
       }
 
-//      conn = getConnection();
+      conn = getConnection();
       pstmt = conn.prepareStatement(sql);
       pstmt.setInt(1, databaseIdAndUri.getFirst());
       pstmt.setString(2, tableName);
@@ -1731,8 +1715,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       int dbid = getDatabaseId(databaseName);
 
       pstmt.setInt(1, dbid);
@@ -1756,8 +1739,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
             " s.SPACE_URI FROM " + TB_TABLES + " t, " + TB_DATABASES + " d, " + TB_SPACES +
             " s WHERE t.DB_ID = d.DB_ID AND d.SPACE_ID = s.SPACE_ID";
 
-    try (Connection conn = getConnection();
-         Statement stmt = conn.createStatement();
+    try (Statement stmt = getConnection().createStatement();
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TableDescriptorProto.Builder builder = TableDescriptorProto.newBuilder();
@@ -1795,8 +1777,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     List<TableOptionProto> options = new ArrayList<>();
     String sql = "SELECT tid, key_, value_ FROM " + TB_OPTIONS;
 
-    try (Connection conn = getConnection();
-         Statement stmt = conn.createStatement();
+    try (Statement stmt = getConnection().createStatement();
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TableOptionProto.Builder builder = TableOptionProto.newBuilder();
@@ -1822,8 +1803,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     List<TableStatsProto> stats = new ArrayList<>();
     String sql = "SELECT tid, num_rows, num_bytes FROM " + TB_STATISTICS;
 
-    try (Connection conn = getConnection();
-         Statement stmt = conn.createStatement();
+    try (Statement stmt = getConnection().createStatement();
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TableStatsProto.Builder builder = TableStatsProto.newBuilder();
@@ -1848,8 +1828,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
             "SELECT TID, COLUMN_NAME, ORDINAL_POSITION, NESTED_FIELD_NUM, DATA_TYPE, TYPE_LENGTH FROM " + TB_COLUMNS +
                     " ORDER BY TID ASC, ORDINAL_POSITION ASC";
 
-    try (Connection conn = getConnection();
-         Statement stmt = conn.createStatement();
+    try (Statement stmt = getConnection().createStatement();
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         ColumnProto.Builder builder = ColumnProto.newBuilder();
@@ -1899,8 +1878,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -1931,8 +1909,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
 
       int databaseId = getDatabaseId(databaseName);
       int tableId = getTableId(databaseId, databaseName, tableName);
@@ -1970,8 +1947,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -2005,8 +1981,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       pstmt.setString(2, partitionName);
       res = pstmt.executeQuery();
@@ -2035,8 +2010,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     String sql = "SELECT "+ COL_COLUMN_NAME  + " , "+ COL_PARTITION_VALUE
             + " FROM " + TB_PARTTION_KEYS + " WHERE " + COL_PARTITIONS_PK + " = ? ";
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setInt(1, pid);
       res = pstmt.executeQuery();
 
@@ -2072,8 +2046,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       pstmt.setInt(1, tableId);
       res = pstmt.executeQuery();
 
@@ -2350,8 +2323,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     String sql = "SELECT " + COL_PARTITIONS_PK + ", " + COL_TABLES_PK + ", PARTITION_NAME, " +
             " PATH FROM " + TB_PARTTIONS;
 
-    try (Connection conn = getConnection();
-         Statement stmt = conn.createStatement();
+    try (Statement stmt = getConnection().createStatement();
          ResultSet resultSet = stmt.executeQuery(sql)) {
       while (resultSet.next()) {
         TablePartitionProto.Builder builder = TablePartitionProto.newBuilder();
@@ -2664,8 +2636,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
 
       pstmt.setInt(1, databaseId);
@@ -2710,8 +2681,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
       int tableId = getTableId(databaseId, databaseName, tableName);
       TableDescProto tableDescProto = getTable(databaseName, tableName);
@@ -2754,8 +2724,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
 
       pstmt.setInt(1, databaseId);
@@ -2786,8 +2755,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql);
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql)) {
       int databaseId = getDatabaseId(databaseName);
       int tableId = getTableId(databaseId, databaseName, tableName);
       Schema relationSchema = new Schema(getTable(databaseName, tableName).getSchema());
@@ -3016,8 +2984,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       LOG.debug(sql.toString());
     }
 
-    try (Connection conn = getConnection();
-         PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+    try (PreparedStatement pstmt = getConnection().prepareStatement(sql.toString())) {
      pstmt.setInt(1, tableId);
       pstmt.setString(2, columnName);
       res = pstmt.executeQuery();

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -2040,8 +2040,8 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     final int tableId = getTableId(databaseId, databaseName, tableName);
     ensurePartitionTable(tableName, tableId);
 
-    String sql = "SELECT PATH, PARTITION_NAME, " + COL_PARTITIONS_PK + " FROM "
-            + TB_PARTTIONS +" WHERE " + COL_TABLES_PK + " = ?  ";
+    String sql = "SELECT PATH, PARTITION_NAME, " + COL_PARTITIONS_PK + ", " + COL_PARTITION_BYTES
+            + " FROM " + TB_PARTTIONS +" WHERE " + COL_TABLES_PK + " = ?  ";
 
     if (LOG.isDebugEnabled()) {
       LOG.debug(sql);


### PR DESCRIPTION
See https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html. 
JDK 7 introduced try-resource statement for better resource allocation and deallocation. 
I adopt this feature to AbstractDBStore.