### PR TITLE
TAJO-1925: Improve hive compatibility with TIMESTAMP partition column.

### DIFF
--- a/tajo-algebra/src/main/java/org/apache/tajo/algebra/TimeValue.java
+++ b/tajo-algebra/src/main/java/org/apache/tajo/algebra/TimeValue.java
@@ -56,7 +56,7 @@ public class TimeValue implements Cloneable {
   }
 
   public void setSecondsFraction(String secondsFraction) {
-    this.secondsFraction = StringUtils.rightPad(secondsFraction, 3, '0');
+    this.secondsFraction = StringUtils.leftPad(secondsFraction, 3, '0');
   }
 
   public String getSecondsFraction() {

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.tajo.BuiltinStorages;
+import org.apache.tajo.SessionVars;
 import org.apache.tajo.TajoConstants;
 import org.apache.tajo.algebra.Expr;
 import org.apache.tajo.algebra.IsNullPredicate;
@@ -974,6 +975,12 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
 
     PartitionFilterAlgebraVisitor visitor = new PartitionFilterAlgebraVisitor();
     visitor.setIsHiveCatalog(true);
+
+    if (conf.get(SessionVars.TIMEZONE.getConfVars().keyname()) != null) {
+      visitor.setTimezoneId(conf.get(SessionVars.TIMEZONE.getConfVars().keyname()));
+    } else {
+      visitor.setTimezoneId(TimeZone.getDefault().getID());
+    }
 
     Expr[] filters = AlgebraicUtil.getRearrangedCNFExpressions(databaseName + "." + tableName, partitionColumns, exprs);
 

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -25,6 +25,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.tajo.SessionVars;
 import org.apache.tajo.algebra.Expr;
 import org.apache.tajo.algebra.JsonHelper;
 import org.apache.tajo.annotation.Nullable;
@@ -2182,9 +2183,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
             case DATE:
               pstmt.setDate(currentIndex, (Date) parameter.getSecond());
               break;
-            case TIMESTAMP:
-              pstmt.setTimestamp(currentIndex, (Timestamp) parameter.getSecond());
-              break;
             case TIME:
               pstmt.setTime(currentIndex, (Time) parameter.getSecond());
               break;
@@ -2262,6 +2260,12 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
       PartitionFilterAlgebraVisitor visitor = new PartitionFilterAlgebraVisitor();
       visitor.setIsHiveCatalog(false);
+
+      if (conf.get(SessionVars.TIMEZONE.getConfVars().keyname()) != null) {
+        visitor.setTimezoneId(conf.get(SessionVars.TIMEZONE.getConfVars().keyname()));
+      } else {
+        visitor.setTimezoneId(TimeZone.getDefault().getID());
+      }
 
       Expr[] filters = AlgebraicUtil.getRearrangedCNFExpressions(tableName, partitionColumns, exprs);
 

--- a/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
@@ -19,9 +19,6 @@
 package org.apache.tajo.datum;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.common.TajoDataTypes.DataType;
 import org.apache.tajo.common.TajoDataTypes.Type;
 import org.apache.tajo.exception.InvalidValueForCastException;
@@ -38,7 +35,6 @@ import java.io.IOException;
 import java.util.TimeZone;
 
 public class DatumFactory {
-  protected static final Log LOG = LogFactory.getLog(DatumFactory.class);
 
   public static Class<? extends Datum> getDatumClass(Type type) {
     switch (type) {

--- a/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
@@ -19,6 +19,9 @@
 package org.apache.tajo.datum;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.common.TajoDataTypes.DataType;
 import org.apache.tajo.common.TajoDataTypes.Type;
 import org.apache.tajo.exception.InvalidValueForCastException;
@@ -35,6 +38,7 @@ import java.io.IOException;
 import java.util.TimeZone;
 
 public class DatumFactory {
+  protected static final Log LOG = LogFactory.getLog(DatumFactory.class);
 
   public static Class<? extends Datum> getDatumClass(Type type) {
     switch (type) {
@@ -362,6 +366,15 @@ public class DatumFactory {
         return parseTimestamp(datum.asChars(), tz);
       case TIMESTAMP:
         return (TimestampDatum) datum;
+      case INT8:
+        TimeMeta tm = new TimeMeta();
+        DateTimeUtil.toJulianTimeMeta(DateTimeUtil.javaTimeToJulianTime(datum.asInt8()), tm);
+        if (tz != null) {
+          DateTimeUtil.toUserTimezone(tm, tz);
+        } else {
+          DateTimeUtil.toUserTimezone(tm, TimeZone.getDefault());
+        }
+        return new TimestampDatum(DateTimeUtil.toJulianTimestamp(tm));
       default:
         throw new TajoRuntimeException(new InvalidValueForCastException(datum.type(), Type.TIMESTAMP));
     }

--- a/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
@@ -363,14 +363,10 @@ public class DatumFactory {
       case TIMESTAMP:
         return (TimestampDatum) datum;
       case INT8:
-        // TimestampDatum use UTC based Julian time microseconds. So this need to convert long number to julian time
-        // microseconds. And if users set their timezone, this must apply the timezone for correct query result.
         TimeMeta tm = new TimeMeta();
         DateTimeUtil.toJulianTimeMeta(DateTimeUtil.javaTimeToJulianTime(datum.asInt8()), tm);
         if (tz != null) {
-          DateTimeUtil.toUserTimezone(tm, tz);
-        } else {
-          DateTimeUtil.toUserTimezone(tm, TimeZone.getDefault());
+          DateTimeUtil.toUTCTimezone(tm, tz);
         }
         return new TimestampDatum(DateTimeUtil.toJulianTimestamp(tm));
       default:

--- a/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/DatumFactory.java
@@ -363,6 +363,8 @@ public class DatumFactory {
       case TIMESTAMP:
         return (TimestampDatum) datum;
       case INT8:
+        // TimestampDatum use UTC based Julian time microseconds. So this need to convert long number to julian time
+        // microseconds. And if users set their timezone, this must apply the timezone for correct query result.
         TimeMeta tm = new TimeMeta();
         DateTimeUtil.toJulianTimeMeta(DateTimeUtil.javaTimeToJulianTime(datum.asInt8()), tm);
         if (tz != null) {

--- a/tajo-common/src/main/java/org/apache/tajo/datum/TimestampDatum.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/TimestampDatum.java
@@ -19,6 +19,8 @@
 package org.apache.tajo.datum;
 
 import com.google.common.primitives.Longs;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.exception.InvalidOperationException;
 import org.apache.tajo.util.Bytes;
@@ -30,6 +32,7 @@ import org.apache.tajo.util.datetime.TimeMeta;
 import java.util.TimeZone;
 
 public class TimestampDatum extends Datum {
+  private static final Log LOG = LogFactory.getLog(TimestampDatum.class);
   public static final int SIZE = 8;
 
   private long timestamp;
@@ -178,6 +181,9 @@ public class TimestampDatum extends Datum {
   public Datum equalsTo(Datum datum) {
     if (datum.type() == TajoDataTypes.Type.TIME) {
       return timestamp == datum.asInt8() ? BooleanDatum.TRUE : BooleanDatum.FALSE;
+    } else if(datum.type() == TajoDataTypes.Type.TIMESTAMP) {
+      TimestampDatum another = (TimestampDatum) datum;
+      return timestamp == another.timestamp ? BooleanDatum.TRUE : BooleanDatum.FALSE;
     } else if (datum.isNull()) {
       return datum;
     } else {
@@ -198,6 +204,7 @@ public class TimestampDatum extends Datum {
     } else if (datum.isNull()) {
       return -1;
     } else {
+      LOG.info("### 2000 ### type:" + datum.type().name() + ", value:" + datum.asChars());
       throw new InvalidOperationException(datum.type());
     }
   }

--- a/tajo-common/src/main/java/org/apache/tajo/datum/TimestampDatum.java
+++ b/tajo-common/src/main/java/org/apache/tajo/datum/TimestampDatum.java
@@ -19,8 +19,6 @@
 package org.apache.tajo.datum;
 
 import com.google.common.primitives.Longs;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.exception.InvalidOperationException;
 import org.apache.tajo.util.Bytes;
@@ -32,7 +30,6 @@ import org.apache.tajo.util.datetime.TimeMeta;
 import java.util.TimeZone;
 
 public class TimestampDatum extends Datum {
-  private static final Log LOG = LogFactory.getLog(TimestampDatum.class);
   public static final int SIZE = 8;
 
   private long timestamp;
@@ -204,7 +201,6 @@ public class TimestampDatum extends Datum {
     } else if (datum.isNull()) {
       return -1;
     } else {
-      LOG.info("### 2000 ### type:" + datum.type().name() + ", value:" + datum.asChars());
       throw new InvalidOperationException(datum.type());
     }
   }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
@@ -215,7 +215,7 @@ public abstract class ColPartitionStoreExec extends UnaryPhysicalExec {
     DateTimeUtil.toUserTimezone(tm, tz);
 
     sb.append(StringUtils.escapePathName(DateTimeFormat.to_char(tm, "yyyy-MM-dd HH24:MI:SS")));
-    
+
     if (tm.fsecs == 0) {
       sb.append(".0");
     } else {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
@@ -214,7 +214,8 @@ public abstract class ColPartitionStoreExec extends UnaryPhysicalExec {
     }
     DateTimeUtil.toUserTimezone(tm, tz);
 
-    sb.append(DateTimeFormat.to_char(tm, "yyyy-MM-dd HH24:MI:SS"));
+    sb.append(StringUtils.escapePathName(DateTimeFormat.to_char(tm, "yyyy-MM-dd HH24:MI:SS")));
+    
     if (tm.fsecs == 0) {
       sb.append(".0");
     } else {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashBasedColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashBasedColPartitionStoreExec.java
@@ -68,7 +68,8 @@ public class HashBasedColPartitionStoreExec extends ColPartitionStoreExec {
       Datum datum = tuple.asDatum(keyIds[i]);
 
       if (datum.type() == TajoDataTypes.Type.TIMESTAMP) {
-        // Converts TimeMeta to formatted string for Hive compatibility.
+        // Hive automatically converts TIMESTAMP value to STRING literals which are accepted in the format YYYY-MM-DD
+        // HH:MM:SS.MS. So Tajo need to convert TimestampDatum to formatted string for Hive compatibility.
         TimestampDatum timestampDatum = (TimestampDatum) datum;
         Timestamp timestamp = new Timestamp(timestampDatum.getJavaTimestamp());
         sb.append(StringUtils.escapePathName(timestamp.toString()));

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashBasedColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashBasedColPartitionStoreExec.java
@@ -20,15 +20,19 @@ package org.apache.tajo.engine.planner.physical;
 
 import org.apache.tajo.catalog.statistics.StatisticsUtil;
 import org.apache.tajo.catalog.statistics.TableStats;
+import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.datum.Datum;
+import org.apache.tajo.datum.TimestampDatum;
 import org.apache.tajo.engine.planner.physical.ComparableVector.ComparableTuple;
 import org.apache.tajo.plan.logical.StoreTableNode;
 import org.apache.tajo.storage.Appender;
 import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.util.StringUtils;
+import org.apache.tajo.util.datetime.DateTimeFormat;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +66,15 @@ public class HashBasedColPartitionStoreExec extends ColPartitionStoreExec {
       }
       sb.append(keyNames[i]).append('=');
       Datum datum = tuple.asDatum(keyIds[i]);
-      sb.append(StringUtils.escapePathName(datum.asChars()));
+
+      if (datum.type() == TajoDataTypes.Type.TIMESTAMP) {
+        // Converts TimeMeta to formatted string for Hive compatibility.
+        TimestampDatum timestampDatum = (TimestampDatum) datum;
+        Timestamp timestamp = new Timestamp(timestampDatum.getJavaTimestamp());
+        sb.append(StringUtils.escapePathName(timestamp.toString()));
+      } else {
+        sb.append(StringUtils.escapePathName(datum.asChars()));
+      }
     }
     appender = getNextPartitionAppender(sb.toString());
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SortBasedColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SortBasedColPartitionStoreExec.java
@@ -22,14 +22,21 @@
 package org.apache.tajo.engine.planner.physical;
 
 import org.apache.tajo.catalog.statistics.StatisticsUtil;
+import org.apache.tajo.common.TajoDataTypes;
 import org.apache.tajo.datum.Datum;
+import org.apache.tajo.datum.DatumFactory;
+import org.apache.tajo.datum.TimestampDatum;
 import org.apache.tajo.engine.planner.physical.ComparableVector.ComparableTuple;
 import org.apache.tajo.plan.logical.StoreTableNode;
 import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.util.StringUtils;
+import org.apache.tajo.util.datetime.DateTimeFormat;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 /**
  * It stores a sorted data set into a number of partition files. It assumes that input tuples are sorted in an
@@ -54,7 +61,15 @@ public class SortBasedColPartitionStoreExec extends ColPartitionStoreExec {
         sb.append('/');
       }
       sb.append(keyNames[i]).append('=');
-      sb.append(StringUtils.escapePathName(datum.asChars()));
+
+      if (datum.type() == TajoDataTypes.Type.TIMESTAMP) {
+        // Converts TimeMeta to formatted string for Hive compatibility.
+        TimestampDatum timestampDatum = (TimestampDatum) datum;
+        Timestamp timestamp = new Timestamp(timestampDatum.getJavaTimestamp());
+        sb.append(StringUtils.escapePathName(timestamp.toString()));
+      } else {
+        sb.append(StringUtils.escapePathName(datum.asChars()));
+      }
     }
     return sb.toString();
   }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SortBasedColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/SortBasedColPartitionStoreExec.java
@@ -63,7 +63,8 @@ public class SortBasedColPartitionStoreExec extends ColPartitionStoreExec {
       sb.append(keyNames[i]).append('=');
 
       if (datum.type() == TajoDataTypes.Type.TIMESTAMP) {
-        // Converts TimeMeta to formatted string for Hive compatibility.
+        // Hive automatically converts TIMESTAMP value to STRING literals which are accepted in the format YYYY-MM-DD
+        // HH:MM:SS.MS. So Tajo need to convert TimestampDatum to formatted string for Hive compatibility.
         TimestampDatum timestampDatum = (TimestampDatum) datum;
         Timestamp timestamp = new Timestamp(timestampDatum.getJavaTimestamp());
         sb.append(StringUtils.escapePathName(timestamp.toString()));

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
@@ -665,7 +665,7 @@ public class DDLExecutor {
     partitionName = partitionName.substring(startIndex +  File.separator.length());
 
     CatalogProtos.PartitionDescProto.Builder builder = CatalogProtos.PartitionDescProto.newBuilder();
-    builder.setPartitionName(partitionName);
+    builder.setPartitionName(StringUtils.escapePathName(partitionName));
 
     String[] partitionKeyPairs = partitionName.split("/");
 
@@ -675,7 +675,7 @@ public class DDLExecutor {
 
       PartitionKeyProto.Builder keyBuilder = PartitionKeyProto.newBuilder();
       keyBuilder.setColumnName(split[0]);
-      keyBuilder.setPartitionValue(split[1]);
+      keyBuilder.setPartitionValue(StringUtils.unescapePathName(split[1]));
 
       builder.addPartitionKeys(keyBuilder.build());
     }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/PartitionedTableRewriter.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/PartitionedTableRewriter.java
@@ -470,6 +470,8 @@ public class PartitionedTableRewriter implements LogicalPlanRewriteRule {
       Column keyColumn = partitionColumnSchema.getColumn(columnId);
 
       if (keyColumn.getDataType().getType() == TajoDataTypes.Type.TIMESTAMP) {
+        // TimestampDatum use UTC based Julian time microseconds. So this need to convert the number of milliseconds
+        // to julian time microseconds.
         Timestamp timestamp = Timestamp.valueOf(StringUtils.unescapePathName(parts[1]));
         long julianTime = DateTimeUtil.javaTimeToJulianTime(timestamp.getTime());
         TimestampDatum timestampDatum = new TimestampDatum(julianTime);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/EvalNodeToExprConverter.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/EvalNodeToExprConverter.java
@@ -18,6 +18,8 @@
 
 package org.apache.tajo.plan.util;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.algebra.*;
 import org.apache.tajo.datum.DateDatum;
 import org.apache.tajo.datum.Datum;
@@ -32,6 +34,8 @@ import java.util.Stack;
  *
  */
 public class EvalNodeToExprConverter extends SimpleEvalNodeVisitor<Object> {
+  protected final Log LOG = LogFactory.getLog(getClass());
+
   private Stack<Expr> exprs = new Stack<>();
 
   private String tableName;
@@ -185,6 +189,8 @@ public class EvalNodeToExprConverter extends SimpleEvalNodeVisitor<Object> {
 
         timeValue = new TimeValue(""+timestampDatum.getHourOfDay()
         , ""+timestampDatum.getMinuteOfHour(), ""+timestampDatum.getSecondOfMinute());
+
+        timeValue.setSecondsFraction(Integer.toString(timestampDatum.getMillisOfSecond()));
 
         value = new TimestampLiteral(dateValue, timeValue);
         break;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/EvalNodeToExprConverter.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/EvalNodeToExprConverter.java
@@ -18,8 +18,6 @@
 
 package org.apache.tajo.plan.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.algebra.*;
 import org.apache.tajo.datum.DateDatum;
 import org.apache.tajo.datum.Datum;
@@ -34,8 +32,6 @@ import java.util.Stack;
  *
  */
 public class EvalNodeToExprConverter extends SimpleEvalNodeVisitor<Object> {
-  protected final Log LOG = LogFactory.getLog(getClass());
-
   private Stack<Expr> exprs = new Stack<>();
 
   private String tableName;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
@@ -20,8 +20,6 @@
 package org.apache.tajo.plan.util;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.algebra.*;
 import org.apache.tajo.catalog.CatalogConstants;
 import org.apache.tajo.catalog.Column;
@@ -49,8 +47,6 @@ import java.util.TimeZone;
  *
  */
 public class PartitionFilterAlgebraVisitor extends SimpleAlgebraVisitor<Object, Expr> {
-  protected final Log LOG = LogFactory.getLog(getClass());
-
   private String tableAlias;
   private Column column;
   private boolean isHiveCatalog = false;
@@ -149,6 +145,9 @@ public class PartitionFilterAlgebraVisitor extends SimpleAlgebraVisitor<Object, 
     TimeMeta tm = new TimeMeta();
     DateTimeUtil.toJulianTimeMeta(julianTimestamp, tm);
 
+    // For Hive compatibility, Tajo need to convert TimeMeta to STRING literals which are accepted in the format
+    // YYYY-MM-DD HH:MM:SS.MS. Also if there is no fractional seconds, we should use '.0' for nanos value in
+    // accordance with Hive partition naming rule.
     String dateFormat = DateTimeFormat.to_char(tm, "yyyy-MM-dd HH24:MI:SS");
     if (tm.fsecs == 0) {
       dateFormat += ".0";

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
@@ -19,6 +19,9 @@
 
 package org.apache.tajo.plan.util;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.algebra.*;
 import org.apache.tajo.catalog.CatalogConstants;
 import org.apache.tajo.catalog.Column;
@@ -30,12 +33,12 @@ import org.apache.tajo.plan.ExprAnnotator;
 import org.apache.tajo.plan.visitor.SimpleAlgebraVisitor;
 import org.apache.tajo.util.Pair;
 import org.apache.tajo.util.TUtil;
+import org.apache.tajo.util.datetime.DateTimeFormat;
 import org.apache.tajo.util.datetime.DateTimeUtil;
 import org.apache.tajo.util.datetime.TimeMeta;
 
 import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Stack;
 import java.util.TimeZone;
@@ -46,6 +49,8 @@ import java.util.TimeZone;
  *
  */
 public class PartitionFilterAlgebraVisitor extends SimpleAlgebraVisitor<Object, Expr> {
+  protected final Log LOG = LogFactory.getLog(getClass());
+
   private String tableAlias;
   private Column column;
   private boolean isHiveCatalog = false;
@@ -122,38 +127,41 @@ public class PartitionFilterAlgebraVisitor extends SimpleAlgebraVisitor<Object, 
   @Override
   public Expr visitTimestampLiteral(Object ctx, Stack<Expr> stack, TimestampLiteral expr) throws TajoException {
     StringBuilder sb = new StringBuilder();
+    DateValue dateValue = expr.getDate();
+    TimeValue timeValue = expr.getTime();
+
+    int [] dates = ExprAnnotator.dateToIntArray(dateValue.getYears(),
+      dateValue.getMonths(),
+      dateValue.getDays());
+    int [] times = ExprAnnotator.timeToIntArray(timeValue.getHours(),
+      timeValue.getMinutes(),
+      timeValue.getSeconds(),
+      timeValue.getSecondsFraction());
+
+    long julianTimestamp;
+    if (timeValue.hasSecondsFraction()) {
+      julianTimestamp = DateTimeUtil.toJulianTimestamp(dates[0], dates[1], dates[2], times[0], times[1], times[2],
+        times[3] * 1000);
+    } else {
+      julianTimestamp = DateTimeUtil.toJulianTimestamp(dates[0], dates[1], dates[2], times[0], times[1], times[2], 0);
+    }
+
+    TimeMeta tm = new TimeMeta();
+    DateTimeUtil.toJulianTimeMeta(julianTimestamp, tm);
+
+    String dateFormat = DateTimeFormat.to_char(tm, "yyyy-MM-dd HH24:MI:SS");
+    if (tm.fsecs == 0) {
+      dateFormat += ".0";
+    } else {
+      int secondsFraction = tm.fsecs / 1000;
+      dateFormat += "." + StringUtils.leftPad(""+secondsFraction, 3, '0');
+    }
 
     if (!isHiveCatalog) {
-      DateValue dateValue = expr.getDate();
-      TimeValue timeValue = expr.getTime();
-
-      int [] dates = ExprAnnotator.dateToIntArray(dateValue.getYears(),
-        dateValue.getMonths(),
-        dateValue.getDays());
-      int [] times = ExprAnnotator.timeToIntArray(timeValue.getHours(),
-        timeValue.getMinutes(),
-        timeValue.getSeconds(),
-        timeValue.getSecondsFraction());
-
-      long julianTimestamp;
-      if (timeValue.hasSecondsFraction()) {
-        julianTimestamp = DateTimeUtil.toJulianTimestamp(dates[0], dates[1], dates[2], times[0], times[1], times[2],
-          times[3] * 1000);
-      } else {
-        julianTimestamp = DateTimeUtil.toJulianTimestamp(dates[0], dates[1], dates[2], times[0], times[1], times[2], 0);
-      }
-
-      TimeMeta tm = new TimeMeta();
-      DateTimeUtil.toJulianTimeMeta(julianTimestamp, tm);
-
-      TimeZone tz = TimeZone.getDefault();
-      DateTimeUtil.toUTCTimezone(tm, tz);
-
       sb.append("?").append(" )");
-      Timestamp timestamp = new Timestamp(DateTimeUtil.julianTimeToJavaTime(DateTimeUtil.toJulianTimestamp(tm)));
-      parameters.add(new Pair(Type.TIMESTAMP, timestamp));
+      parameters.add(new Pair(Type.TEXT, dateFormat));
     } else {
-      sb.append("\"").append(expr.toString()).append("\"");
+      throw new UnsupportedException("Timestamp type");
     }
     queries.push(sb.toString());
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
@@ -161,6 +161,10 @@ public class PartitionFilterAlgebraVisitor extends SimpleAlgebraVisitor<Object, 
       sb.append("?").append(" )");
       parameters.add(new Pair(Type.TEXT, dateFormat));
     } else {
+      // Currently, Hive doesn't support to use Timestamp type using partition api. As a result, if Tajo uses Timestamp
+      // type, Hive will throws MetaException. Also Hive doesn't allow cast operator using partition api. So if there
+      // is any Timestamp type on filter conditions, Tajo must get all list of partitions of the table and build
+      // correct query result with the list.
       throw new UnsupportedException("Timestamp type");
     }
     queries.push(sb.toString());


### PR DESCRIPTION
This patch contains following modifications:

* When making partition directories, use partition name which are accepted in the format ```YYYY-MM-DD HH:MM:SS.MS```.
* When pruning partitions, convert UTC of EvalNode to customer timezone.
* When building partition filter in catalog, convert UTC of algebra expression to customer timezone.
* Add timestamp cast operation with the number of milliseconds. 

And I found that the patch ran successfully with MySQLStore and HiveCatalogStore.