### PR TITLE
TAJO-1875: Resource leak after a query failure

### DIFF
--- a/tajo-core-tests/src/test/java/org/apache/tajo/worker/MockTaskManager.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/worker/MockTaskManager.java
@@ -29,18 +29,31 @@ import org.apache.tajo.worker.event.TaskManagerEvent;
 
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeoutException;
 
 public class MockTaskManager extends TaskManager {
 
   private final Semaphore barrier;
+  private boolean testEbCreateFailure = false;
 
   public MockTaskManager(Semaphore barrier, Dispatcher dispatcher, TajoWorker.WorkerContext workerContext) {
     super(dispatcher, workerContext);
     this.barrier = barrier;
   }
 
+  public void enableEbCreateFailure() {
+    testEbCreateFailure = true;
+  }
+
+  public void disableEbCreateFailure() {
+    testEbCreateFailure = true;
+  }
+
   @Override
   protected ExecutionBlockContext createExecutionBlock(ExecutionBlockId executionBlockId, String queryMaster) {
+    if (testEbCreateFailure) {
+      throw new RuntimeException("Failure for test");
+    }
     try {
       ExecutionBlockContextResponse.Builder builder = ExecutionBlockContextResponse.newBuilder();
       builder.setExecutionBlockId(executionBlockId.getProto())

--- a/tajo-core-tests/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/worker/TestNodeResourceManager.java
@@ -32,7 +32,9 @@ import org.apache.tajo.worker.event.NodeResourceDeallocateEvent;
 import org.apache.tajo.worker.event.NodeResourceEvent;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import java.util.List;
 import java.util.Queue;
@@ -42,6 +44,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.tajo.ResourceProtos.*;
 import static org.junit.Assert.*;
 public class TestNodeResourceManager {
+
+  @Rule
+  public TestName name = new TestName();
 
   private MockNodeResourceManager resourceManager;
   private NodeStatusUpdater statusUpdater;
@@ -54,6 +59,14 @@ public class TestNodeResourceManager {
   private CompositeService service;
   private int taskMemory;
   private TajoConf conf;
+
+  private static boolean enableEbCreateFailure(String testName) {
+    if (testName.equals("testResourceDeallocateWithEbCreateFailure")) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 
   @Before
   public void setup() {
@@ -106,6 +119,10 @@ public class TestNodeResourceManager {
     taskExecutor = new MockTaskExecutor(new Semaphore(0), workerContext);
     resourceManager = new MockNodeResourceManager(new Semaphore(0), dispatcher, workerContext);
     statusUpdater = new MockNodeStatusUpdater(new CountDownLatch(0), workerContext);
+
+    if (enableEbCreateFailure(name.getMethodName())) {
+      ((MockTaskManager)taskManager).enableEbCreateFailure();
+    }
 
     service = new CompositeService("MockService") {
       @Override
@@ -235,7 +252,6 @@ public class TestNodeResourceManager {
 
     List<Future> futureList = Lists.newArrayList();
 
-    long startTime = System.currentTimeMillis();
     for (int i = 0; i < parallelCount; i++) {
       futureList.add(executor.submit(new Runnable() {
             @Override
@@ -276,5 +292,26 @@ public class TestNodeResourceManager {
 
     executor.shutdown();
     assertEquals(taskSize, totalComplete.get());
+  }
+
+  @Test
+  public void testResourceDeallocateWithEbCreateFailure() throws Exception {
+    final int taskSize = 10;
+    resourceManager.setTaskHandlerEvent(true);
+
+    final ExecutionBlockId ebId = new ExecutionBlockId(LocalTajoTestingUtility.newQueryId(), 0);
+    final Queue<TaskAllocationProto>
+        totalTasks = MockNodeResourceManager.createTaskRequests(ebId, taskMemory, taskSize);
+
+    TaskAllocationProto task = totalTasks.poll();
+    BatchAllocationRequest.Builder requestProto = BatchAllocationRequest.newBuilder();
+    requestProto.addTaskRequest(task);
+    requestProto.setExecutionBlockId(ebId.getProto());
+    CallFuture<BatchAllocationResponse> callFuture = new CallFuture<>();
+    dispatcher.getEventHandler().handle(new NodeResourceAllocateEvent(requestProto.build(), callFuture));
+    assertTrue(callFuture.get().getCancellationTaskCount() == 0);
+
+    Thread.sleep(2000); // wait for resource deallocation
+    assertEquals(resourceManager.getTotalResource(), resourceManager.getAvailableResource());
   }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskExecutor.java
@@ -138,9 +138,16 @@ public class TaskExecutor extends AbstractService implements EventHandler<TaskSt
     NodeResource resource =  allocatedResourceMap.remove(taskId);
 
     if(resource != null) {
-      workerContext.getNodeResourceManager().getDispatcher().getEventHandler().handle(
-          new NodeResourceDeallocateEvent(resource, NodeResourceEvent.ResourceType.TASK));
+      releaseResource(resource);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Task resource " + taskId + " is released. (" + resource + ")");
+      }
     }
+  }
+
+  protected void releaseResource(NodeResource resource) {
+    workerContext.getNodeResourceManager().getDispatcher().getEventHandler().handle(
+        new NodeResourceDeallocateEvent(resource, NodeResourceEvent.ResourceType.TASK));
   }
 
   protected Task createTask(ExecutionBlockContext executionBlockContext,

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskManager.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskManager.java
@@ -185,12 +185,14 @@ public class TaskManager extends AbstractService implements EventHandler<TaskMan
                 + ", running tasks:" + getRunningTasks() + ", availableResource: "
                 + workerContext.getNodeResourceManager().getAvailableResource());
           }
-          getTaskExecutor().handle(taskStartEvent);
-        } catch (Exception e) {
-          getTaskExecutor().releaseResource(taskStartEvent.getTaskAttemptId());
+        } catch (Throwable e) {
+          LOG.fatal(e.getMessage(), e);
+          getTaskExecutor().releaseResource(taskStartEvent.getAllocatedResource());
           getWorkerContext().getTaskManager().getDispatcher().getEventHandler()
               .handle(new ExecutionBlockErrorEvent(taskStartEvent.getExecutionBlockId(), e));
+          break;
         }
+        getTaskExecutor().handle(taskStartEvent);
         break;
       }
       case EB_STOP: {


### PR DESCRIPTION
The main reason is that wrong resource release routine. 
When TaskManager receives a task start event ```e```, it checks that ```e``` is the first task start event of the current eb. If so, it create a context for the current eb. Here, if an error occurs while creating a eb context, the resource assigned for ```e``` must be released. 
However, in the current implementation, the resource release routine requires a task attempt id which will not exist with an eb start failure. As a result, resource manager loses the resource assigned for ```e```.