### PR TITLE
TAJO-1895: Add a maven profile to skip the unit tests of tajo-storage-pgsql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_install: ulimit -t 514029 -u 2048 -n 3000
 install: ./dev-support/travis-install-dependencies.sh
 
 script: 
-  mvn clean install -q -ff -Dsurefire.useFile=false -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2
+  mvn clean install -q -ff -Dsurefire.useFile=false -Pparallel-test -DLOG_LEVEL=WARN -Dmaven.fork.count=2 -Ptest-storage-pgsql

--- a/tajo-project/pom.xml
+++ b/tajo-project/pom.xml
@@ -481,7 +481,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.1</version>
           <configuration>
             <findbugsXmlOutput>true</findbugsXmlOutput>
             <xmlOutput>true</xmlOutput>

--- a/tajo-storage/tajo-storage-pgsql/pom.xml
+++ b/tajo-storage/tajo-storage-pgsql/pom.xml
@@ -223,62 +223,8 @@
 
   <profiles>
     <profile>
-      <!-- testing-postgresql-server only supports x86-64 on linux environment -->
-      <id>linux-x86_64-tests</id>
-      <activation>
-        <os>
-          <name>linux</name>
-          <arch>x86_64</arch>
-        </os>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration combine.self="override">
-              <systemProperties>
-                <tajo.test.enabled>TRUE</tajo.test.enabled>
-              </systemProperties>
-              <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <!-- testing-postgresql-server only supports amd64 on linux environment -->
-      <id>linux-amd64-tests</id>
-      <activation>
-        <os>
-          <name>linux</name>
-          <arch>amd64</arch>
-        </os>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration combine.self="override">
-              <systemProperties>
-                <tajo.test.enabled>TRUE</tajo.test.enabled>
-              </systemProperties>
-              <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <!-- testing-postgresql-server only supports x86-64 on mac os environment -->
-      <id>macos-x86_64-tests</id>
-      <activation>
-        <os>
-          <name>mac os x</name>
-          <arch>x86_64</arch>
-        </os>
-      </activation>
+      <!-- Run unit tests in tajo-storage-pgsql, whereas it is disabled as by default. -->
+      <id>test-storage-pgsql</id>
       <build>
         <plugins>
           <plugin>

--- a/tajo-storage/tajo-storage-pgsql/src/main/java/org/apache/tajo/storage/pgsql/PgSQLTablespace.java
+++ b/tajo-storage/tajo-storage-pgsql/src/main/java/org/apache/tajo/storage/pgsql/PgSQLTablespace.java
@@ -68,4 +68,9 @@ public class PgSQLTablespace extends JdbcTablespace {
     scanner.setTarget(target.toArray());
     return scanner;
   }
+
+  @Override
+  public int hashCode() {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
You can disable tajo-storage-pgsql unit test by the profile ``-Ptest-storage-pgsql`` as follows:
```
mvn clean install -Ptest-storage-pgsql
```

The unit tests of tajo-storage-pgsql are disabled by default. Please refer to the discussion.
http://markmail.org/message/pdhz7u4r4rsfabz7