### PR TITLE
TAJO-1920: Calling 'Collection.toArray()' with zero-length array argument makes performance worse

### DIFF
--- a/tajo-algebra/src/main/java/org/apache/tajo/algebra/TruncateTable.java
+++ b/tajo-algebra/src/main/java/org/apache/tajo/algebra/TruncateTable.java
@@ -46,6 +46,6 @@ public class TruncateTable extends Expr {
   @Override
   boolean equalsTo(Expr expr) {
     TruncateTable another = (TruncateTable) expr;
-    return Arrays.equals(tableNames.toArray(new String[]{}), another.tableNames.toArray(new String[]{}));
+    return Arrays.equals(tableNames.toArray(new String[tableNames.size()]), another.tableNames.toArray(new String[another.tableNames.size()]));
   }
 }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
@@ -718,7 +718,7 @@ public class TestGroupByQuery extends QueryTestCaseBase {
         break;
       }
     }
-    TajoTestingCluster.createTable("testnumshufflepartition", schema, tableOptions, data.toArray(new String[]{}), 3);
+    TajoTestingCluster.createTable("testnumshufflepartition", schema, tableOptions, data.toArray(new String[data.size()]), 3);
 
     try {
       testingCluster.setAllTajoDaemonConfValue(ConfVars.$DIST_QUERY_GROUPBY_PARTITION_VOLUME.varname, "2");

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
@@ -796,7 +796,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       datas.add(df.format(i) + "|value" + i);
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     executeString("insert into hbase_mapped_table " +
         "select id, name from base_table ").close();
@@ -851,7 +851,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       datas.add(i + "|value" + i);
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     executeString("insert into hbase_mapped_table " +
         "select id, name from base_table ").close();
@@ -910,7 +910,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       datas.add(df.format(i) + "|value" + i);
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     executeString("insert into hbase_mapped_table " +
         "select id, name from base_table ").close();
@@ -969,7 +969,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       datas.add(df.format(i) + "|" + (i + 100) + "|value" + i);
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     executeString("insert into hbase_mapped_table " +
         "select id1, id2, name from base_table ").close();
@@ -1024,7 +1024,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       datas.add(i + "|value" + i);
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     executeString("insert into hbase_mapped_table " +
         "select id, name from base_table ").close();
@@ -1084,7 +1084,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       }
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     executeString("insert into hbase_mapped_table " +
         "select rk, col2_key, col2_value, col3 from base_table ").close();
@@ -1169,7 +1169,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       datas.add(i + "|value" + i);
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     try {
       executeString("insert into hbase_mapped_table " +
@@ -1242,7 +1242,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
       datas.add(df.format(i) + "|value" + i);
     }
     TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-        schema, tableOptions, datas.toArray(new String[]{}), 2);
+        schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
     executeString(
         "CREATE TABLE hbase_mapped_table (rk text, col1 text) TABLESPACE cluster1 " +
@@ -1364,7 +1364,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
         datas.add(df.format(i) + "|value" + i + "|comment-" + i);
       }
       TajoTestingCluster.createTable(getCurrentDatabase() + ".base_table",
-          schema, tableOptions, datas.toArray(new String[]{}), 2);
+          schema, tableOptions, datas.toArray(new String[datas.size()]), 2);
 
       executeString("insert into location '/tmp/hfile_test' " +
           "select id, name, comment from base_table ").close();

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestTablePartitions.java
@@ -1119,7 +1119,7 @@ public class TestTablePartitions extends QueryTestCaseBase {
         index++;
       }
 
-      TajoTestingCluster.createTable("testscatteredhashshuffle", schema, tableOptions, data.toArray(new String[]{}), 3);
+      TajoTestingCluster.createTable("testscatteredhashshuffle", schema, tableOptions, data.toArray(new String[data.size()]), 3);
       CatalogService catalog = testingCluster.getMaster().getCatalog();
       assertTrue(catalog.existsTable("default", "testscatteredhashshuffle"));
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/util/TestJSPUtil.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/util/TestJSPUtil.java
@@ -59,24 +59,24 @@ public class TestJSPUtil {
 
     Collections.shuffle(tasks);
 
-    Task[] taskArray = tasks.toArray(new Task[]{});
+    Task[] taskArray = tasks.toArray(new Task[tasks.size()]);
     JSPUtil.sortTaskArray(taskArray, "id", "asc");
     for (int i = 0; i < 10; i++) {
       assertEquals(i, taskArray[i].getId().getId());
     }
 
-    taskArray = tasks.toArray(new Task[]{});
+    taskArray = tasks.toArray(new Task[tasks.size()]);
     JSPUtil.sortTaskArray(taskArray, "id", "desc");
     for (int i = 0; i < 10; i++) {
       assertEquals(9 - i, taskArray[i].getId().getId());
     }
 
-    taskArray = tasks.toArray(new Task[]{});
+    taskArray = tasks.toArray(new Task[tasks.size()]);
     JSPUtil.sortTaskArray(taskArray, "runTime", "asc");
     assertEquals(0, taskArray[0].getId().getId());
     assertEquals(9, taskArray[9].getId().getId());
 
-    taskArray = tasks.toArray(new Task[]{});
+    taskArray = tasks.toArray(new Task[tasks.size()]);
     JSPUtil.sortTaskArray(taskArray, "runTime", "desc");
     assertEquals(8, taskArray[0].getId().getId());
     assertEquals(9, taskArray[9].getId().getId());

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
@@ -1110,7 +1110,7 @@ public class PhysicalPlannerImpl implements PhysicalPlanner {
         sortSpecs.add(new SortSpec(eachColumn));
       }
     }
-    sortNode.setSortSpecs(sortSpecs.toArray(new SortSpec[]{}));
+    sortNode.setSortSpecs(sortSpecs.toArray(new SortSpec[sortSpecs.size()]));
     sortNode.setInSchema(distinctNode.getInSchema());
     sortNode.setOutSchema(distinctNode.getInSchema());
     ExternalSortExec sortExec = new ExternalSortExec(context, sortNode, subOp);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/builder/DistinctGroupbyBuilder.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/builder/DistinctGroupbyBuilder.java
@@ -229,7 +229,7 @@ public class DistinctGroupbyBuilder {
               groupingColumns.add(eachGroupingColumn);
             }
           }
-          distinctGroupbyNode.setGroupingColumns(groupingColumns.toArray(new Column[]{}));
+          distinctGroupbyNode.setGroupingColumns(groupingColumns.toArray(new Column[groupingColumns.size()]));
         }
         buildInfo.addAggFunction(aggFunction);
         buildInfo.addAggFunctionTarget(aggFunctionTarget);
@@ -262,7 +262,7 @@ public class DistinctGroupbyBuilder {
         targets[targetIdx++] = eachAggFunctionTarget;
       }
       eachGroupbyNode.setTargets(targets);
-      eachGroupbyNode.setAggFunctions(groupbyAggFunctions.toArray(new AggregationFunctionCallEval[]{}));
+      eachGroupbyNode.setAggFunctions(groupbyAggFunctions.toArray(new AggregationFunctionCallEval[groupbyAggFunctions.size()]));
       eachGroupbyNode.setDistinct(true);
       eachGroupbyNode.setInSchema(groupbyNode.getInSchema());
 
@@ -283,14 +283,14 @@ public class DistinctGroupbyBuilder {
 
       otherGroupbyNode.setTargets(targets);
       otherGroupbyNode.setGroupingColumns(new Column[]{});
-      otherGroupbyNode.setAggFunctions(otherAggregationFunctionCallEvals.toArray(new AggregationFunctionCallEval[]{}));
+      otherGroupbyNode.setAggFunctions(otherAggregationFunctionCallEvals.toArray(new AggregationFunctionCallEval[otherAggregationFunctionCallEvals.size()]));
       otherGroupbyNode.setInSchema(groupbyNode.getInSchema());
 
       childGroupbyNodes.add(otherGroupbyNode);
     }
 
     DistinctGroupbyNode baseDistinctNode = new DistinctGroupbyNode(context.getPlan().getLogicalPlan().newPID());
-    baseDistinctNode.setTargets(baseGroupByTargets.toArray(new Target[]{}));
+    baseDistinctNode.setTargets(baseGroupByTargets.toArray(new Target[baseGroupByTargets.size()]));
     baseDistinctNode.setGroupingColumns(groupbyNode.getGroupingColumns());
     baseDistinctNode.setInSchema(groupbyNode.getInSchema());
     baseDistinctNode.setChild(groupbyNode.getChild());
@@ -399,7 +399,7 @@ public class DistinctGroupbyBuilder {
               groupingColumns.add(eachGroupingColumn);
             }
           }
-          distinctGroupbyNode.setGroupingColumns(groupingColumns.toArray(new Column[]{}));
+          distinctGroupbyNode.setGroupingColumns(groupingColumns.toArray(new Column[groupingColumns.size()]));
         }
         buildInfo.addAggFunction(aggFunction);
         buildInfo.addAggFunctionTarget(aggFunctionTarget);
@@ -425,7 +425,7 @@ public class DistinctGroupbyBuilder {
         targets[targetIdx++] = eachAggFunctionTarget;
       }
       eachGroupbyNode.setTargets(targets);
-      eachGroupbyNode.setAggFunctions(groupbyAggFunctions.toArray(new AggregationFunctionCallEval[]{}));
+      eachGroupbyNode.setAggFunctions(groupbyAggFunctions.toArray(new AggregationFunctionCallEval[groupbyAggFunctions.size()]));
       eachGroupbyNode.setDistinct(true);
       eachGroupbyNode.setInSchema(groupbyNode.getInSchema());
 
@@ -448,8 +448,8 @@ public class DistinctGroupbyBuilder {
       }
 
       otherGroupbyNode.setTargets(targets);
-      otherGroupbyNode.setGroupingColumns(originalGroupingColumns.toArray(new Column[]{}));
-      otherGroupbyNode.setAggFunctions(otherAggregationFunctionCallEvals.toArray(new AggregationFunctionCallEval[]{}));
+      otherGroupbyNode.setGroupingColumns(originalGroupingColumns.toArray(new Column[originalGroupingColumns.size()]));
+      otherGroupbyNode.setAggFunctions(otherAggregationFunctionCallEvals.toArray(new AggregationFunctionCallEval[otherAggregationFunctionCallEvals.size()]));
       otherGroupbyNode.setInSchema(groupbyNode.getInSchema());
 
       childGroupbyNodes.add(otherGroupbyNode);
@@ -530,12 +530,12 @@ public class DistinctGroupbyBuilder {
           Target target = new Target(new FieldEval(column));
           firstGroupbyTargets.add(target);
         }
-        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[]{}));
+        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[firstGroupbyTargets.size()]));
 
         // SecondStage:
         //   Set grouping column with origin groupby's columns
         //   Remove distinct group column from targets
-        secondStageGroupbyNode.setGroupingColumns(originGroupColumns.toArray(new Column[]{}));
+        secondStageGroupbyNode.setGroupingColumns(originGroupColumns.toArray(new Column[originGroupColumns.size()]));
 
         Target[] oldTargets = secondStageGroupbyNode.getTargets();
         List<Target> secondGroupbyTargets = new ArrayList<>();
@@ -567,7 +567,7 @@ public class DistinctGroupbyBuilder {
           }
           columnIdIndex++;
         }
-        secondStageGroupbyNode.setTargets(secondGroupbyTargets.toArray(new Target[]{}));
+        secondStageGroupbyNode.setTargets(secondGroupbyTargets.toArray(new Target[secondGroupbyTargets.size()]));
       } else {
         // FirstStage: Change target of aggFunction to function name expr
         List<Target> firstGroupbyTargets = new ArrayList<>();
@@ -597,7 +597,7 @@ public class DistinctGroupbyBuilder {
           columnIdIndex++;
           aggFuncIdx++;
         }
-        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[]{}));
+        firstStageGroupbyNode.setTargets(firstGroupbyTargets.toArray(new Target[firstGroupbyTargets.size()]));
         secondStageGroupbyNode.setInSchema(firstStageGroupbyNode.getOutSchema());
       }
       grpIdx++;
@@ -656,7 +656,7 @@ public class DistinctGroupbyBuilder {
         }
       }
     }
-    firstStageDistinctNode.setTargets(firstTargets.toArray(new Target[]{}));
+    firstStageDistinctNode.setTargets(firstTargets.toArray(new Target[firstTargets.size()]));
     firstStageDistinctNode.setResultColumnIds(TUtil.toArray(firstStageColumnIds));
 
     //Set SecondStage ColumnId and Input schema

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
@@ -91,7 +91,7 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
       }
       resultTupleLength += eachGroupby.getAggFunctions().length;
     }
-    aggregators = aggregatorList.toArray(new DistinctFinalAggregator[]{});
+    aggregators = aggregatorList.toArray(new DistinctFinalAggregator[aggregatorList.size()]);
     outTuple = new VTuple(resultTupleLength);
 
     // make output schema mapping index

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/PhysicalPlanUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/PhysicalPlanUtil.java
@@ -120,7 +120,7 @@ public class PhysicalPlanUtil {
         fragments.add(fileFragment);
       }
     }
-    return FragmentConvertor.toFragmentProtoArray(fragments.toArray(new FileFragment[]{}));
+    return FragmentConvertor.toFragmentProtoArray(fragments.toArray(new FileFragment[fragments.size()]));
   }
 
   /**

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultFileScanner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultFileScanner.java
@@ -114,7 +114,7 @@ public class NonForwardQueryResultFileScanner implements NonForwardQueryResultSc
     }
 
     if (!fragments.isEmpty()) {
-      FragmentProto[] fragmentProtos = FragmentConvertor.toFragmentProtoArray(fragments.toArray(new Fragment[]{}));
+      FragmentProto[] fragmentProtos = FragmentConvertor.toFragmentProtoArray(fragments.toArray(new Fragment[fragments.size()]));
       this.taskContext = new TaskAttemptContext(
           new QueryContext(tajoConf), null,
           new TaskAttemptId(new TaskId(new ExecutionBlockId(queryId, 1), 0), 0),

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/DefaultTaskScheduler.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/DefaultTaskScheduler.java
@@ -218,7 +218,8 @@ public class DefaultTaskScheduler extends AbstractTaskScheduler {
           fragmentsForNonLeafTask = new FileFragment[2];
           fragmentsForNonLeafTask[0] = castEvent.getLeftFragment();
           if (castEvent.hasRightFragments()) {
-            FileFragment[] rightFragments = castEvent.getRightFragments().toArray(new FileFragment[]{});
+            Collection<Fragment> var = castEvent.getRightFragments();
+            FileFragment[] rightFragments = var.toArray(new FileFragment[var.size()]);
             fragmentsForNonLeafTask[1] = rightFragments[0];
             if (rightFragments.length > 1) {
               broadcastFragmentsForNonLeafTask = new FileFragment[rightFragments.length - 1];

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Task.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Task.java
@@ -279,7 +279,7 @@ public class Task implements EventHandler<TaskEvent> {
         fragmentList.add("ERROR: " + eachFragment.getDataFormat() + "," + eachFragment.getId() + ": " + e.getMessage());
       }
     }
-    taskHistory.setFragments(fragmentList.toArray(new String[]{}));
+    taskHistory.setFragments(fragmentList.toArray(new String[fragmentList.size()]));
 
     List<String[]> fetchList = new ArrayList<>();
     for (Map.Entry<String, Set<FetchImpl>> e : getFetchMap().entrySet()) {
@@ -297,7 +297,7 @@ public class Task implements EventHandler<TaskEvent> {
       dataLocationList.add(eachLocation.toString());
     }
 
-    taskHistory.setDataLocations(dataLocationList.toArray(new String[]{}));
+    taskHistory.setDataLocations(dataLocationList.toArray(new String[dataLocationList.size()]));
     return taskHistory;
   }
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
@@ -262,6 +262,6 @@ public class DistinctGroupbyNode extends UnaryNode implements Projectable, Clone
       }
     }
 
-    return shuffleKeyColumns.toArray(new Column[]{});
+    return shuffleKeyColumns.toArray(new Column[shuffleKeyColumns.size()]);
   }
 }

--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseTablespace.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseTablespace.java
@@ -1002,7 +1002,7 @@ public class HBaseTablespace extends Tablespace {
         } else {
           tupleRanges.remove(tupleRanges.size() - 1);
         }
-        return tupleRanges.toArray(new TupleRange[]{});
+        return tupleRanges.toArray(new TupleRange[tupleRanges.size()]);
       } finally {
         htable.close();
       }

--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/SortedInsertRewriter.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/SortedInsertRewriter.java
@@ -67,7 +67,7 @@ public class SortedInsertRewriter implements LogicalPlanRewriteRule {
       }
     }
 
-    return indexColumns.toArray(new Column[]{});
+    return indexColumns.toArray(new Column[indexColumns.size()]);
   }
 
   @Override

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
@@ -78,9 +78,10 @@ public class FileFragment implements Fragment, Comparable<FileFragment>, Cloneab
     for(Integer eachValue: proto.getDiskIdsList()) {
       diskIds[i++] = eachValue;
     }
+    List<String> var = proto.getHostsList();
     this.set(proto.getId(), new Path(proto.getPath()),
         proto.getStartOffset(), proto.getLength(),
-        proto.getHostsList().toArray(new String[]{}),
+            var.toArray(new String[var.size()]),
         diskIds);
   }
 


### PR DESCRIPTION
When passing in an array of too small size, the toArray() method has to construct a new array of the right size using reflection. This has significantly worse performance than passing in an array of at least the size of the collection itself.