### PR TITLE
TAJO-1899: Calling 'Arrays.asList()' with too few arguments cause memory extravagance

### DIFF
--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/CommonJoinExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/CommonJoinExec.java
@@ -36,7 +36,11 @@ import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+
 
 /**
  * common exec for all join execs

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/CommonJoinExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/CommonJoinExec.java
@@ -36,10 +36,7 @@ import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.*;
 
 /**
  * common exec for all join execs
@@ -186,7 +183,7 @@ public abstract class CommonJoinExec extends BinaryPhysicalExec {
    * @return created list of a null tuple
    */
   protected List<Tuple> nullTupleList(int width) {
-    return Arrays.asList(NullTuple.create(width));
+    return Collections.singletonList(NullTuple.create(width));
   }
 
   @Override

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
@@ -461,7 +461,7 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     columns.add(tuple);
 
     ResultSet result = new TajoMetaDataResultSet(
-            Collections.singletonList("TABLE_TYPE")
+        Collections.singletonList("TABLE_TYPE")
         , Collections.singletonList(Type.VARCHAR)
         , columns);
 
@@ -768,7 +768,7 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     return new TajoMetaDataResultSet(
         Arrays.asList("TABLE_SCHEM", "TABLE_CATALOG"),
         Arrays.asList(Type.VARCHAR, Type.VARCHAR),
-            Collections.singletonList(tuple));
+        Collections.singletonList(tuple));
   }
 
   @Override

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
@@ -431,7 +431,7 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     return new TajoMetaDataResultSet(
         Arrays.asList("TABLE_SCHEM", "TABLE_CATALOG"),
         Arrays.asList(Type.VARCHAR, Type.VARCHAR),
-        Arrays.asList(tuple));
+            Collections.singletonList(tuple));
   }
 
   @Override
@@ -448,8 +448,8 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     }
 
     return new TajoMetaDataResultSet(
-        Arrays.asList("TABLE_CAT"),
-        Arrays.asList(Type.VARCHAR) ,
+            Collections.singletonList("TABLE_CAT"),
+            Collections.singletonList(Type.VARCHAR),
         tuples);
   }
 
@@ -461,8 +461,8 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     columns.add(tuple);
 
     ResultSet result = new TajoMetaDataResultSet(
-        Arrays.asList("TABLE_TYPE")
-        , Arrays.asList(Type.VARCHAR)
+            Collections.singletonList("TABLE_TYPE")
+        , Collections.singletonList(Type.VARCHAR)
         , columns);
 
     return result;
@@ -768,7 +768,7 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     return new TajoMetaDataResultSet(
         Arrays.asList("TABLE_SCHEM", "TABLE_CATALOG"),
         Arrays.asList(Type.VARCHAR, Type.VARCHAR),
-        Arrays.asList(tuple));
+            Collections.singletonList(tuple));
   }
 
   @Override

--- a/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
+++ b/tajo-jdbc/src/main/java/org/apache/tajo/jdbc/TajoDatabaseMetaData.java
@@ -431,7 +431,7 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     return new TajoMetaDataResultSet(
         Arrays.asList("TABLE_SCHEM", "TABLE_CATALOG"),
         Arrays.asList(Type.VARCHAR, Type.VARCHAR),
-            Collections.singletonList(tuple));
+        Collections.singletonList(tuple));
   }
 
   @Override
@@ -448,8 +448,8 @@ public class TajoDatabaseMetaData implements DatabaseMetaData {
     }
 
     return new TajoMetaDataResultSet(
-            Collections.singletonList("TABLE_CAT"),
-            Collections.singletonList(Type.VARCHAR),
+        Collections.singletonList("TABLE_CAT"),
+        Collections.singletonList(Type.VARCHAR),
         tuples);
   }
 


### PR DESCRIPTION
Reports any calls to Arrays.asList() with zero arguments or only one argument.
Such calls could be replaced with either a call to Collections.singletonList() or Collections.emptyList() which will save some memory.