### PR TITLE
TAJO-1933: When a simple query executed on partitioned tables, the number of result rows is always the number of rows of the whole table

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/TajoCli.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/TajoCli.java
@@ -50,7 +50,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
 
-public class TajoCli {
+public class TajoCli implements Closeable {
   public static final int SHUTDOWN_HOOK_PRIORITY = 50;
   public static final String ERROR_PREFIX = "ERROR: ";
   public static final String KILL_PREFIX = "KILL: ";

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -18,6 +18,7 @@
 
 package org.apache.tajo.cli.tsql;
 
+import com.google.common.io.NullOutputStream;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.PosixParser;
@@ -470,6 +471,22 @@ public class TestTajoCli {
       assertOutputResult(consoleResult);
     } finally {
       cli.close();
+    }
+  }
+
+  @Test
+  public void testResultRowNumWhenSelectingOnPartitionedTable() throws Exception {
+    try (TajoCli cli2 = new TajoCli(cluster.getConfiguration(), new String[]{}, null, System.in,
+        new NullOutputStream())) {
+      cli2.executeScript("create table region_part (r_regionkey int8, r_name text) " +
+          "partition by column (r_comment text) as select * from region");
+
+      setVar(tajoCli, SessionVars.CLI_FORMATTER_CLASS, TajoCliOutputTestFormatter.class.getName());
+      tajoCli.executeScript("select r_comment from region_part where r_comment = 'hs use ironic, even requests. s'");
+      String consoleResult = new String(out.toByteArray());
+      assertOutputResult(consoleResult);
+    } finally {
+      tajoCli.executeScript("drop table region_part purge");
     }
   }
 

--- a/tajo-core-tests/src/test/resources/results/TestTajoCli/testNonForwardQueryPause.result
+++ b/tajo-core-tests/src/test/resources/results/TestTajoCli/testNonForwardQueryPause.result
@@ -3,4 +3,4 @@ l_orderkey,  l_partkey,  l_suppkey,  l_linenumber,  l_quantity,  l_extendedprice
 1,  1,  7706,  1,  17.0,  21168.23,  0.04,  0.02,  N,  O,  1996-03-13,  1996-02-12,  1996-03-22,  DELIVER IN PERSON,  TRUCK,  egular courts above the
 1,  1,  7311,  2,  36.0,  45983.16,  0.09,  0.06,  N,  O,  1996-04-12,  1996-02-28,  1996-04-20,  TAKE BACK RETURN,  MAIL,  ly final dependencies: slyly bold 
 (2 rows, continue... 'q' is quit)
-(unknown row number, , 0 B selected)
+(unknown row number, , unknown bytes selected)

--- a/tajo-core-tests/src/test/resources/results/TestTajoCli/testResultRowNumWhenSelectingOnPartitionedTable.result
+++ b/tajo-core-tests/src/test/resources/results/TestTajoCli/testResultRowNumWhenSelectingOnPartitionedTable.result
@@ -1,0 +1,4 @@
+r_comment
+-------------------------------
+hs use ironic, even requests. s
+(1 rows, , 0 B selected)

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
@@ -289,7 +289,6 @@ public class QueryExecutor {
 
     final TableDesc resultDesc = new TableDesc("", scanNode.getOutSchema(),
         new TableMeta(BuiltinStorages.DRAW, table.getMeta().getOptions()), null);
-    resultDesc.setStats(new TableStats());
 
     // push down limit
     int maxRow = Integer.MAX_VALUE;
@@ -298,17 +297,6 @@ public class QueryExecutor {
       maxRow = (int) limitNode.getFetchFirstNum();
       scanNode.setLimit(maxRow);
     }
-
-    // get the estimated number of rows
-    long estimatedRowNum;
-    if (table.getStats().getNumRows() == 0) {
-      estimatedRowNum = TajoConstants.UNKNOWN_ROW_NUMBER;
-    } else {
-      estimatedRowNum = table.getStats().getNumRows();
-    }
-    estimatedRowNum = Math.min(estimatedRowNum, maxRow);
-    resultDesc.getStats().setNumRows(estimatedRowNum);
-
 
     final QueryInfo queryInfo = context.getQueryJobManager().createNewSimpleQuery(queryContext, session, query,
         plan.getRootBlock().getRoot());


### PR DESCRIPTION
I've changed to print unknown row number and unknown bytes if the total row number is larger than that printed in a page. Otherwise, the actual row number is printed.
IMHO, this is valid because the execution of a simple query is an iterable process, so it is difficult to get the total row number of the result.