### PR TITLE
TAJO-1850: Using TUtil.newHash(Set/Map) should be replaced by Java's diamond operator

### DIFF
--- a/tajo-algebra/src/main/java/org/apache/tajo/algebra/RelationList.java
+++ b/tajo-algebra/src/main/java/org/apache/tajo/algebra/RelationList.java
@@ -18,8 +18,9 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import org.apache.tajo.util.TUtil;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 public class RelationList extends Expr {
@@ -64,9 +65,9 @@ public class RelationList extends Expr {
 
   @Override
   boolean equalsTo(Expr expr) {
-    Set<Expr> thisSet = TUtil.newHashSet(relations);
+    Set<Expr> thisSet = new HashSet<>(Arrays.asList(relations));
     RelationList another = (RelationList) expr;
-    Set<Expr> anotherSet = TUtil.newHashSet(another.relations);
+    Set<Expr> anotherSet = new HashSet<>(Arrays.asList(another.relations));
     return thisSet.equals(anotherSet);
   }
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/json/CatalogGsonHelper.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/json/CatalogGsonHelper.java
@@ -26,9 +26,9 @@ import org.apache.tajo.function.Function;
 import org.apache.tajo.common.TajoDataTypes.DataType;
 import org.apache.tajo.datum.Datum;
 import org.apache.tajo.json.*;
-import org.apache.tajo.util.TUtil;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 
 public class CatalogGsonHelper {
@@ -39,7 +39,7 @@ public class CatalogGsonHelper {
   }
 
   private static Map<Type, GsonSerDerAdapter> registerAdapters() {
-    Map<Type, GsonSerDerAdapter> adapters = TUtil.newHashMap();
+    Map<Type, GsonSerDerAdapter> adapters = new HashMap<>();
     adapters.put(Class.class, new ClassNameSerializer());
     adapters.put(Path.class, new PathSerializer());
     adapters.put(TableMeta.class, new TableMetaAdapter());

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
@@ -725,7 +725,7 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
       partition.setDbName(databaseName);
       partition.setTableName(tableName);
 
-      Map<String, String> params = TUtil.newHashMap();
+      Map<String, String> params = new HashMap<>();
       params.put(StatsSetupConst.TOTAL_SIZE, Long.toString(partitionDescProto.getNumBytes()));
       partition.setParameters(params);
 

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -1108,7 +1108,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     Connection conn = null;
     PreparedStatement pstmt = null;
     ResultSet res = null;
-    Map<String, String> options = TUtil.newHashMap();
+    Map<String, String> options = new HashMap<>();
 
     try {
       String tidSql = "SELECT key_, value_ FROM " + TB_OPTIONS + " WHERE TID=?";

--- a/tajo-catalog/tajo-catalog-server/src/test/java/org/apache/tajo/catalog/TestCatalog.java
+++ b/tajo-catalog/tajo-catalog-server/src/test/java/org/apache/tajo/catalog/TestCatalog.java
@@ -513,7 +513,7 @@ public class TestCatalog {
 	  assertTrue(catalog.existIndexByName(DEFAULT_DATABASE_NAME, desc2.getName()));
 	  assertTrue(catalog.existIndexByColumnNames(DEFAULT_DATABASE_NAME, "indexed", new String[]{"score"}));
 
-    Set<IndexDesc> indexDescs = TUtil.newHashSet();
+    Set<IndexDesc> indexDescs = new HashSet<>();
     indexDescs.add(desc1);
     indexDescs.add(desc2);
     indexDescs.add(desc3);

--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -32,7 +32,6 @@ import org.apache.tajo.service.BaseServiceTracker;
 import org.apache.tajo.unit.StorageUnit;
 import org.apache.tajo.util.NetUtils;
 import org.apache.tajo.util.NumberUtil;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.datetime.DateTimeConstants;
 import org.apache.tajo.validation.ConstraintViolationException;
 import org.apache.tajo.validation.Validator;
@@ -41,6 +40,7 @@ import org.apache.tajo.validation.Validators;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -49,7 +49,7 @@ public class TajoConf extends Configuration {
   private static TimeZone SYSTEM_TIMEZONE;
   private static int DATE_ORDER = -1;
   
-  private static final Map<String, ConfVars> vars = TUtil.newHashMap();
+  private static final Map<String, ConfVars> vars = new HashMap<>();
 
   static {
     Configuration.addDefaultResource("catalog-default.xml");

--- a/tajo-common/src/main/java/org/apache/tajo/json/CommonGsonHelper.java
+++ b/tajo-common/src/main/java/org/apache/tajo/json/CommonGsonHelper.java
@@ -25,9 +25,9 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import org.apache.tajo.datum.Datum;
-import org.apache.tajo.util.TUtil;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 
 public class CommonGsonHelper {
@@ -38,7 +38,7 @@ public class CommonGsonHelper {
   }
 
 	private static Map<Type, GsonSerDerAdapter> registerAdapters() {
-    Map<Type, GsonSerDerAdapter> adapters = TUtil.newHashMap();
+    Map<Type, GsonSerDerAdapter> adapters = new HashMap<>();
     adapters.put(Datum.class, new DatumAdapter());
 
     return adapters;

--- a/tajo-common/src/main/java/org/apache/tajo/rule/EvaluationContext.java
+++ b/tajo-common/src/main/java/org/apache/tajo/rule/EvaluationContext.java
@@ -18,13 +18,12 @@
 
 package org.apache.tajo.rule;
 
+import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.tajo.util.TUtil;
 
 public class EvaluationContext {
 
-  private final Map<String, Object> paramMap = TUtil.newHashMap();
+  private final Map<String, Object> paramMap = new HashMap<>();
   
   public void clearParameters() {
     paramMap.clear();

--- a/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleEngine.java
+++ b/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleEngine.java
@@ -18,13 +18,7 @@
 
 package org.apache.tajo.rule;
 
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-
-import org.apache.tajo.util.TUtil;
+import java.util.*;
 
 public class SelfDiagnosisRuleEngine {
 
@@ -32,7 +26,7 @@ public class SelfDiagnosisRuleEngine {
   private static volatile SelfDiagnosisRuleEngine instance;
   
   private SelfDiagnosisRuleEngine() {
-    wrapperMap = TUtil.newHashMap();
+    wrapperMap = new HashMap<>();
     loadPredefinedRules();
   }
   
@@ -69,7 +63,7 @@ public class SelfDiagnosisRuleEngine {
         Map<String, RuleWrapper> categoryMap = wrapperMap.get(wrapper.getCategoryName());
 
         if (categoryMap == null) {
-          categoryMap = TUtil.newHashMap();
+          categoryMap = new HashMap<>();
           wrapperMap.put(wrapper.getCategoryName(), categoryMap);
         }
 

--- a/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleSession.java
+++ b/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleSession.java
@@ -18,12 +18,8 @@
 
 package org.apache.tajo.rule;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.apache.tajo.rule.EvaluationResult.EvaluationResultCode;
 import org.apache.tajo.rule.SelfDiagnosisRuleEngine.RuleWrapper;
@@ -37,8 +33,8 @@ public class SelfDiagnosisRuleSession {
 
   protected SelfDiagnosisRuleSession(SelfDiagnosisRuleEngine engine) {
     ruleEngine = engine;
-    categoryPredicate = TUtil.newHashSet();
-    rulePredicate = TUtil.newHashSet();
+    categoryPredicate = new HashSet<>();
+    rulePredicate = new HashSet<>();
   }
   
   public SelfDiagnosisRuleSession withCategoryNames(String...categories) {

--- a/tajo-common/src/main/java/org/apache/tajo/rule/base/TajoConfValidationRule.java
+++ b/tajo-common/src/main/java/org/apache/tajo/rule/base/TajoConfValidationRule.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.rule.base;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.tajo.conf.TajoConf;
@@ -28,7 +29,6 @@ import org.apache.tajo.rule.SelfDiagnosisRuleVisibility;
 import org.apache.tajo.rule.EvaluationResult.EvaluationResultCode;
 import org.apache.tajo.rule.SelfDiagnosisRuleDefinition;
 import org.apache.tajo.rule.SelfDiagnosisRule;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.validation.ConstraintViolation;
 import org.apache.tajo.validation.ConstraintViolationException;
 import org.apache.tajo.validation.Validator;
@@ -38,7 +38,7 @@ import org.apache.tajo.validation.Validator;
 public class TajoConfValidationRule implements SelfDiagnosisRule {
   
   private Collection<ConstraintViolation> isValidationTestPassed(TajoConf.ConfVars confVar, String varValue) {
-    Set<ConstraintViolation> violationSet = TUtil.newHashSet();
+    Set<ConstraintViolation> violationSet = new HashSet<>();
     
     if (varValue != null && confVar.valueClass() != null && confVar.validator() != null) {
       Class<?> valueClazz = confVar.valueClass();

--- a/tajo-common/src/main/java/org/apache/tajo/util/KeyValueSet.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/KeyValueSet.java
@@ -42,7 +42,7 @@ public class KeyValueSet implements ProtoObject<KeyValueSetProto>, Cloneable, Gs
   @Expose private Map<String,String> keyVals;
 
 	public KeyValueSet() {
-    keyVals = TUtil.newHashMap();
+    keyVals = new HashMap<>();
 	}
 
   public KeyValueSet(Map<String, String> keyVals) {
@@ -51,7 +51,7 @@ public class KeyValueSet implements ProtoObject<KeyValueSetProto>, Cloneable, Gs
   }
 
 	public KeyValueSet(KeyValueSetProto proto) {
-    this.keyVals = TUtil.newHashMap();
+    this.keyVals = new HashMap<>();
     for(KeyValueProto keyval : proto.getKeyvalList()) {
       this.keyVals.put(keyval.getKey(), keyval.getValue());
     }

--- a/tajo-common/src/main/java/org/apache/tajo/util/ProtoUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/ProtoUtil.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import org.apache.tajo.common.ProtoObject;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,7 +47,7 @@ public class ProtoUtil {
   }
 
   public static Map<String, String> convertToMap(KeyValueSetProto proto) {
-    Map<String, String> keyVals = TUtil.newHashMap();
+    Map<String, String> keyVals = new HashMap<>();
     for(KeyValueProto keyval : proto.getKeyvalList()) {
       keyVals.put(keyval.getKey(), keyval.getValue());
     }

--- a/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
@@ -122,28 +122,6 @@ public class TUtil {
     return result;
   }
 
-  public static <T> Set<T> newHashSet() {
-    return new HashSet<>();
-  }
-
-  public static <T> Set<T> newHashSet(T ...items) {
-    return new HashSet<>(Arrays.asList(items));
-  }
-
-  public static <K,V> Map<K,V> newHashMap() {
-    return new HashMap<>();
-  }
-
-  public static <K,V> Map<K,V> newHashMap(Map<K,V> map) {
-    return new HashMap<>(map);
-  }
-
-  public static <K, V> Map<K,V> newHashMap(K k, V v) {
-    HashMap<K, V> newMap = new HashMap<>();
-    newMap.put(k, v);
-    return newMap;
-  }
-
   public static <K,V> Map<K,V> newLinkedHashMap() {
     return new LinkedHashMap<>();
   }

--- a/tajo-common/src/main/java/org/apache/tajo/validation/AbstractValidator.java
+++ b/tajo-common/src/main/java/org/apache/tajo/validation/AbstractValidator.java
@@ -19,8 +19,7 @@
 package org.apache.tajo.validation;
 
 import java.util.Collection;
-
-import org.apache.tajo.util.TUtil;
+import java.util.HashSet;
 
 public abstract class AbstractValidator implements Validator {
   
@@ -30,7 +29,7 @@ public abstract class AbstractValidator implements Validator {
 
   @Override
   public <T> Collection<ConstraintViolation> validate(T object) {
-    Collection<ConstraintViolation> violations = TUtil.newHashSet();
+    Collection<ConstraintViolation> violations = new HashSet<>();
     
     if (!validateInternal(object)) {
       ConstraintViolation violation = new ConstraintViolation();

--- a/tajo-common/src/main/java/org/apache/tajo/validation/Validators.java
+++ b/tajo-common/src/main/java/org/apache/tajo/validation/Validators.java
@@ -18,12 +18,13 @@
 
 package org.apache.tajo.validation;
 
-import org.apache.tajo.util.TUtil;
+import java.util.Arrays;
+import java.util.HashSet;
 
 public class Validators {
   
   public static Validator groups(Validator...validators) {
-    return new GroupValidator(TUtil.newHashSet(validators));
+    return new GroupValidator(new HashSet<>(Arrays.asList(validators)));
   }
   
   public static Validator length(int maxLength) {

--- a/tajo-common/src/test/java/org/apache/tajo/validation/TestValidators.java
+++ b/tajo-common/src/test/java/org/apache/tajo/validation/TestValidators.java
@@ -25,10 +25,7 @@ import static org.junit.Assert.fail;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Random;
-import java.util.UUID;
+import java.util.*;
 
 import org.apache.tajo.util.TUtil;
 import org.hamcrest.Description;
@@ -322,7 +319,7 @@ public class TestValidators {
     String httpUrl = "http://tajo.apache.org";
     Collection<Validator> validators = null;
     
-    validators = TUtil.newHashSet();
+    validators = new HashSet<>();
     validators.add(new PatternValidator("^[a-zA-Z]+://"));
     validators.add(new LengthValidator(255));
     assertThat(new GroupValidator(validators).validate(httpUrl).size(), is(0));
@@ -330,7 +327,7 @@ public class TestValidators {
     assertThat(new GroupValidator(validators).validate("tajo"),
         hasItem(hasAClass(equalTo(PatternValidator.class))));
     
-    validators = TUtil.newHashSet();
+    validators = new HashSet<>();
     validators.add(new PatternValidator("^[a-zA-Z]+://"));
     validators.add(new LengthValidator(7));
     assertThat(new GroupValidator(validators).validate(httpUrl).size(), is(1));
@@ -351,7 +348,7 @@ public class TestValidators {
   public void testExceptionThrow() {
     Collection<Validator> validators = null;
     
-    validators = TUtil.newHashSet();
+    validators = new HashSet<>();
     validators.add(new PatternValidator("^[a-zA-Z]+://"));
     validators.add(new LengthValidator(255));
     new GroupValidator(validators).validate("tajo", true);

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/TestLogicalPlanner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/TestLogicalPlanner.java
@@ -516,7 +516,7 @@ public class TestLogicalPlanner {
     optimizer.optimize(plan);
 
     LogicalNode[] nodes = PlannerUtil.findAllNodes(node, NodeType.JOIN);
-    Map<BinaryEval, Boolean> qualMap = TUtil.newHashMap();
+    Map<BinaryEval, Boolean> qualMap = new HashMap<>();
     BinaryEval joinQual = new BinaryEval(EvalType.EQUAL
         , new FieldEval(new Column("default.n.n_regionkey", Type.INT4))
         , new FieldEval(new Column("default.ps.ps_suppkey", Type.INT4))
@@ -555,7 +555,7 @@ public class TestLogicalPlanner {
     optimizer.optimize(plan);
 
     LogicalNode[] nodes = PlannerUtil.findAllNodes(node, NodeType.SCAN);
-    Map<BinaryEval, Boolean> qualMap = TUtil.newHashMap();
+    Map<BinaryEval, Boolean> qualMap = new HashMap<>();
     BinaryEval joinQual = new BinaryEval(EvalType.EQUAL
         , new FieldEval(new Column("default.n.n_name", Type.TEXT))
         , new ConstEval(new TextDatum("MOROCCO"))
@@ -596,7 +596,7 @@ public class TestLogicalPlanner {
     optimizer.optimize(plan);
 
     LogicalNode[] nodes = PlannerUtil.findAllNodes(node, NodeType.SCAN);
-    Map<BinaryEval, Boolean> qualMap = TUtil.newHashMap();
+    Map<BinaryEval, Boolean> qualMap = new HashMap<>();
     TextDatum[] datums = new TextDatum[3];
     datums[0] = new TextDatum("ARGENTINA");
     datums[1] = new TextDatum("ETHIOPIA");
@@ -642,7 +642,7 @@ public class TestLogicalPlanner {
     LogicalOptimizer optimizer = new LogicalOptimizer(util.getConfiguration(), catalog);
     optimizer.optimize(plan);
 
-    Map<BinaryEval, Boolean> scanMap = TUtil.newHashMap();
+    Map<BinaryEval, Boolean> scanMap = new HashMap<>();
     TextDatum[] datums = new TextDatum[3];
     datums[0] = new TextDatum("ARGENTINA");
     datums[1] = new TextDatum("ETHIOPIA");
@@ -654,7 +654,7 @@ public class TestLogicalPlanner {
     );
     scanMap.put(scanQual, Boolean.FALSE);
 
-    Map<BinaryEval, Boolean> joinQualMap = TUtil.newHashMap();
+    Map<BinaryEval, Boolean> joinQualMap = new HashMap<>();
     BinaryEval joinQual = new BinaryEval(EvalType.GTH
         , new FieldEval(new Column("default.t.n_nationkey", Type.INT4))
         , new FieldEval(new Column("default.s.s_suppkey", Type.INT4))

--- a/tajo-core-tests/src/test/java/org/apache/tajo/master/TestRepartitioner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/master/TestRepartitioner.java
@@ -443,7 +443,7 @@ public class TestRepartitioner {
     assertEquals(32, fetches.size());
 
     int expectedSize = 0;
-    Set<FetchImpl> fetchSet = TUtil.newHashSet();
+    Set<FetchImpl> fetchSet = new HashSet<>();
     for(List<FetchImpl> list : fetches){
       expectedSize += list.size();
       fetchSet.addAll(list);

--- a/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/RestTestUtils.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/RestTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.tajo.ws.rs.resources;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -41,12 +42,11 @@ import org.apache.tajo.plan.function.GeneralFunction;
 import org.apache.tajo.plan.logical.LogicalNode;
 import org.apache.tajo.plan.serder.EvalNodeAdapter;
 import org.apache.tajo.plan.serder.LogicalNodeAdapter;
-import org.apache.tajo.util.TUtil;
 
 public class RestTestUtils {
   
   public static Map<Type, GsonSerDerAdapter<?>> registerTypeAdapterMap() {
-    Map<Type, GsonSerDerAdapter<?>> adapters = TUtil.newHashMap();
+    Map<Type, GsonSerDerAdapter<?>> adapters = new HashMap<>();
     adapters.put(Path.class, new PathSerializer());
     adapters.put(Class.class, new ClassNameSerializer());
     adapters.put(LogicalNode.class, new LogicalNodeAdapter());

--- a/tajo-core/src/main/java/org/apache/tajo/engine/json/CoreGsonHelper.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/json/CoreGsonHelper.java
@@ -34,9 +34,9 @@ import org.apache.tajo.plan.logical.LogicalNode;
 import org.apache.tajo.function.Function;
 import org.apache.tajo.plan.serder.EvalNodeAdapter;
 import org.apache.tajo.plan.serder.LogicalNodeAdapter;
-import org.apache.tajo.util.TUtil;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -48,7 +48,7 @@ public class CoreGsonHelper {
   }
 	
 	private static Map<Type, GsonSerDerAdapter> registerAdapters() {
-    Map<Type, GsonSerDerAdapter> adapters = TUtil.newHashMap();
+    Map<Type, GsonSerDerAdapter> adapters = new HashMap<>();
     adapters.put(Path.class, new PathSerializer());
     adapters.put(Class.class, new ClassNameSerializer());
     adapters.put(LogicalNode.class, new LogicalNodeAdapter());

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/enforce/Enforcer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/enforce/Enforcer.java
@@ -24,6 +24,7 @@ import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +40,7 @@ public class Enforcer implements ProtoObject<EnforcerProto> {
 
   @SuppressWarnings("unused")
   public Enforcer() {
-    properties = TUtil.newHashMap();
+    properties = new HashMap<>();
   }
 
   public Enforcer(EnforcerProto proto) {
@@ -52,7 +53,7 @@ public class Enforcer implements ProtoObject<EnforcerProto> {
 
   private void initProperties() {
     if (properties == null) {
-      properties = TUtil.newHashMap();
+      properties = new HashMap<>();
       for (EnforceProperty property : proto.getPropertiesList()) {
         TUtil.putToNestedList(properties, property.getType(), property);
       }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/ExecutionBlock.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/ExecutionBlock.java
@@ -17,7 +17,6 @@ package org.apache.tajo.engine.planner.global;
 import org.apache.tajo.ExecutionBlockId;
 import org.apache.tajo.engine.planner.enforce.Enforcer;
 import org.apache.tajo.plan.logical.*;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 
@@ -42,7 +41,7 @@ public class ExecutionBlock {
   private boolean hasUnionPlan;
   private boolean isUnionOnly;
 
-  private Map<String, ScanNode> broadcastRelations = TUtil.newHashMap();
+  private Map<String, ScanNode> broadcastRelations = new HashMap<>();
 
   /*
    * An execution block is null-supplying or preserved-row when its output is used as an input for outer join.

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
@@ -157,7 +157,7 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
     private final long thresholdForCrossJoin;
     private final boolean broadcastForNonCrossJoinEnabled;
     private final GlobalPlanRewriteUtil.ParentFinder parentFinder;
-    private final Map<ExecutionBlockId, Long> estimatedEbOutputSize = TUtil.newHashMap();
+    private final Map<ExecutionBlockId, Long> estimatedEbOutputSize = new HashMap<>();
 
     public BroadcastJoinPlanBuilder(MasterPlan plan, RelationSizeComparator relationSizeComparator,
                                     GlobalPlanRewriteUtil.ParentFinder parentFinder,

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BSTIndexScanExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/BSTIndexScanExec.java
@@ -36,7 +36,6 @@ import org.apache.tajo.plan.logical.ScanNode;
 import org.apache.tajo.plan.rewrite.rules.IndexScanInfo.SimplePredicate;
 import org.apache.tajo.storage.*;
 import org.apache.tajo.storage.index.bst.BSTIndex;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
@@ -95,7 +94,7 @@ public class BSTIndexScanExec extends ScanExec {
 
   private static Schema mergeSubSchemas(Schema originalSchema, Schema subSchema, Target[] targets, EvalNode qual) {
     Schema mergedSchema = new Schema();
-    Set<Column> qualAndTargets = TUtil.newHashSet();
+    Set<Column> qualAndTargets = new HashSet<>();
     qualAndTargets.addAll(EvalTreeUtil.findUniqueColumns(qual));
     for (Target target : targets) {
       qualAndTargets.addAll(EvalTreeUtil.findUniqueColumns(target.getEvalTree()));

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyFirstAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyFirstAggregationExec.java
@@ -31,7 +31,6 @@ import org.apache.tajo.plan.logical.GroupbyNode;
 import org.apache.tajo.storage.NullTuple;
 import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.storage.VTuple;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
@@ -97,10 +96,10 @@ public class DistinctGroupbyFirstAggregationExec extends UnaryPhysicalExec {
   private int fetchedRows;
 
   private NonDistinctHashAggregator nonDistinctHashAggregator;
-  private Map<Integer, DistinctHashAggregator> nodeSeqToDistinctAggregators = TUtil.newHashMap();
+  private Map<Integer, DistinctHashAggregator> nodeSeqToDistinctAggregators = new HashMap<>();
 
   private KeyProjector nonDistinctGroupingKeyProjector;
-  private Map<Integer, KeyProjector> distinctGroupbyKeyProjectors = TUtil.newHashMap();
+  private Map<Integer, KeyProjector> distinctGroupbyKeyProjectors = new HashMap<>();
 
   private int resultTupleLength;
 
@@ -316,7 +315,7 @@ public class DistinctGroupbyFirstAggregationExec extends UnaryPhysicalExec {
 
     public DistinctHashAggregator(GroupbyNode groupbyNode, int nodeSequence) throws IOException {
 
-      Set<Column> groupingKeySet = TUtil.newHashSet(plan.getGroupingColumns());
+      Set<Column> groupingKeySet = new HashSet<>(Arrays.asList(plan.getGroupingColumns()));
 
       List<Column> distinctGroupingKeyIndexSet = new ArrayList<>();
       Column[] groupingColumns = groupbyNode.getGroupingColumns();

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
@@ -329,7 +329,7 @@ public class Query implements EventHandler<QueryEvent> {
   }
 
   public List<PartitionDescProto> getPartitions() {
-    Set<PartitionDescProto> partitions = TUtil.newHashSet();
+    Set<PartitionDescProto> partitions = new HashSet<>();
     for(Stage eachStage : getStages()) {
       partitions.addAll(eachStage.getPartitions());
     }

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Stage.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Stage.java
@@ -63,7 +63,6 @@ import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.unit.StorageUnit;
 import org.apache.tajo.util.KeyValueSet;
 import org.apache.tajo.util.RpcParameterFactory;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.history.StageHistory;
 import org.apache.tajo.util.history.TaskHistory;
 import org.apache.tajo.worker.FetchImpl;
@@ -501,7 +500,7 @@ public class Stage implements EventHandler<StageEvent> {
   }
 
   public Set<PartitionDescProto> getPartitions() {
-    Set<PartitionDescProto> partitions = TUtil.newHashSet();
+    Set<PartitionDescProto> partitions = new HashSet<>();
     for(Task eachTask : getTasks()) {
       if (eachTask.getLastAttempt() != null && !eachTask.getLastAttempt().getPartitions().isEmpty()) {
         partitions.addAll(eachTask.getLastAttempt().getPartitions());

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/TaskAttempt.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/TaskAttempt.java
@@ -36,7 +36,6 @@ import org.apache.tajo.master.event.TaskAttemptToSchedulerEvent.TaskAttemptSched
 import org.apache.tajo.master.event.TaskSchedulerEvent.EventType;
 import org.apache.tajo.querymaster.Task.IntermediateEntry;
 import org.apache.tajo.querymaster.Task.PullHost;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 import java.util.concurrent.locks.Lock;
@@ -192,7 +191,7 @@ public class TaskAttempt implements EventHandler<TaskAttemptEvent> {
     this.writeLock = readWriteLock.writeLock();
 
     stateMachine = stateMachineFactory.make(this);
-    this.partitions = TUtil.newHashSet();
+    this.partitions = new HashSet<>();
   }
 
   public TaskAttemptState getState() {

--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/TajoRestService.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/TajoRestService.java
@@ -43,7 +43,6 @@ import org.apache.tajo.plan.function.GeneralFunction;
 import org.apache.tajo.plan.logical.LogicalNode;
 import org.apache.tajo.plan.serder.EvalNodeAdapter;
 import org.apache.tajo.plan.serder.LogicalNodeAdapter;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.ws.rs.netty.NettyRestServer;
 import org.apache.tajo.ws.rs.netty.NettyRestServerFactory;
 import org.apache.tajo.ws.rs.netty.gson.GsonFeature;
@@ -54,6 +53,7 @@ import org.glassfish.jersey.server.ServerProperties;
 import java.lang.reflect.Type;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -71,7 +71,7 @@ public class TajoRestService extends CompositeService {
   }
   
   private Map<Type, GsonSerDerAdapter<?>> registerTypeAdapterMap() {
-    Map<Type, GsonSerDerAdapter<?>> adapters = TUtil.newHashMap();
+    Map<Type, GsonSerDerAdapter<?>> adapters = new HashMap<>();
     adapters.put(Path.class, new PathSerializer());
     adapters.put(Class.class, new ClassNameSerializer());
     adapters.put(LogicalNode.class, new LogicalNodeAdapter());

--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/responses/NewSessionResponse.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/responses/NewSessionResponse.java
@@ -20,8 +20,8 @@ package org.apache.tajo.ws.rs.responses;
 
 import com.google.gson.annotations.Expose;
 import org.apache.tajo.error.Errors.ResultCode;
-import org.apache.tajo.util.TUtil;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class NewSessionResponse {
@@ -57,7 +57,7 @@ public class NewSessionResponse {
 
   public Map<String, String> getVariables() {
     if (variables == null) {
-      variables = TUtil.newHashMap();
+      variables = new HashMap<>();
     }
     return variables;
   }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalOptimizer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalOptimizer.java
@@ -170,8 +170,8 @@ public class LogicalOptimizer {
       LogicalNode topParent = PlannerUtil.findTopParentNode(block.getRoot(), NodeType.JOIN);
       if (topParent.getType() == NodeType.SELECTION) {
         SelectionNode topParentSelect = (SelectionNode) topParent;
-        Set<EvalNode> filters = TUtil.newHashSet();
-        filters.addAll(TUtil.newHashSet(AlgebraicUtil.toConjunctiveNormalFormArray(topParentSelect.getQual())));
+        Set<EvalNode> filters = new HashSet<>();
+        filters.addAll(new HashSet<>(Arrays.asList(AlgebraicUtil.toConjunctiveNormalFormArray(topParentSelect.getQual()))));
         filters.addAll(remainingQuals);
         topParentSelect.setQual(AlgebraicUtil.createSingletonExprFromCNF(
             filters.toArray(new EvalNode[filters.size()])));
@@ -304,7 +304,7 @@ public class LogicalOptimizer {
         JoinEdge edge = context.getJoinGraph().addJoin(context, joinNode.getJoinSpec(), leftVertex, rightVertex);
 
         // find all possible predicates for this join edge
-        Set<EvalNode> joinConditions = TUtil.newHashSet();
+        Set<EvalNode> joinConditions = new HashSet<>();
         if (joinNode.hasJoinQual()) {
           Set<EvalNode> originPredicates = joinNode.getJoinSpec().getPredicates();
           for (EvalNode predicate : joinNode.getJoinSpec().getPredicates()) {
@@ -483,7 +483,7 @@ public class LogicalOptimizer {
   }
 
   private static class RelationNodeFinderContext {
-    private Set<RelationNode> founds = TUtil.newHashSet();
+    private Set<RelationNode> founds = new HashSet<>();
     private boolean findMostLeft;
     private boolean findMostRight;
   }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlan.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlan.java
@@ -67,7 +67,7 @@ public class LogicalPlan {
   private Map<String, QueryBlock> queryBlocks = new LinkedHashMap<>();
   private Map<Integer, LogicalNode> nodeMap = new HashMap<>();
   private Map<Integer, QueryBlock> queryBlockByPID = new HashMap<>();
-  private Map<String, String> exprToBlockNameMap = TUtil.newHashMap();
+  private Map<String, String> exprToBlockNameMap = new HashMap<>();
   private SimpleDirectedGraph<String, BlockEdge> queryBlockGraph = new SimpleDirectedGraph<>();
 
   /** planning and optimization log */
@@ -427,12 +427,12 @@ public class LogicalPlan {
     private NodeType rootType;
 
     // transient states
-    private final Map<String, RelationNode> canonicalNameToRelationMap = TUtil.newHashMap();
-    private final Map<String, List<String>> relationAliasMap = TUtil.newHashMap();
-    private final Map<String, String> columnAliasMap = TUtil.newHashMap();
-    private final Map<OpType, List<Expr>> operatorToExprMap = TUtil.newHashMap();
+    private final Map<String, RelationNode> canonicalNameToRelationMap = new HashMap<>();
+    private final Map<String, List<String>> relationAliasMap = new HashMap<>();
+    private final Map<String, String> columnAliasMap = new HashMap<>();
+    private final Map<OpType, List<Expr>> operatorToExprMap = new HashMap<>();
     private final List<RelationNode> relationList = TUtil.newList();
-    private final Map<Integer, List<AccessPathInfo>> relNodePidAccessPathMap = TUtil.newHashMap();
+    private final Map<Integer, List<AccessPathInfo>> relNodePidAccessPathMap = new HashMap<>();
     private boolean hasWindowFunction = false;
     private final Map<String, ConstEval> constantPoolByRef = Maps.newHashMap();
     private final Map<Expr, String> constantPool = Maps.newHashMap();
@@ -440,13 +440,13 @@ public class LogicalPlan {
     /**
      * It's a map between nodetype and node. node types can be duplicated. So, latest node type is only kept.
      */
-    private final Map<NodeType, LogicalNode> nodeTypeToNodeMap = TUtil.newHashMap();
-    private final Map<String, LogicalNode> exprToNodeMap = TUtil.newHashMap();
+    private final Map<NodeType, LogicalNode> nodeTypeToNodeMap = new HashMap<>();
+    private final Map<String, LogicalNode> exprToNodeMap = new HashMap<>();
     final NamedExprsManager namedExprsMgr;
 
     private LogicalNode currentNode;
     private LogicalNode latestNode;
-    private final Set<JoinType> includedJoinTypes = TUtil.newHashSet();
+    private final Set<JoinType> includedJoinTypes = new HashSet<>();
     /**
      * Set true value if this query block has either implicit or explicit aggregation.
      */

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
@@ -1443,7 +1443,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
   private void setTargetOfTableSubQuery (PlanContext context, QueryBlock block, TableSubQueryNode subQueryNode)
       throws TajoException {
     // Add additional expressions required in upper nodes.
-    Set<String> newlyEvaluatedExprs = TUtil.newHashSet();
+    Set<String> newlyEvaluatedExprs = new HashSet<>();
     for (NamedExpr rawTarget : block.namedExprsMgr.getAllNamedExprs()) {
       try {
         EvalNode evalNode = exprAnnotator.createEvalNode(context, rawTarget.getExpr(),

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalContext.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalContext.java
@@ -19,13 +19,13 @@
 package org.apache.tajo.plan.expr;
 
 import org.apache.tajo.plan.function.python.TajoScriptEngine;
-import org.apache.tajo.util.TUtil;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 public class EvalContext {
-  private final Map<EvalNode, TajoScriptEngine> scriptEngineMap = TUtil.newHashMap();
+  private final Map<EvalNode, TajoScriptEngine> scriptEngineMap = new HashMap<>();
 
   public void addScriptEngine(EvalNode evalNode, TajoScriptEngine scriptExecutor) {
     this.scriptEngineMap.put(evalNode, scriptExecutor);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/InEval.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/InEval.java
@@ -26,8 +26,9 @@ import org.apache.tajo.datum.Datum;
 import org.apache.tajo.datum.DatumFactory;
 import org.apache.tajo.datum.NullDatum;
 import org.apache.tajo.storage.Tuple;
-import org.apache.tajo.util.TUtil;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 public class InEval extends BinaryEval {
@@ -61,7 +62,7 @@ public class InEval extends BinaryEval {
       throw new IllegalStateException("bind() must be called before eval()");
     }
     if (values == null) {
-      values = TUtil.newHashSet(((ValueSetEval) rightExpr).getValues());
+      values = new HashSet<>(Arrays.asList(((ValueSetEval) rightExpr).getValues()));
     }
 
     Datum leftValue = leftExpr.eval(tuple);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/python/PythonScriptEngine.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/python/PythonScriptEngine.java
@@ -45,6 +45,7 @@ import org.apache.tajo.util.TUtil;
 import java.io.*;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -72,7 +73,7 @@ public class PythonScriptEngine extends TajoScriptEngine {
   public static Set<FunctionDesc> registerFunctions(URI path, String namespace) throws IOException {
     // TODO: we should support the namespace for python functions.
 
-    Set<FunctionDesc> functionDescs = TUtil.newHashSet();
+    Set<FunctionDesc> functionDescs = new HashSet<>();
 
     InputStream in = getScriptAsStream(path);
     List<FunctionInfo> functions = null;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/GreedyHeuristicJoinOrderAlgorithm.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/GreedyHeuristicJoinOrderAlgorithm.java
@@ -27,8 +27,9 @@ import org.apache.tajo.plan.expr.AlgebraicUtil;
 import org.apache.tajo.plan.logical.*;
 import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.util.StringUtils;
-import org.apache.tajo.util.TUtil;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -45,7 +46,7 @@ public class GreedyHeuristicJoinOrderAlgorithm implements JoinOrderAlgorithm {
   public FoundJoinOrder findBestOrder(LogicalPlan plan, LogicalPlan.QueryBlock block, JoinGraphContext graphContext)
       throws TajoException {
 
-    Set<JoinVertex> vertexes = TUtil.newHashSet();
+    Set<JoinVertex> vertexes = new HashSet<>();
     for (RelationNode relationNode : block.getRelations()) {
       vertexes.add(new RelationVertex(relationNode));
     }
@@ -75,8 +76,8 @@ public class GreedyHeuristicJoinOrderAlgorithm implements JoinOrderAlgorithm {
       //
       // The chosen best pair will be regarded as a join vertex again.
       // So, the join edges which share any vertexes with the best pair should be updated, too.
-      Set<JoinEdge> willBeRemoved = TUtil.newHashSet();
-      Set<JoinEdge> willBeAdded = TUtil.newHashSet();
+      Set<JoinEdge> willBeRemoved = new HashSet<>();
+      Set<JoinEdge> willBeAdded = new HashSet<>();
 
       // Find every join edges which should be updated.
       prepareGraphUpdate(graphContext, joinGraph, bestPair, newVertex, willBeAdded, willBeRemoved);
@@ -252,7 +253,7 @@ public class GreedyHeuristicJoinOrderAlgorithm implements JoinOrderAlgorithm {
   }
 
   private static class JoinEdgeFinderContext {
-    private Set<JoinVertex> visited = TUtil.newHashSet();
+    private Set<JoinVertex> visited = new HashSet<>();
 
     public void reset() {
       visited.clear();
@@ -297,7 +298,7 @@ public class GreedyHeuristicJoinOrderAlgorithm implements JoinOrderAlgorithm {
             interchangeableWithRightVertex = JoinOrderingUtil.getAllInterchangeableVertexes(graphContext,
                 edgeFromLeftTarget.getRightVertex());
           } else {
-            interchangeableWithRightVertex = TUtil.newHashSet(edgeFromLeftTarget.getRightVertex());
+            interchangeableWithRightVertex = new HashSet<>(Arrays.asList(edgeFromLeftTarget.getRightVertex()));
           }
 
           if (interchangeableWithRightVertex.contains(rightTarget)) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinGraphContext.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinGraphContext.java
@@ -22,13 +22,13 @@ import org.apache.commons.collections.map.LRUMap;
 import org.apache.tajo.plan.expr.EvalNode;
 import org.apache.tajo.plan.logical.JoinSpec;
 import org.apache.tajo.util.Pair;
-import org.apache.tajo.util.TUtil;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 public class JoinGraphContext {
-  private Set<JoinVertex> rootVertexes = TUtil.newHashSet(); // most left vertex in the join plan
+  private Set<JoinVertex> rootVertexes = new HashSet<>(); // most left vertex in the join plan
   private JoinGraph joinGraph = new JoinGraph();
 
   // New join edges are frequently created during join order optimization.
@@ -37,10 +37,10 @@ public class JoinGraphContext {
 
   // candidate predicates contain the predicates which are not pushed to any join nodes yet.
   // evaluated predicates contain the predicates which are already pushed to some join nodes.
-  private Set<EvalNode> candidateJoinConditions = TUtil.newHashSet(); // predicates from the on clause
-  private Set<EvalNode> candidateJoinFilters = TUtil.newHashSet();    // predicates from the where clause
-  private Set<EvalNode> evaluatedJoinConditions = TUtil.newHashSet(); // predicates from the on clause
-  private Set<EvalNode> evaluatedJoinFilters = TUtil.newHashSet();    // predicates from the where clause
+  private Set<EvalNode> candidateJoinConditions = new HashSet<>(); // predicates from the on clause
+  private Set<EvalNode> candidateJoinFilters = new HashSet<>();    // predicates from the where clause
+  private Set<EvalNode> evaluatedJoinConditions = new HashSet<>(); // predicates from the on clause
+  private Set<EvalNode> evaluatedJoinFilters = new HashSet<>();    // predicates from the where clause
 
   public JoinGraph getJoinGraph() {
     return joinGraph;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinOrderingUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinOrderingUtil.java
@@ -24,8 +24,8 @@ import org.apache.tajo.plan.expr.EvalNode;
 import org.apache.tajo.plan.expr.EvalTreeUtil;
 import org.apache.tajo.plan.expr.EvalType;
 import org.apache.tajo.plan.util.PlannerUtil;
-import org.apache.tajo.util.TUtil;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -42,7 +42,7 @@ public class JoinOrderingUtil {
    */
   public static Set<EvalNode> findJoinConditionForJoinVertex(Set<EvalNode> candidates, JoinEdge edge,
                                                              boolean isOnPredicates) {
-    Set<EvalNode> conditionsForThisJoin = TUtil.newHashSet();
+    Set<EvalNode> conditionsForThisJoin = new HashSet<>();
     for (EvalNode predicate : candidates) {
       if (EvalTreeUtil.isJoinQual(predicate, false)
           && checkIfEvaluatedAtEdge(predicate, edge, isOnPredicates)) {
@@ -205,14 +205,14 @@ public class JoinOrderingUtil {
    * @return
    */
   public static Set<JoinVertex> getAllInterchangeableVertexes(JoinGraphContext context, JoinVertex from) {
-    Set<JoinVertex> founds = TUtil.newHashSet();
+    Set<JoinVertex> founds = new HashSet<>();
     getAllInterchangeableVertexes(founds, context, from);
     return founds;
   }
 
   public static void getAllInterchangeableVertexes(Set<JoinVertex> founds, JoinGraphContext context, JoinVertex vertex) {
     founds.add(vertex);
-    Set<JoinVertex> foundAtThis = TUtil.newHashSet();
+    Set<JoinVertex> foundAtThis = new HashSet<>();
     List<JoinEdge> candidateEdges = context.getJoinGraph().getOutgoingEdges(vertex);
     if (candidateEdges != null) {
       for (JoinEdge candidateEdge : candidateEdges) {
@@ -304,7 +304,7 @@ public class JoinOrderingUtil {
    * @return
    */
   public static Set<JoinEdge> getAllAssociativeEdges(JoinGraphContext context, JoinEdge edge) {
-    Set<JoinEdge> associativeEdges = TUtil.newHashSet();
+    Set<JoinEdge> associativeEdges = new HashSet<>();
     JoinVertex start = edge.getRightVertex();
     List<JoinEdge> candidateEdges = context.getJoinGraph().getOutgoingEdges(start);
     if (candidateEdges != null) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinedRelationsVertex.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/JoinedRelationsVertex.java
@@ -25,8 +25,8 @@ import org.apache.tajo.plan.logical.JoinNode;
 import org.apache.tajo.plan.logical.LogicalNode;
 import org.apache.tajo.plan.logical.RelationNode;
 import org.apache.tajo.plan.util.PlannerUtil;
-import org.apache.tajo.util.TUtil;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -34,7 +34,7 @@ import java.util.Set;
  */
 public class JoinedRelationsVertex implements JoinVertex {
 
-  private final Set<RelationVertex> relations = TUtil.newHashSet();
+  private final Set<RelationVertex> relations = new HashSet<>();
   private final JoinEdge joinEdge;
 
   public JoinedRelationsVertex(JoinEdge joinEdge) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/RelationVertex.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/joinorder/RelationVertex.java
@@ -22,8 +22,9 @@ import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.plan.LogicalPlan;
 import org.apache.tajo.plan.logical.LogicalNode;
 import org.apache.tajo.plan.logical.RelationNode;
-import org.apache.tajo.util.TUtil;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 public class RelationVertex implements JoinVertex{
@@ -62,7 +63,7 @@ public RelationVertex(RelationNode relationNode) {
 
   @Override
   public Set<RelationVertex> getRelations() {
-    return TUtil.newHashSet(this);
+    return new HashSet<>(Arrays.asList(this));
   }
 
   @Override

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/JoinSpec.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/JoinSpec.java
@@ -22,11 +22,8 @@ import com.google.common.base.Objects;
 import org.apache.tajo.algebra.JoinType;
 import org.apache.tajo.plan.expr.AlgebraicUtil;
 import org.apache.tajo.plan.expr.EvalNode;
-import org.apache.tajo.util.TUtil;
 
-import java.util.Comparator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 public class JoinSpec implements Cloneable {
 
@@ -84,7 +81,7 @@ public class JoinSpec implements Cloneable {
   }
 
   public void setSingletonPredicate(EvalNode predicates) {
-    this.setPredicates(TUtil.newHashSet(AlgebraicUtil.toConjunctiveNormalFormArray(predicates)));
+    this.setPredicates(new HashSet<>(Arrays.asList(AlgebraicUtil.toConjunctiveNormalFormArray(predicates))));
   }
 
   public EvalNode getSingletonPredicate() {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/NameResolver.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/NameResolver.java
@@ -35,10 +35,7 @@ import org.apache.tajo.util.Pair;
 import org.apache.tajo.util.StringUtils;
 import org.apache.tajo.util.TUtil;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Column name resolution utility. A SQL statement can include many kinds of column names,
@@ -129,7 +126,7 @@ public abstract class NameResolver {
    */
   public static Collection<RelationNode> lookupTableByColumns(LogicalPlan.QueryBlock block, String columnName) {
 
-    Set<RelationNode> found = TUtil.newHashSet();
+    Set<RelationNode> found = new HashSet<>();
 
     for (RelationNode rel : block.getRelations()) {
       if (rel.getLogicalSchema().contains(columnName)) {
@@ -373,7 +370,7 @@ public abstract class NameResolver {
     // - tbname.column_name.nested_field...
     // - column.nested_fieldX...
 
-    Set<RelationNode> guessedRelations = TUtil.newHashSet();
+    Set<RelationNode> guessedRelations = new HashSet<>();
 
     // this position indicates the index of column name in qualifierParts;
     // It must be 0 or more because a qualified column is always passed to lookupQualifierAndCanonicalName().

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/CommonConditionReduceRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/CommonConditionReduceRule.java
@@ -28,8 +28,9 @@ import org.apache.tajo.plan.logical.SelectionNode;
 import org.apache.tajo.plan.rewrite.LogicalPlanRewriteRule;
 import org.apache.tajo.plan.rewrite.LogicalPlanRewriteRuleContext;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
-import org.apache.tajo.util.TUtil;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
 
@@ -172,13 +173,13 @@ public class CommonConditionReduceRule implements LogicalPlanRewriteRule {
         EvalType innerType = leftChild.getType();
 
         // Find common quals from the left and right children.
-        Set<EvalNode> commonQuals = TUtil.newHashSet();
+        Set<EvalNode> commonQuals = new HashSet<>();
         Set<EvalNode> leftChildSplits = innerType == EvalType.AND ?
-            TUtil.newHashSet(AlgebraicUtil.toConjunctiveNormalFormArray(leftChild)) :
-            TUtil.newHashSet(AlgebraicUtil.toDisjunctiveNormalFormArray(leftChild));
+            new HashSet<>(Arrays.asList(AlgebraicUtil.toConjunctiveNormalFormArray(leftChild))) :
+            new HashSet<>(Arrays.asList(AlgebraicUtil.toDisjunctiveNormalFormArray(leftChild)));
         Set<EvalNode> rightChildSplits = innerType == EvalType.AND ?
-            TUtil.newHashSet(AlgebraicUtil.toConjunctiveNormalFormArray(rightChild)) :
-            TUtil.newHashSet(AlgebraicUtil.toDisjunctiveNormalFormArray(rightChild));
+            new HashSet<>(Arrays.asList(AlgebraicUtil.toConjunctiveNormalFormArray(rightChild))) :
+            new HashSet<>(Arrays.asList(AlgebraicUtil.toDisjunctiveNormalFormArray(rightChild)));
 
         for (EvalNode eachLeftChildSplit : leftChildSplits) {
           if (rightChildSplits.contains(eachLeftChildSplit)) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/InSubqueryRewriteRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/InSubqueryRewriteRule.java
@@ -34,9 +34,7 @@ import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
 import org.apache.tajo.util.TUtil;
 
-import java.util.List;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 
 /**
  * InSubqueryRewriteRule finds all subqueries occurring in the where clause with "IN" keywords,
@@ -144,7 +142,7 @@ public class InSubqueryRewriteRule implements LogicalPlanRewriteRule {
       EvalNode[] originDnfs = AlgebraicUtil.toDisjunctiveNormalFormArray(node.getQual());
       List<EvalNode> rewrittenDnfs = TUtil.newList();
       for (EvalNode eachDnf : originDnfs) {
-        Set<EvalNode> cnfs = TUtil.newHashSet(AlgebraicUtil.toConjunctiveNormalFormArray(eachDnf));
+        Set<EvalNode> cnfs = new HashSet<>(Arrays.asList(AlgebraicUtil.toConjunctiveNormalFormArray(eachDnf)));
         cnfs.removeAll(inSubqueries);
         if (!cnfs.isEmpty()) {
           rewrittenDnfs.add(AlgebraicUtil.createSingletonExprFromCNF(cnfs));

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/serder/PlanGsonHelper.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/serder/PlanGsonHelper.java
@@ -32,9 +32,9 @@ import org.apache.tajo.plan.expr.EvalNode;
 import org.apache.tajo.plan.function.AggFunction;
 import org.apache.tajo.plan.function.GeneralFunction;
 import org.apache.tajo.plan.logical.LogicalNode;
-import org.apache.tajo.util.TUtil;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -46,7 +46,7 @@ public class PlanGsonHelper {
   }
 	
 	private static Map<Type, GsonSerDerAdapter> registerAdapters() {
-    Map<Type, GsonSerDerAdapter> adapters = TUtil.newHashMap();
+    Map<Type, GsonSerDerAdapter> adapters = new HashMap<>();
     adapters.put(Path.class, new PathSerializer());
     adapters.put(Class.class, new ClassNameSerializer());
     adapters.put(LogicalNode.class, new LogicalNodeAdapter());

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/PreLogicalPlanVerifier.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/PreLogicalPlanVerifier.java
@@ -30,10 +30,10 @@ import org.apache.tajo.catalog.TableDesc;
 import org.apache.tajo.exception.*;
 import org.apache.tajo.plan.algebra.BaseAlgebraVisitor;
 import org.apache.tajo.plan.util.ExprFinder;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.validation.ConstraintViolation;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
 
@@ -84,7 +84,7 @@ public class PreLogicalPlanVerifier extends BaseAlgebraVisitor<PreLogicalPlanVer
   public Expr visitProjection(Context context, Stack<Expr> stack, Projection expr) throws TajoException {
     super.visitProjection(context, stack, expr);
 
-    Set<String> names = TUtil.newHashSet();
+    Set<String> names = new HashSet<>();
 
     for (NamedExpr namedExpr : expr.getNamedExprs()) {
 

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/FileTablespace.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/FileTablespace.java
@@ -43,7 +43,6 @@ import org.apache.tajo.plan.logical.NodeType;
 import org.apache.tajo.storage.fragment.FileFragment;
 import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.util.Bytes;
-import org.apache.tajo.util.TUtil;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -834,10 +833,10 @@ public class FileTablespace extends Tablespace {
             && (!overwriteEnabled || (overwriteEnabled && summary.getFileCount() > 0L))) {
             // This is a map for existing non-leaf directory to rename. A key is current directory and a value is
             // renaming directory.
-            Map<Path, Path> renameDirs = TUtil.newHashMap();
+            Map<Path, Path> renameDirs = new HashMap<>();
             // This is a map for recovering existing partition directory. A key is current directory and a value is
             // temporary directory to back up.
-            Map<Path, Path> recoveryDirs = TUtil.newHashMap();
+            Map<Path, Path> recoveryDirs = new HashMap<>();
 
             try {
               if (!fs.exists(finalOutputDir)) {


### PR DESCRIPTION
See the title. We introduced Java 7. We don't need TUtil.newHash(Set|Map) utility methods anymore. We need to eliminate them.
This commit pass all the test with mvn clean install.