### PR TITLE
TAJO-1578: User configuration for pull server port is ignored.

### DIFF
--- a/tajo-pullserver/src/main/java/org/apache/tajo/pullserver/TajoPullServerService.java
+++ b/tajo-pullserver/src/main/java/org/apache/tajo/pullserver/TajoPullServerService.java
@@ -195,7 +195,7 @@ public class TajoPullServerService extends AbstractService {
       localFS = new LocalFileSystem();
 
       conf.setInt(TajoConf.ConfVars.PULLSERVER_PORT.varname
-              , conf.getInt(TajoConf.ConfVars.PULLSERVER_PORT.varname, TajoConf.ConfVars.PULLSERVER_PORT.defaultIntVal));
+          , conf.getInt(TajoConf.ConfVars.PULLSERVER_PORT.varname, TajoConf.ConfVars.PULLSERVER_PORT.defaultIntVal));
       super.init(conf);
       LOG.info("Tajo PullServer initialized: readaheadLength=" + readaheadLength);
     } catch (Throwable t) {

--- a/tajo-pullserver/src/main/java/org/apache/tajo/pullserver/TajoPullServerService.java
+++ b/tajo-pullserver/src/main/java/org/apache/tajo/pullserver/TajoPullServerService.java
@@ -195,7 +195,7 @@ public class TajoPullServerService extends AbstractService {
       localFS = new LocalFileSystem();
 
       conf.setInt(TajoConf.ConfVars.PULLSERVER_PORT.varname
-          , TajoConf.ConfVars.PULLSERVER_PORT.defaultIntVal);
+              , conf.getInt(TajoConf.ConfVars.PULLSERVER_PORT.varname, TajoConf.ConfVars.PULLSERVER_PORT.defaultIntVal));
       super.init(conf);
       LOG.info("Tajo PullServer initialized: readaheadLength=" + readaheadLength);
     } catch (Throwable t) {


### PR DESCRIPTION
When TajoPullServerService is initialized, it overwrites user-configured pull server port with the default value.