### PR TITLE
TAJO-1936: NPE when calling the query result REST api

### DIFF
--- a/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
@@ -39,6 +39,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -58,7 +59,6 @@ import static org.apache.tajo.exception.ErrorUtil.isOk;
 import static org.junit.Assert.*;
 
 public class TestQueryResultResource extends QueryTestCaseBase {
-
   private URI restServiceURI;
   private URI sessionsURI;
   private URI queriesURI;
@@ -148,6 +148,17 @@ public class TestQueryResultResource extends QueryTestCaseBase {
     assertNotNull(response.getResultset());
     assertTrue(response.getResultset().getId() != 0);
     assertNotNull(response.getResultset().getLink());
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void testGetQueryResultWithoutSessionId() throws Exception {
+    String sessionId = generateNewSessionAndGetId();
+    URI queryIdURI = sendNewQueryResquest(sessionId, "select * from lineitem");
+    URI queryResultURI = new URI(queryIdURI + "/result");
+
+    GetQueryResultDataResponse response = restClient.target(queryResultURI)
+            .request()
+            .get(new GenericType<>(GetQueryResultDataResponse.class));
   }
 
   @Test

--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResource.java
@@ -213,6 +213,12 @@ public class QueryResource {
       initializeContext();
       JerseyResourceDelegateContextKey<String> sessionIdKey =
           JerseyResourceDelegateContextKey.valueOf(sessionIdKeyName, String.class);
+
+      if (sessionId == null || sessionId.isEmpty()) {
+        return ResourcesUtil.createBadRequestResponse(LOG, "Session id is required. Please refer the header " +
+                QueryResource.tajoSessionIdHeaderName);
+      }
+
       context.put(sessionIdKey, sessionId);
       JerseyResourceDelegateContextKey<SubmitQueryRequest> submitQueryRequestKey =
           JerseyResourceDelegateContextKey.valueOf(submitQueryRequestKeyName, SubmitQueryRequest.class);

--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/QueryResultResource.java
@@ -155,6 +155,12 @@ public class QueryResultResource {
       initializeContext();
       JerseyResourceDelegateContextKey<String> sessionIdKey =
           JerseyResourceDelegateContextKey.valueOf(sessionIdKeyName, String.class);
+
+      if (sessionId == null || sessionId.isEmpty()) {
+        return ResourcesUtil.createBadRequestResponse(LOG, "Session id is required. Please refer the header " +
+                QueryResource.tajoSessionIdHeaderName);
+      }
+
       context.put(sessionIdKey, sessionId);
       
       response = JerseyResourceDelegateUtil.runJerseyResourceDelegate(
@@ -256,6 +262,12 @@ public class QueryResultResource {
       initializeContext();
       JerseyResourceDelegateContextKey<String> sessionIdKey =
           JerseyResourceDelegateContextKey.valueOf(sessionIdKeyName, String.class);
+
+      if (sessionId == null || sessionId.isEmpty()) {
+        return ResourcesUtil.createBadRequestResponse(LOG, "Session id is required. Please refer the header " +
+                QueryResource.tajoSessionIdHeaderName);
+      }
+
       context.put(sessionIdKey, sessionId);
       JerseyResourceDelegateContextKey<Long> cacheIdKey =
           JerseyResourceDelegateContextKey.valueOf(cacheIdKeyName, Long.class);

--- a/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/SessionsResource.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ws/rs/resources/SessionsResource.java
@@ -177,6 +177,12 @@ public class SessionsResource {
       initializeContext();
       JerseyResourceDelegateContextKey<String> sessionIdKey =
           JerseyResourceDelegateContextKey.valueOf(sessionIdKeyName, String.class);
+
+      if (sessionId == null || sessionId.isEmpty()) {
+        return ResourcesUtil.createBadRequestResponse(LOG, "Session id is required. Please refer the header " +
+                QueryResource.tajoSessionIdHeaderName);
+      }
+
       context.put(sessionIdKey, sessionId);
       
       response = JerseyResourceDelegateUtil.runJerseyResourceDelegate(
@@ -239,6 +245,12 @@ public class SessionsResource {
       initializeContext();
       JerseyResourceDelegateContextKey<String> sessionIdKey =
           JerseyResourceDelegateContextKey.valueOf(sessionIdKeyName, String.class);
+
+      if (sessionId == null || sessionId.isEmpty()) {
+        return ResourcesUtil.createBadRequestResponse(LOG, "Session id is required. Please refer the header " +
+                QueryResource.tajoSessionIdHeaderName);
+      }
+
       context.put(sessionIdKey, sessionId);
       
       response = JerseyResourceDelegateUtil.runJerseyResourceDelegate(
@@ -308,6 +320,12 @@ public class SessionsResource {
       initializeContext();
       JerseyResourceDelegateContextKey<String> sessionIdKey =
           JerseyResourceDelegateContextKey.valueOf(sessionIdKeyName, String.class);
+
+      if (sessionId == null || sessionId.isEmpty()) {
+        return ResourcesUtil.createBadRequestResponse(LOG, "Session id is required. Please refer the header " +
+                QueryResource.tajoSessionIdHeaderName);
+      }
+
       context.put(sessionIdKey, sessionId);
       JerseyResourceDelegateContextKey<Map> variablesMapKey =
           JerseyResourceDelegateContextKey.valueOf(variablesKeyName, Map.class);


### PR DESCRIPTION
Currently, Tajo Rest API return NPE when sessionId is null.
because of ConcurrentHashMap's put method throws when value is null.
So. I changed NPE to BadRequestExeception when session id is null.

Thanks.