### PR TITLE
TAJO-1971: Replace 'for' loop with 'foreach'

### DIFF
--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStoreClientPool.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStoreClientPool.java
@@ -114,8 +114,7 @@ public class HiveCatalogStoreClientPool {
   }
 
   public void setParameters(Configuration conf) {
-    for( Iterator<Entry<String, String>> iter = conf.iterator(); iter.hasNext();) {
-      Map.Entry<String, String> entry = iter.next();
+    for (Entry<String, String> entry : conf) {
       this.hiveConf.set(entry.getKey(), entry.getValue());
     }
   }

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/test/java/org/apache/tajo/catalog/store/TestHiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/test/java/org/apache/tajo/catalog/store/TestHiveCatalogStore.java
@@ -416,8 +416,8 @@ public class TestHiveCatalogStore {
 
     List<PartitionKeyProto> partitionKeyList = new ArrayList<>();
     String[] partitionNames = partitionName.split("/");
-    for(int i = 0; i < partitionNames.length; i++) {
-      String[] eachPartitionName = partitionNames[i].split("=");
+    for (String partitionName1 : partitionNames) {
+      String[] eachPartitionName = partitionName1.split("=");
 
       PartitionKeyProto.Builder builder = PartitionKeyProto.newBuilder();
       builder.setColumnName(eachPartitionName[0]);
@@ -454,8 +454,8 @@ public class TestHiveCatalogStore {
 
       List<PartitionKeyProto> partitionKeyList = new ArrayList<>();
       String[] split = partitionName.split("/");
-      for(int i = 0; i < split.length; i++) {
-        String[] eachPartitionName = split[i].split("=");
+      for (String aSplit : split) {
+        String[] eachPartitionName = aSplit.split("=");
 
         PartitionKeyProto.Builder keyBuilder = PartitionKeyProto.newBuilder();
         keyBuilder.setColumnName(eachPartitionName[0]);

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/dictionary/InfoSchemaMetadataDictionary.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/dictionary/InfoSchemaMetadataDictionary.java
@@ -96,8 +96,7 @@ public class InfoSchemaMetadataDictionary {
     }
     
     tableName = tableName.toUpperCase();
-    for (int idx = 0; idx < schemaInfoTableDescriptors.size(); idx++) {
-      TableDescriptor testDescriptor = schemaInfoTableDescriptors.get(idx);
+    for (TableDescriptor testDescriptor : schemaInfoTableDescriptors) {
       if (testDescriptor.getTableNameString().equalsIgnoreCase(tableName)) {
         tableDescriptor = testDescriptor;
         break;

--- a/tajo-catalog/tajo-catalog-server/src/test/java/org/apache/tajo/catalog/CatalogTestingUtil.java
+++ b/tajo-catalog/tajo-catalog-server/src/test/java/org/apache/tajo/catalog/CatalogTestingUtil.java
@@ -144,14 +144,14 @@ public class CatalogTestingUtil {
     String[] partitionNames = partitionName.split("/");
 
     List<PartitionKeyProto> partitionKeyList = new ArrayList<>();
-    for(int i = 0; i < partitionNames.length; i++) {
-      String [] splits = partitionNames[i].split("=");
+    for (String partitionName1 : partitionNames) {
+      String[] splits = partitionName1.split("=");
       String columnName = "", partitionValue = "";
       if (splits.length == 2) {
         columnName = splits[0];
         partitionValue = splits[1];
       } else if (splits.length == 1) {
-        if (partitionNames[i].charAt(0) == '=') {
+        if (partitionName1.charAt(0) == '=') {
           partitionValue = splits[0];
         } else {
           columnName = "";

--- a/tajo-common/src/main/java/org/apache/tajo/util/BytesUtils.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/BytesUtils.java
@@ -229,8 +229,8 @@ public class BytesUtils {
 
     int maxLen = Integer.MIN_VALUE;
 
-    for (int i = 0; i < bytes.length; i++) {
-      maxLen = Math.max(maxLen, bytes[i].length);
+    for (byte[] aByte : bytes) {
+      maxLen = Math.max(maxLen, aByte.length);
     }
 
     for (int i = 0; i < bytes.length; i++) {

--- a/tajo-common/src/main/java/org/apache/tajo/util/ProtoUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/ProtoUtil.java
@@ -67,8 +67,8 @@ public class ProtoUtil {
    */
   public static <T> Iterable<T> toProtoObjects(ProtoObject[] protoObjects) {
     List<T> converted = Lists.newArrayList();
-    for (int i = 0; i < protoObjects.length; i++) {
-      converted.add((T) protoObjects[i].getProto());
+    for (ProtoObject protoObject : protoObjects) {
+      converted.add((T) protoObject.getProto());
     }
     return converted;
   }

--- a/tajo-common/src/test/java/org/apache/tajo/datum/TestIntervalDatum.java
+++ b/tajo-common/src/test/java/org/apache/tajo/datum/TestIntervalDatum.java
@@ -122,8 +122,8 @@ public class TestIntervalDatum {
 
     // date '2001-10-01' - integer '7' ==>	date '2001-09-24'
     datum = DatumFactory.createDate(2001, 10, 1);
-    for (int i = 0; i < datums.length; i++) {
-      Datum result2 = datum.minus(datums[i]);
+    for (Datum datum1 : datums) {
+      Datum result2 = datum.minus(datum1);
       assertEquals(TajoDataTypes.Type.DATE, result2.type());
       assertEquals(DatumFactory.createDate(2001, 9, 24), result2);
     }
@@ -177,12 +177,12 @@ public class TestIntervalDatum {
         new Float4Datum(900.0f), new Float8Datum(900.0f)};
 
     datum = new IntervalDatum(1000);
-    for (int i = 0; i < datum900.length; i++) {
-      Datum result2 = datum.multiply(datum900[i]);
+    for (Datum aDatum900 : datum900) {
+      Datum result2 = datum.multiply(aDatum900);
       assertEquals(TajoDataTypes.Type.INTERVAL, result2.type());
       assertEquals(new IntervalDatum(15 * 60 * 1000), result2);
 
-      result2 = datum900[i].multiply(datum);
+      result2 = aDatum900.multiply(datum);
       assertEquals(TajoDataTypes.Type.INTERVAL, result2.type());
       assertEquals(new IntervalDatum(15 * 60 * 1000), result2);
     }

--- a/tajo-common/src/test/java/org/apache/tajo/tuple/memory/TestMemoryRowBlock.java
+++ b/tajo-common/src/test/java/org/apache/tajo/tuple/memory/TestMemoryRowBlock.java
@@ -253,10 +253,10 @@ public class TestMemoryRowBlock {
     LOG.info("reading takes " + (readEnd - readStart) + " msec");
 
     int count = 0;
-    for (int l = 0; l < rowBlock.size(); l++) {
-      for(int m = 0; m < schema.length; m++ ) {
-        if (rowBlock.get(l).contains(m) && rowBlock.get(l).get(m).type() == Type.INT4) {
-          count ++;
+    for (VTuple aRowBlock : rowBlock) {
+      for (int m = 0; m < schema.length; m++) {
+        if (aRowBlock.contains(m) && aRowBlock.get(m).type() == Type.INT4) {
+          count++;
         }
       }
     }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/eval/TestEvalTreeUtil.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/eval/TestEvalTreeUtil.java
@@ -348,8 +348,8 @@ public class TestEvalTreeUtil {
     EvalNode [] aggEvals = groupByNode.getAggFunctions();
 
     List<AggregationFunctionCallEval> list = new ArrayList<>();
-    for (int i = 0; i < aggEvals.length; i++) {
-      list.addAll(EvalTreeUtil.findDistinctAggFunction(aggEvals[i]));
+    for (EvalNode aggEval : aggEvals) {
+      list.addAll(EvalTreeUtil.findDistinctAggFunction(aggEval));
     }
     assertEquals(2, list.size());
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestHashPartitioner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestHashPartitioner.java
@@ -99,19 +99,19 @@ public class TestHashPartitioner {
     }
 
     int[] testNumPartitions = new int[]{31, 62, 124, 32, 63, 125};
-    for (int index = 0; index <  testNumPartitions.length; index++) {
-      Partitioner p = new HashPartitioner(new int[]{0, 1, 2}, testNumPartitions[index]);
+    for (int testNumPartition : testNumPartitions) {
+      Partitioner p = new HashPartitioner(new int[]{0, 1, 2}, testNumPartition);
 
       Set<Integer> ids = new TreeSet<>();
       for (int i = 0; i < data.length; i++) {
         Tuple tuple = new VTuple(
-            new Datum[]{new TextDatum(data[i][0]), new TextDatum(data[i][1]), new TextDatum(data[i][2])});
+                new Datum[]{new TextDatum(data[i][0]), new TextDatum(data[i][1]), new TextDatum(data[i][2])});
 
         ids.add(p.getPartition(tuple));
       }
 
       // The number of partitions isn't exactly matched.
-      assertTrue(ids.size() + 5 >= testNumPartitions[index]);
+      assertTrue(ids.size() + 5 >= testNumPartition);
     }
   }
 }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/master/TestRepartitioner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/master/TestRepartitioner.java
@@ -179,10 +179,10 @@ public class TestRepartitioner {
     for (int i = 0; i < 20; i++) {
       List<Pair<Long, Integer>> pages = new ArrayList<>();
       long offset = 0;
-      for (int j = 0; j < pageLengths.length; j++) {
-        pages.add(new Pair(offset, pageLengths[j]));
-        offset += pageLengths[j];
-        expectedTotalLength += pageLengths[j];
+      for (int pageLength : pageLengths) {
+        pages.add(new Pair(offset, pageLength));
+        offset += pageLength;
+        expectedTotalLength += pageLength;
       }
       IntermediateEntry interm = new IntermediateEntry(i, -1, -1, new Task.PullHost("" + i, i));
       interm.setPages(pages);
@@ -237,10 +237,10 @@ public class TestRepartitioner {
     for (int i = 0; i < 20; i++) {
       List<Pair<Long, Integer>> pages = new ArrayList<>();
       long offset = 0;
-      for (int j = 0; j < pageLengths.length; j++) {
-        pages.add(new Pair(offset, pageLengths[j]));
-        offset += pageLengths[j];
-        expectedTotalLength += pageLengths[j];
+      for (int pageLength : pageLengths) {
+        pages.add(new Pair(offset, pageLength));
+        offset += pageLength;
+        expectedTotalLength += pageLength;
       }
       IntermediateEntry interm = new IntermediateEntry(i, -1, 0, new Task.PullHost("" + i, i));
       interm.setPages(pages);
@@ -368,8 +368,8 @@ public class TestRepartitioner {
     List<IntermediateEntry> entries = new ArrayList<>();
     for (int i = 0; i < 2; i++) {
       List<Pair<Long, Integer>> pages = new ArrayList<>();
-      for (int j = 0; j < pageDatas.length; j++) {
-        pages.add(new Pair(pageDatas[j][0], (int) (pageDatas[j][1])));
+      for (long[] pageData : pageDatas) {
+        pages.add(new Pair(pageData[0], (int) (pageData[1])));
       }
       IntermediateEntry entry = new IntermediateEntry(-1, -1, 1, new Task.PullHost("host" + i , 9000));
       entry.setPages(pages);
@@ -426,10 +426,10 @@ public class TestRepartitioner {
     for (int i = 0; i < 20; i++) {
       List<Pair<Long, Integer>> pages = new ArrayList<>();
       long offset = 0;
-      for (int j = 0; j < pageLengths.length; j++) {
-        pages.add(new Pair(offset, pageLengths[j]));
-        offset += pageLengths[j];
-        expectedTotalLength += pageLengths[j];
+      for (int pageLength : pageLengths) {
+        pages.add(new Pair(offset, pageLength));
+        offset += pageLength;
+        expectedTotalLength += pageLength;
       }
       IntermediateEntry interm = new IntermediateEntry(i, -1, 0, pullHost);
       interm.setPages(pages);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/codegen/CaseWhenEmitter.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/codegen/CaseWhenEmitter.java
@@ -142,8 +142,8 @@ class CaseWhenEmitter {
   private static EvalNode extractCommonTerm(List<CaseWhenEval.IfThenEval> ifThenEvals) {
     EvalNode commonTerm = null;
 
-    for (int i = 0; i < ifThenEvals.size(); i++) {
-      EvalNode predicate = ifThenEvals.get(i).getCondition();
+    for (CaseWhenEval.IfThenEval ifThenEval : ifThenEvals) {
+      EvalNode predicate = ifThenEval.getCondition();
       if (!checkIfSimplePredicate(predicate)) {
         return null;
       }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
@@ -990,8 +990,8 @@ public class PhysicalPlannerImpl implements PhysicalPlanner {
       List<SortSpec> enforcedSortSpecList = Lists.newArrayList();
       int i = 0;
       outer:
-      for (int j = 0; j < sortSpecProtos.size(); j++) {
-        SortSpec enforcedSortSpecs = new SortSpec(sortSpecProtos.get(j));
+      for (SortSpecProto sortSpecProto : sortSpecProtos) {
+        SortSpec enforcedSortSpecs = new SortSpec(sortSpecProto);
 
         for (Column grpKey : grpColumns) { // if this sort key is included in grouping columns, skip it.
           if (enforcedSortSpecs.getSortKey().equals(grpKey)) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ColPartitionStoreExec.java
@@ -168,8 +168,7 @@ public abstract class ColPartitionStoreExec extends UnaryPhysicalExec {
 
     String[] partitionKeyPairs = partition.split("/");
 
-    for(int i = 0; i < partitionKeyPairs.length; i++) {
-      String partitionKeyPair = partitionKeyPairs[i];
+    for (String partitionKeyPair : partitionKeyPairs) {
       String[] split = partitionKeyPair.split("=");
 
       PartitionKeyProto.Builder keyBuilder = PartitionKeyProto.newBuilder();

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyFirstAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyFirstAggregationExec.java
@@ -319,8 +319,7 @@ public class DistinctGroupbyFirstAggregationExec extends UnaryPhysicalExec {
 
       List<Column> distinctGroupingKeyIndexSet = new ArrayList<>();
       Column[] groupingColumns = groupbyNode.getGroupingColumns();
-      for (int idx = 0; idx < groupingColumns.length; idx++) {
-        Column col = groupingColumns[idx];
+      for (Column col : groupingColumns) {
         if (!groupingKeySet.contains(col)) {
           distinctGroupingKeyIndexSet.add(col);
         }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
@@ -152,8 +152,7 @@ public class DistinctGroupbyHashAggregationExec extends UnaryPhysicalExec {
     List<TupleList> tupleSlots = new ArrayList<>();
 
     // aggregation with single grouping key
-    for (int i = 0; i < hashAggregators.length; i++) {
-      HashAggregator hashAggregator = hashAggregators[i];
+    for (HashAggregator hashAggregator : hashAggregators) {
       if (!hashAggregator.iterator.hasNext()) {
         nullCount++;
         tupleSlots.add(new TupleList());
@@ -284,12 +283,12 @@ public class DistinctGroupbyHashAggregationExec extends UnaryPhysicalExec {
   private void loadChildHashTable() throws IOException {
     Tuple tuple;
     while(!context.isStopped() && (tuple = child.next()) != null) {
-      for (int i = 0; i < hashAggregators.length; i++) {
-        hashAggregators[i].compute(tuple);
+      for (HashAggregator hashAggregator : hashAggregators) {
+        hashAggregator.compute(tuple);
       }
     }
-    for (int i = 0; i < hashAggregators.length; i++) {
-      hashAggregators[i].initFetch();
+    for (HashAggregator hashAggregator : hashAggregators) {
+      hashAggregator.initFetch();
     }
 
     totalNumRows = hashAggregators[0].hashTable.size();
@@ -298,8 +297,8 @@ public class DistinctGroupbyHashAggregationExec extends UnaryPhysicalExec {
   @Override
   public void close() throws IOException {
     if (hashAggregators != null) {
-      for (int i = 0; i < hashAggregators.length; i++) {
-        hashAggregators[i].close();
+      for (HashAggregator hashAggregator : hashAggregators) {
+        hashAggregator.close();
       }
     }
     if (child != null) {
@@ -316,8 +315,8 @@ public class DistinctGroupbyHashAggregationExec extends UnaryPhysicalExec {
 
   public void rescan() throws IOException {
     finished = false;
-    for (int i = 0; i < hashAggregators.length; i++) {
-      hashAggregators[i].initFetch();
+    for (HashAggregator hashAggregator : hashAggregators) {
+      hashAggregator.initFetch();
     }
     if (currentAggregatedTuples != null) {
       currentAggregatedTuples.clear();
@@ -366,8 +365,8 @@ public class DistinctGroupbyHashAggregationExec extends UnaryPhysicalExec {
 
       Column[] keyColumns = groupbyNode.getGroupingColumns();
       Column col;
-      for (int idx = 0; idx < keyColumns.length; idx++) {
-        col = keyColumns[idx];
+      for (Column keyColumn : keyColumns) {
+        col = keyColumn;
         if (!distinctGroupingKeyColumnSet.contains(col)) {
           groupingKeyColumnList.add(col);
         }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySecondAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySecondAggregationExec.java
@@ -142,8 +142,7 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
       if (eachGroupby.isDistinct()) {
         List<Integer> distinctGroupingKeyIndex = new ArrayList<>();
         Column[] distinctGroupingColumns = eachGroupby.getGroupingColumns();
-        for (int idx = 0; idx < distinctGroupingColumns.length; idx++) {
-          Column col = distinctGroupingColumns[idx];
+        for (Column col : distinctGroupingColumns) {
           int keyIndex;
           if (col.hasQualifier()) {
             keyIndex = inSchema.getColumnId(col.getQualifiedName());

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySortAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySortAggregationExec.java
@@ -109,11 +109,11 @@ public class DistinctGroupbySortAggregationExec extends PhysicalExec {
     }
 
     int mergeTupleIndex = 0;
-    for (int i = 0; i < currentTuples.length; i++) {
-      int tupleSize = currentTuples[i].size();
+    for (Tuple currentTuple : currentTuples) {
+      int tupleSize = currentTuple.size();
       for (int j = 0; j < tupleSize; j++) {
         if (resultColumnIdIndexes[mergeTupleIndex] >= 0) {
-          outTuple.put(resultColumnIdIndexes[mergeTupleIndex], currentTuples[i].asDatum(j));
+          outTuple.put(resultColumnIdIndexes[mergeTupleIndex], currentTuple.asDatum(j));
         }
         mergeTupleIndex++;
       }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/WindowAggExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/WindowAggExec.java
@@ -282,8 +282,7 @@ public class WindowAggExec extends UnaryPhysicalExec {
 
     evaluatedTuples = new TupleList();
 
-    for (Object accumulatedInTuple : accumulatedInTuples) {
-      Tuple inTuple = accumulatedInTuple;
+    for (Tuple inTuple : accumulatedInTuples) {
 
       for (int c = 0; c < nonFunctionColumnNum; c++) {
         evaluatedTuple.put(c, inTuple.asDatum(nonFunctionColumns[c]));
@@ -316,9 +315,8 @@ public class WindowAggExec extends UnaryPhysicalExec {
       }
 
       if (aggFuncFlags[idx]) {
-        for (Object evaluatedTuple1 : evaluatedTuples) {
+        for (Tuple outTuple : evaluatedTuples) {
           Datum result = functions[idx].terminate(contexts[idx]);
-          Tuple outTuple = evaluatedTuple1;
           outTuple.put(nonFunctionColumnNum + idx, result);
         }
       }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/WindowAggExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/WindowAggExec.java
@@ -282,8 +282,8 @@ public class WindowAggExec extends UnaryPhysicalExec {
 
     evaluatedTuples = new TupleList();
 
-    for (int i = 0; i <accumulatedInTuples.size(); i++) {
-      Tuple inTuple = accumulatedInTuples.get(i);
+    for (Object accumulatedInTuple : accumulatedInTuples) {
+      Tuple inTuple = accumulatedInTuple;
 
       for (int c = 0; c < nonFunctionColumnNum; c++) {
         evaluatedTuple.put(c, inTuple.asDatum(nonFunctionColumns[c]));
@@ -316,9 +316,9 @@ public class WindowAggExec extends UnaryPhysicalExec {
       }
 
       if (aggFuncFlags[idx]) {
-        for (int i = 0; i < evaluatedTuples.size(); i++) {
+        for (Object evaluatedTuple1 : evaluatedTuples) {
           Datum result = functions[idx].terminate(contexts[idx]);
-          Tuple outTuple = evaluatedTuples.get(i);
+          Tuple outTuple = evaluatedTuple1;
           outTuple.put(nonFunctionColumnNum + idx, result);
         }
       }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/query/TaskRequestImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/query/TaskRequestImpl.java
@@ -241,8 +241,8 @@ public class TaskRequestImpl implements TaskRequest {
 			builder.setId(this.id.getProto());
 		}
 		if (fragments != null) {
-			for (int i = 0; i < fragments.size(); i++) {
-				builder.addFragments(fragments.get(i));
+			for (FragmentProto fragment : fragments) {
+				builder.addFragments(fragment);
 			}
 		}
 		if (this.outputTable != null) {
@@ -258,9 +258,9 @@ public class TaskRequestImpl implements TaskRequest {
 		  builder.setInterQuery(this.interQuery);
 		}
     if (this.fetches != null) {
-      for (int i = 0; i < fetches.size(); i++) {
-        builder.addFetches(fetches.get(i).getProto());
-      }
+		for (FetchImpl fetche : fetches) {
+			builder.addFetches(fetche.getProto());
+		}
     }
     if (this.queryMasterHostAndPort != null) {
       builder.setQueryMasterHostAndPort(this.queryMasterHostAndPort);

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
@@ -669,8 +669,7 @@ public class DDLExecutor {
 
     String[] partitionKeyPairs = partitionName.split("/");
 
-    for(int i = 0; i < partitionKeyPairs.length; i++) {
-      String partitionKeyPair = partitionKeyPairs[i];
+    for (String partitionKeyPair : partitionKeyPairs) {
       String[] split = partitionKeyPair.split("=");
 
       PartitionKeyProto.Builder keyBuilder = PartitionKeyProto.newBuilder();

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/QueryExecutor.java
@@ -373,8 +373,8 @@ public class QueryExecutor {
 
   public static void startScriptExecutors(QueryContext queryContext, EvalContext evalContext, Target[] targets)
       throws IOException {
-    for (int i = 0; i < targets.length; i++) {
-      EvalNode eval = targets[i].getEvalTree();
+    for (Target target : targets) {
+      EvalNode eval = target.getEvalTree();
       if (eval instanceof GeneralFunctionEval) {
         GeneralFunctionEval functionEval = (GeneralFunctionEval) eval;
         if (functionEval.getFuncDesc().getInvocation().hasPython()) {

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
@@ -265,8 +265,8 @@ public class Query implements EventHandler<QueryEvent> {
       float totalProgress = 0.0f;
       float proportion = 1.0f / (float)(getExecutionBlockCursor().size() - 1); // minus one is due to
 
-      for (int i = 0; i < subProgresses.length; i++) {
-        totalProgress += subProgresses[i] * proportion;
+      for (float subProgress : subProgresses) {
+        totalProgress += subProgress * proportion;
       }
 
       return totalProgress;

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -146,8 +146,8 @@ public class Repartitioner {
     if (joinNode != null) {
       // If all stats are zero, return
       boolean isEmptyAllJoinTables = true;
-      for (int i = 0; i < stats.length; i++) {
-        if (stats[i] > 0) {
+      for (long stat : stats) {
+        if (stat > 0) {
           isEmptyAllJoinTables = false;
           break;
         }

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Task.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Task.java
@@ -884,8 +884,7 @@ public class Task implements EventHandler<TaskEvent> {
       long currentBytes = 0;
 
       long realSplitVolume = firstSplitVolume > 0 ? firstSplitVolume : splitVolume;
-      for (int i = 0; i < pageSize; i++) {
-        Pair<Long, Integer> eachPage = pages.get(i);
+      for (Pair<Long, Integer> eachPage : pages) {
         if (currentOffset == -1) {
           currentOffset = eachPage.getFirst();
         }

--- a/tajo-core/src/main/java/org/apache/tajo/webapp/HttpServer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/webapp/HttpServer.java
@@ -357,10 +357,10 @@ public class HttpServer {
       }
       // Make sure there is no handler failures.
       Handler[] handlers = webServer.getHandlers();
-      for (int i = 0; i < handlers.length; i++) {
-        if (handlers[i].isFailed()) {
+      for (Handler handler : handlers) {
+        if (handler.isFailed()) {
           throw new IOException(
-              "Problem in starting http server. Server handlers failed");
+                  "Problem in starting http server. Server handlers failed");
         }
       }
     } catch (IOException e) {

--- a/tajo-jdbc/src/test/java/org/apache/tajo/jdbc/TestTajoJdbc.java
+++ b/tajo-jdbc/src/test/java/org/apache/tajo/jdbc/TestTajoJdbc.java
@@ -367,14 +367,14 @@ public class TestTajoJdbc extends QueryTestCaseBase {
     conns[1] = DriverManager.getConnection(connUri);
 
     try {
-      for (int i = 0; i < conns.length; i++) {
+      for (Connection conn : conns) {
         Statement stmt = null;
         ResultSet res = null;
         try {
-          stmt = conns[i].createStatement();
+          stmt = conn.createStatement();
 
           res = stmt.executeQuery("select l_returnflag, l_linestatus, count(*) as count_order from lineitem " +
-            "group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus");
+                  "group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus");
 
           try {
             Map<String, Integer> result = Maps.newHashMap();
@@ -425,14 +425,14 @@ public class TestTajoJdbc extends QueryTestCaseBase {
     conns[1] = DriverManager.getConnection(connUri);
 
     try {
-      for (int i = 0; i < conns.length; i++) {
+      for (Connection conn : conns) {
         Statement stmt = null;
         ResultSet res = null;
         try {
-          stmt = conns[i].createStatement();
+          stmt = conn.createStatement();
 
           res = stmt.executeQuery("select l_returnflag, l_linestatus, count(*) as count_order from lineitem " +
-            "group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus");
+                  "group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus");
 
           try {
             Map<String, Integer> result = Maps.newHashMap();
@@ -461,7 +461,7 @@ public class TestTajoJdbc extends QueryTestCaseBase {
           if (stmt != null) {
             stmt.close();
           }
-          conns[i].close();
+          conn.close();
         }
       }
     } finally {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
@@ -739,8 +739,8 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
         }
       }
     }
-    for (int i = 0; i < winFuncRefs.size(); i++) {
-      targets[targetIdx++] = block.namedExprsMgr.getTarget(winFuncRefs.get(i));
+    for (String winFuncRef : winFuncRefs) {
+      targets[targetIdx++] = block.namedExprsMgr.getTarget(winFuncRef);
     }
     windowAggNode.setTargets(targets);
     verifyProjectedFields(block, windowAggNode);
@@ -1012,12 +1012,11 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
 
     // Set grouping sets
     List<Column> groupingColumns = Lists.newArrayList();
-    for (int i = 0; i < groupingKeyRefNames.length; i++) {
-      String refName = groupingKeyRefNames[i];
+    for (String refName : groupingKeyRefNames) {
       if (context.getQueryBlock().isConstReference(refName)) {
         continue;
-      } else if (block.namedExprsMgr.isEvaluated(groupingKeyRefNames[i])) {
-        groupingColumns.add(block.namedExprsMgr.getTarget(groupingKeyRefNames[i]).getNamedColumn());
+      } else if (block.namedExprsMgr.isEvaluated(refName)) {
+        groupingColumns.add(block.namedExprsMgr.getTarget(refName).getNamedColumn());
       } else {
         throw makeSyntaxError("Each grouping column expression must be a scalar expression.");
       }
@@ -1701,11 +1700,11 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
       // It guarantees that the equivalence between the numbers of target and projected columns.
       ColumnReferenceExpr [] targets = expr.getTargetColumns();
       Schema targetColumns = new Schema();
-      for (int i = 0; i < targets.length; i++) {
-        Column targetColumn = desc.getLogicalSchema().getColumn(targets[i].getCanonicalName().replace(".", "/"));
+      for (ColumnReferenceExpr target : targets) {
+        Column targetColumn = desc.getLogicalSchema().getColumn(target.getCanonicalName().replace(".", "/"));
 
         if (targetColumn == null) {
-          throw makeSyntaxError("column '" + targets[i] + "' of relation '" + desc.getName() + "' does not exist");
+          throw makeSyntaxError("column '" + target + "' of relation '" + desc.getName() + "' does not exist");
         }
 
         targetColumns.addColumn(targetColumn);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
@@ -213,8 +213,8 @@ public class DistinctGroupbyNode extends UnaryNode implements Projectable, Clone
     for (GroupbyNode eachNode: subGroupbyPlan) {
       if (eachNode.hasAggFunctions()) {
         AggregationFunctionCallEval[] aggrFunctions = eachNode.getAggFunctions();
-        for (int j = 0; j < aggrFunctions.length; j++) {
-          sb.append(prefix).append(aggrFunctions[j]);
+        for (AggregationFunctionCallEval aggrFunction : aggrFunctions) {
+          sb.append(prefix).append(aggrFunction);
           prefix = ",";
         }
       }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/serder/EvalNodeSerializer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/serder/EvalNodeSerializer.java
@@ -268,8 +268,8 @@ public class EvalNodeSerializer
     // building itself
     PlanProto.FunctionEval.Builder funcBuilder = PlanProto.FunctionEval.newBuilder();
     funcBuilder.setFuncion(function.getFuncDesc().getProto());
-    for (int i = 0; i < childIds.length; i++) {
-      funcBuilder.addParamIds(childIds[i]);
+    for (int childId : childIds) {
+      funcBuilder.addParamIds(childId);
     }
 
     // registering itself and building EvalNode

--- a/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/BaseTupleComparator.java
+++ b/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/BaseTupleComparator.java
@@ -174,8 +174,8 @@ public class BaseTupleComparator extends TupleComparator implements ProtoObject<
   public TupleComparatorProto getProto() {
     TupleComparatorProto.Builder builder = TupleComparatorProto.newBuilder();
     builder.setSchema(schema.getProto());
-    for (int i = 0; i < sortSpecs.length; i++) {
-      builder.addSortSpecs(sortSpecs[i].getProto());
+    for (SortSpec sortSpec : sortSpecs) {
+      builder.addSortSpecs(sortSpec.getProto());
     }
 
     TupleComparatorSpecProto.Builder sortSpecBuilder;

--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseTablespace.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseTablespace.java
@@ -139,8 +139,8 @@ public class HBaseTablespace extends Tablespace {
     ColumnMapping columnMapping = new ColumnMapping(schema, tableMeta.getOptions());
     int numRowKeys = 0;
     boolean[] isRowKeyMappings = columnMapping.getIsRowKeyMappings();
-    for (int i = 0; i < isRowKeyMappings.length; i++) {
-      if (isRowKeyMappings[i]) {
+    for (boolean isRowKeyMapping : isRowKeyMappings) {
+      if (isRowKeyMapping) {
         numRowKeys++;
       }
     }

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/FileTablespace.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/FileTablespace.java
@@ -336,9 +336,7 @@ public class FileTablespace extends Tablespace {
 
     PathFilter inputFilter = new MultiPathFilter(filters);
 
-    for (int i = 0; i < dirs.length; ++i) {
-      Path p = dirs[i];
-
+    for (Path p : dirs) {
       FileStatus[] matches = fs.globStatus(p, inputFilter);
       if (matches == null) {
         LOG.warn("Input path does not exist: " + p);

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/parquet/TajoSchemaConverter.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/parquet/TajoSchemaConverter.java
@@ -55,11 +55,10 @@ public class TajoSchemaConverter {
 
   private Schema convertFields(List<Type> parquetFields) {
     List<Column> columns = new ArrayList<>();
-    for (int i = 0; i < parquetFields.size(); ++i) {
-      Type fieldType = parquetFields.get(i);
+    for (Type fieldType : parquetFields) {
       if (fieldType.isRepetition(Type.Repetition.REPEATED)) {
         throw new RuntimeException("REPEATED not supported outside LIST or" +
-            " MAP. Type: " + fieldType);
+                " MAP. Type: " + fieldType);
       }
       columns.add(convertField(fieldType));
     }

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/rcfile/RCFile.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/rcfile/RCFile.java
@@ -915,8 +915,7 @@ public class RCFile {
     public int getKeyBufferSize() throws IOException {
       int ret = 0;
       ret += WritableUtils.getVIntSize(bufferedRecords);
-      for (int i = 0; i < columnBuffers.length; i++) {
-        ColumnBuffer currentBuf = columnBuffers[i];
+      for (ColumnBuffer currentBuf : columnBuffers) {
         ret += WritableUtils.getVIntSize(currentBuf.columnValueLength);
         ret += WritableUtils.getVIntSize(currentBuf.uncompressedColumnValueLength);
         ret += WritableUtils.getVIntSize(currentBuf.columnKeyLength);
@@ -936,8 +935,7 @@ public class RCFile {
       int ret = 12; //12 bytes |record count, key length, compressed key length|
 
       ret += WritableUtils.getVIntSize(bufferedRecords);
-      for (int i = 0; i < columnBuffers.length; i++) {
-        ColumnBuffer currentBuf = columnBuffers[i];
+      for (ColumnBuffer currentBuf : columnBuffers) {
         ret += WritableUtils.getVIntSize(currentBuf.columnValueLength);
         ret += WritableUtils.getVIntSize(currentBuf.uncompressedColumnValueLength);
         ret += WritableUtils.getVIntSize(currentBuf.columnKeyLength);
@@ -950,8 +948,7 @@ public class RCFile {
 
     private void WriteKeyBuffer(DataOutputStream out) throws IOException {
       WritableUtils.writeVLong(out, bufferedRecords);
-      for (int i = 0; i < columnBuffers.length; i++) {
-        ColumnBuffer currentBuf = columnBuffers[i];
+      for (ColumnBuffer currentBuf : columnBuffers) {
         WritableUtils.writeVLong(out, currentBuf.columnValueLength);
         WritableUtils.writeVLong(out, currentBuf.uncompressedColumnValueLength);
         WritableUtils.writeVLong(out, currentBuf.columnKeyLength);

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/sequencefile/SequenceFileScanner.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/sequencefile/SequenceFileScanner.java
@@ -240,8 +240,8 @@ public class SequenceFileScanner extends FileScanner {
         fieldLength[i] = elementSize;
         lastFieldByteEnd = fieldStart[i] + fieldLength[i];
 
-        for (int j = 0; j < projectionMap.length; j++) {
-          if (projectionMap[j] == i) {
+        for (int aProjectionMap : projectionMap) {
+          if (aProjectionMap == i) {
             Datum datum = serde.deserialize(i, bytes, fieldStart[i], fieldLength[i], nullChars);
             outTuple.put(i, datum);
           }

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/thirdparty/orc/OrcUtils.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/thirdparty/orc/OrcUtils.java
@@ -117,8 +117,8 @@ public class OrcUtils {
               endIdx += 1;
               StructObjectInspector structInsp = (StructObjectInspector) sfOI;
               List<? extends StructField> structFields = structInsp.getAllStructFieldRefs();
-              for (int j = 0; j < structFields.size(); ++j) {
-                endIdx += getFlattenedColumnsCount(structFields.get(j).getFieldObjectInspector());
+              for (StructField structField : structFields) {
+                endIdx += getFlattenedColumnsCount(structField.getFieldObjectInspector());
               }
               break;
             case MAP:
@@ -136,8 +136,8 @@ public class OrcUtils {
               endIdx += 1;
               UnionObjectInspector unionInsp = (UnionObjectInspector) sfOI;
               List<ObjectInspector> choices = unionInsp.getObjectInspectors();
-              for (int j = 0; j < choices.size(); ++j) {
-                endIdx += getFlattenedColumnsCount(choices.get(j));
+              for (ObjectInspector choice : choices) {
+                endIdx += getFlattenedColumnsCount(choice);
               }
               break;
             default:
@@ -168,8 +168,8 @@ public class OrcUtils {
         numWriters += 1;
         StructObjectInspector structInsp = (StructObjectInspector) inspector;
         List<? extends StructField> fields = structInsp.getAllStructFieldRefs();
-        for (int i = 0; i < fields.size(); ++i) {
-          numWriters += getFlattenedColumnsCount(fields.get(i).getFieldObjectInspector());
+        for (StructField field : fields) {
+          numWriters += getFlattenedColumnsCount(field.getFieldObjectInspector());
         }
         break;
       case MAP:
@@ -187,8 +187,8 @@ public class OrcUtils {
         numWriters += 1;
         UnionObjectInspector unionInsp = (UnionObjectInspector) inspector;
         List<ObjectInspector> choices = unionInsp.getObjectInspectors();
-        for (int i = 0; i < choices.size(); ++i) {
-          numWriters += getFlattenedColumnsCount(choices.get(i));
+        for (ObjectInspector choice : choices) {
+          numWriters += getFlattenedColumnsCount(choice);
         }
         break;
       default:

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/AnnotationWriter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/AnnotationWriter.java
@@ -138,50 +138,50 @@ final class AnnotationWriter extends AnnotationVisitor {
         } else if (value instanceof byte[]) {
             byte[] v = (byte[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('B', cw.newInteger(v[i]).index);
+            for (byte aV : v) {
+                bv.put12('B', cw.newInteger(aV).index);
             }
         } else if (value instanceof boolean[]) {
             boolean[] v = (boolean[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('Z', cw.newInteger(v[i] ? 1 : 0).index);
+            for (boolean aV : v) {
+                bv.put12('Z', cw.newInteger(aV ? 1 : 0).index);
             }
         } else if (value instanceof short[]) {
             short[] v = (short[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('S', cw.newInteger(v[i]).index);
+            for (short aV : v) {
+                bv.put12('S', cw.newInteger(aV).index);
             }
         } else if (value instanceof char[]) {
             char[] v = (char[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('C', cw.newInteger(v[i]).index);
+            for (char aV : v) {
+                bv.put12('C', cw.newInteger(aV).index);
             }
         } else if (value instanceof int[]) {
             int[] v = (int[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('I', cw.newInteger(v[i]).index);
+            for (int aV : v) {
+                bv.put12('I', cw.newInteger(aV).index);
             }
         } else if (value instanceof long[]) {
             long[] v = (long[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('J', cw.newLong(v[i]).index);
+            for (long aV : v) {
+                bv.put12('J', cw.newLong(aV).index);
             }
         } else if (value instanceof float[]) {
             float[] v = (float[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('F', cw.newFloat(v[i]).index);
+            for (float aV : v) {
+                bv.put12('F', cw.newFloat(aV).index);
             }
         } else if (value instanceof double[]) {
             double[] v = (double[]) value;
             bv.put12('[', v.length);
-            for (int i = 0; i < v.length; i++) {
-                bv.put12('D', cw.newDouble(v[i]).index);
+            for (double aV : v) {
+                bv.put12('D', cw.newDouble(aV).index);
             }
         } else {
             Item i = cw.newConstItem(value);

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/ClassReader.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/ClassReader.java
@@ -1945,9 +1945,9 @@ public class ClassReader {
     private Attribute readAttribute(final Attribute[] attrs, final String type,
             final int off, final int len, final char[] buf, final int codeOff,
             final Label[] labels) {
-        for (int i = 0; i < attrs.length; ++i) {
-            if (attrs[i].type.equals(type)) {
-                return attrs[i].read(this, off, len, buf, codeOff, labels);
+        for (Attribute attr : attrs) {
+            if (attr.type.equals(type)) {
+                return attr.read(this, off, len, buf, codeOff, labels);
             }
         }
         return new Attribute(type).read(this, off, len, null, -1, null);

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/ClassWriter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/ClassWriter.java
@@ -1200,8 +1200,7 @@ public class ClassWriter extends ClassVisitor {
         int argsLength = bsmArgs.length;
         bootstrapMethods.putShort(argsLength);
 
-        for (int i = 0; i < argsLength; i++) {
-            Object bsmArg = bsmArgs[i];
+        for (Object bsmArg : bsmArgs) {
             hashCode ^= bsmArg.hashCode();
             bootstrapMethods.putShort(newConst(bsmArg));
         }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/Frame.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/Frame.java
@@ -821,8 +821,8 @@ final class Frame {
                 inputLocals[i++] = UNINITIALIZED_THIS;
             }
         }
-        for (int j = 0; j < args.length; ++j) {
-            int t = type(cw, args[j].getDescriptor());
+        for (Type arg : args) {
+            int t = type(cw, arg.getDescriptor());
             inputLocals[i++] = t;
             if (t == LONG || t == DOUBLE) {
                 inputLocals[i++] = TOP;

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/MethodWriter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/MethodWriter.java
@@ -1108,8 +1108,8 @@ class MethodWriter extends MethodVisitor {
         code.putByteArray(null, 0, (4 - code.length % 4) % 4);
         dflt.put(this, code, source, true);
         code.putInt(min).putInt(max);
-        for (int i = 0; i < labels.length; ++i) {
-            labels[i].put(this, code, source, true);
+        for (Label label : labels) {
+            label.put(this, code, source, true);
         }
         // updates currentBlock
         visitSwitchInsn(dflt, labels);
@@ -1140,17 +1140,17 @@ class MethodWriter extends MethodVisitor {
                 // adds current block successors
                 addSuccessor(Edge.NORMAL, dflt);
                 dflt.getFirst().status |= Label.TARGET;
-                for (int i = 0; i < labels.length; ++i) {
-                    addSuccessor(Edge.NORMAL, labels[i]);
-                    labels[i].getFirst().status |= Label.TARGET;
+                for (Label label : labels) {
+                    addSuccessor(Edge.NORMAL, label);
+                    label.getFirst().status |= Label.TARGET;
                 }
             } else {
                 // updates current stack size (max stack size unchanged)
                 --stackSize;
                 // adds current block successors
                 addSuccessor(stackSize, dflt);
-                for (int i = 0; i < labels.length; ++i) {
-                    addSuccessor(stackSize, labels[i]);
+                for (Label label : labels) {
+                    addSuccessor(stackSize, label);
                 }
             }
             // ends current block

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/Type.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/Type.java
@@ -644,8 +644,8 @@ public class Type {
             final Type... argumentTypes) {
         StringBuffer buf = new StringBuffer();
         buf.append('(');
-        for (int i = 0; i < argumentTypes.length; ++i) {
-            argumentTypes[i].getDescriptor(buf);
+        for (Type argumentType : argumentTypes) {
+            argumentType.getDescriptor(buf);
         }
         buf.append(')');
         returnType.getDescriptor(buf);
@@ -715,8 +715,8 @@ public class Type {
         Class<?>[] parameters = c.getParameterTypes();
         StringBuffer buf = new StringBuffer();
         buf.append('(');
-        for (int i = 0; i < parameters.length; ++i) {
-            getDescriptor(buf, parameters[i]);
+        for (Class<?> parameter : parameters) {
+            getDescriptor(buf, parameter);
         }
         return buf.append(")V").toString();
     }
@@ -732,8 +732,8 @@ public class Type {
         Class<?>[] parameters = m.getParameterTypes();
         StringBuffer buf = new StringBuffer();
         buf.append('(');
-        for (int i = 0; i < parameters.length; ++i) {
-            getDescriptor(buf, parameters[i]);
+        for (Class<?> parameter : parameters) {
+            getDescriptor(buf, parameter);
         }
         buf.append(')');
         getDescriptor(buf, m.getReturnType());

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/AdviceAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/AdviceAdapter.java
@@ -29,16 +29,12 @@
  */
 package org.apache.tajo.org.objectweb.asm.commons;
 
+import org.apache.tajo.org.objectweb.asm.*;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.tajo.org.objectweb.asm.Label;
-import org.apache.tajo.org.objectweb.asm.Type;
-import org.apache.tajo.org.objectweb.asm.Handle;
-import org.apache.tajo.org.objectweb.asm.MethodVisitor;
-import org.apache.tajo.org.objectweb.asm.Opcodes;
 
 /**
  * A {@link org.apache.tajo.org.objectweb.asm.MethodVisitor} to insert before, after and around
@@ -419,9 +415,9 @@ public abstract class AdviceAdapter extends GeneratorAdapter implements Opcodes 
         mv.visitMethodInsn(opcode, owner, name, desc);
         if (constructor) {
             Type[] types = Type.getArgumentTypes(desc);
-            for (int i = 0; i < types.length; i++) {
+            for (Type type1 : types) {
                 popValue();
-                if (types[i].getSize() == 2) {
+                if (type1.getSize() == 2) {
                     popValue();
                 }
             }
@@ -460,9 +456,9 @@ public abstract class AdviceAdapter extends GeneratorAdapter implements Opcodes 
         mv.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
         if (constructor) {
             Type[] types = Type.getArgumentTypes(desc);
-            for (int i = 0; i < types.length; i++) {
+            for (Type type : types) {
                 popValue();
-                if (types[i].getSize() == 2) {
+                if (type.getSize() == 2) {
                     popValue();
                 }
             }
@@ -544,8 +540,8 @@ public abstract class AdviceAdapter extends GeneratorAdapter implements Opcodes 
 
     private void addBranches(final Label dflt, final Label[] labels) {
         addBranch(dflt);
-        for (int i = 0; i < labels.length; i++) {
-            addBranch(labels[i]);
+        for (Label label : labels) {
+            addBranch(label);
         }
     }
 

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/AnalyzerAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/AnalyzerAdapter.java
@@ -177,33 +177,32 @@ public class AnalyzerAdapter extends MethodVisitor {
             }
         }
         Type[] types = Type.getArgumentTypes(desc);
-        for (int i = 0; i < types.length; ++i) {
-            Type type = types[i];
+        for (Type type : types) {
             switch (type.getSort()) {
-            case Type.BOOLEAN:
-            case Type.CHAR:
-            case Type.BYTE:
-            case Type.SHORT:
-            case Type.INT:
-                locals.add(Opcodes.INTEGER);
-                break;
-            case Type.FLOAT:
-                locals.add(Opcodes.FLOAT);
-                break;
-            case Type.LONG:
-                locals.add(Opcodes.LONG);
-                locals.add(Opcodes.TOP);
-                break;
-            case Type.DOUBLE:
-                locals.add(Opcodes.DOUBLE);
-                locals.add(Opcodes.TOP);
-                break;
-            case Type.ARRAY:
-                locals.add(types[i].getDescriptor());
-                break;
-            // case Type.OBJECT:
-            default:
-                locals.add(types[i].getInternalName());
+                case Type.BOOLEAN:
+                case Type.CHAR:
+                case Type.BYTE:
+                case Type.SHORT:
+                case Type.INT:
+                    locals.add(Opcodes.INTEGER);
+                    break;
+                case Type.FLOAT:
+                    locals.add(Opcodes.FLOAT);
+                    break;
+                case Type.LONG:
+                    locals.add(Opcodes.LONG);
+                    locals.add(Opcodes.TOP);
+                    break;
+                case Type.DOUBLE:
+                    locals.add(Opcodes.DOUBLE);
+                    locals.add(Opcodes.TOP);
+                    break;
+                case Type.ARRAY:
+                    locals.add(type.getDescriptor());
+                    break;
+                // case Type.OBJECT:
+                default:
+                    locals.add(type.getInternalName());
             }
         }
     }
@@ -283,8 +282,8 @@ public class AnalyzerAdapter extends MethodVisitor {
                     mv.visitLabel(l);
                 }
             }
-            for (int i = 0; i < labels.size(); ++i) {
-                uninitializedTypes.put(labels.get(i), type);
+            for (Label label : labels) {
+                uninitializedTypes.put(label, type);
             }
         }
         if (mv != null) {
@@ -538,8 +537,8 @@ public class AnalyzerAdapter extends MethodVisitor {
         if (c == '(') {
             int n = 0;
             Type[] types = Type.getArgumentTypes(desc);
-            for (int i = 0; i < types.length; ++i) {
-                n += types[i].getSize();
+            for (Type type : types) {
+                n += type.getSize();
             }
             pop(n);
         } else if (c == 'J' || c == 'D') {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/GeneratorAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/GeneratorAdapter.java
@@ -1258,8 +1258,8 @@ public class GeneratorAdapter extends LocalVariablesSorter {
             if (useTable) {
                 Label[] labels = new Label[range];
                 Arrays.fill(labels, def);
-                for (int i = 0; i < len; ++i) {
-                    labels[keys[i] - min] = newLabel();
+                for (int key : keys) {
+                    labels[key - min] = newLabel();
                 }
                 mv.visitTableSwitchInsn(min, max, def, labels);
                 for (int i = 0; i < range; ++i) {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/JSRInlinerAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/JSRInlinerAdapter.java
@@ -195,9 +195,8 @@ public class JSRInlinerAdapter extends MethodNode implements Opcodes {
 
         // Go through the head of each subroutine and find any nodes reachable
         // to that subroutine without following any JSR links.
-        for (Iterator<Map.Entry<LabelNode, BitSet>> it = subroutineHeads
-                .entrySet().iterator(); it.hasNext();) {
-            Map.Entry<LabelNode, BitSet> entry = it.next();
+        for (Map.Entry<LabelNode, BitSet> entry : subroutineHeads
+                .entrySet()) {
             LabelNode lab = entry.getKey();
             BitSet sub = entry.getValue();
             int index = instructions.indexOf(lab);
@@ -234,10 +233,7 @@ public class JSRInlinerAdapter extends MethodNode implements Opcodes {
         boolean loop = true;
         while (loop) {
             loop = false;
-            for (Iterator<TryCatchBlockNode> it = tryCatchBlocks.iterator(); it
-                    .hasNext();) {
-                TryCatchBlockNode trycatch = it.next();
-
+            for (TryCatchBlockNode trycatch : tryCatchBlocks) {
                 if (LOGGING) {
                     // TODO use of default toString().
                     log("Scanning try/catch " + trycatch);
@@ -507,10 +503,7 @@ public class JSRInlinerAdapter extends MethodNode implements Opcodes {
         }
 
         // Emit try/catch blocks that are relevant to this method.
-        for (Iterator<TryCatchBlockNode> it = tryCatchBlocks.iterator(); it
-                .hasNext();) {
-            TryCatchBlockNode trycatch = it.next();
-
+        for (TryCatchBlockNode trycatch : tryCatchBlocks) {
             if (LOGGING) {
                 // TODO use of default toString().
                 log("try catch block original labels=" + trycatch.start + '-'
@@ -544,9 +537,7 @@ public class JSRInlinerAdapter extends MethodNode implements Opcodes {
                     trycatch.type));
         }
 
-        for (Iterator<LocalVariableNode> it = localVariables.iterator(); it
-                .hasNext();) {
-            LocalVariableNode lvnode = it.next();
+        for (LocalVariableNode lvnode : localVariables) {
             if (LOGGING) {
                 log("local var " + lvnode.name);
             }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/LocalVariablesSorter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/LocalVariablesSorter.java
@@ -113,8 +113,8 @@ public class LocalVariablesSorter extends MethodVisitor {
         super(api, mv);
         Type[] args = Type.getArgumentTypes(desc);
         nextLocal = (Opcodes.ACC_STATIC & access) == 0 ? 1 : 0;
-        for (int i = 0; i < args.length; i++) {
-            nextLocal += args[i].getSize();
+        for (Type arg : args) {
+            nextLocal += arg.getSize();
         }
         firstLocal = nextLocal;
     }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/Remapper.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/Remapper.java
@@ -119,8 +119,8 @@ public abstract class Remapper {
 
         Type[] args = Type.getArgumentTypes(desc);
         StringBuffer s = new StringBuffer("(");
-        for (int i = 0; i < args.length; i++) {
-            s.append(mapDesc(args[i].getDescriptor()));
+        for (Type arg : args) {
+            s.append(mapDesc(arg.getDescriptor()));
         }
         Type returnType = Type.getReturnType(desc);
         if (returnType == Type.VOID_TYPE) {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/SerialVersionUIDAdder.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/commons/SerialVersionUIDAdder.java
@@ -370,8 +370,8 @@ public class SerialVersionUIDAdder extends ClassVisitor {
              * encoding.
              */
             Arrays.sort(interfaces);
-            for (int i = 0; i < interfaces.length; i++) {
-                dos.writeUTF(interfaces[i].replace('/', '.'));
+            for (String anInterface : interfaces) {
+                dos.writeUTF(anInterface.replace('/', '.'));
             }
 
             /*

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/AnnotationConstantsCollector.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/AnnotationConstantsCollector.java
@@ -66,43 +66,43 @@ public class AnnotationConstantsCollector extends AnnotationVisitor {
             cp.newUTF8(((Type) value).getDescriptor());
         } else if (value instanceof byte[]) {
             byte[] v = (byte[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newInteger(v[i]);
+            for (byte aV : v) {
+                cp.newInteger(aV);
             }
         } else if (value instanceof boolean[]) {
             boolean[] v = (boolean[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newInteger(v[i] ? 1 : 0);
+            for (boolean aV : v) {
+                cp.newInteger(aV ? 1 : 0);
             }
         } else if (value instanceof short[]) {
             short[] v = (short[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newInteger(v[i]);
+            for (short aV : v) {
+                cp.newInteger(aV);
             }
         } else if (value instanceof char[]) {
             char[] v = (char[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newInteger(v[i]);
+            for (char aV : v) {
+                cp.newInteger(aV);
             }
         } else if (value instanceof int[]) {
             int[] v = (int[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newInteger(v[i]);
+            for (int aV : v) {
+                cp.newInteger(aV);
             }
         } else if (value instanceof long[]) {
             long[] v = (long[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newLong(v[i]);
+            for (long aV : v) {
+                cp.newLong(aV);
             }
         } else if (value instanceof float[]) {
             float[] v = (float[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newFloat(v[i]);
+            for (float aV : v) {
+                cp.newFloat(aV);
             }
         } else if (value instanceof double[]) {
             double[] v = (double[]) value;
-            for (int i = 0; i < v.length; i++) {
-                cp.newDouble(v[i]);
+            for (double aV : v) {
+                cp.newDouble(aV);
             }
         } else {
             cp.newConst(value);

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/ClassConstantsCollector.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/ClassConstantsCollector.java
@@ -70,8 +70,8 @@ public class ClassConstantsCollector extends ClassVisitor {
             cp.newClass(superName);
         }
         if (interfaces != null) {
-            for (int i = 0; i < interfaces.length; ++i) {
-                cp.newClass(interfaces[i]);
+            for (String anInterface : interfaces) {
+                cp.newClass(anInterface);
             }
         }
         cv.visit(version, access, name, signature, superName, interfaces);
@@ -174,8 +174,8 @@ public class ClassConstantsCollector extends ClassVisitor {
         }
         if (exceptions != null) {
             cp.newUTF8("Exceptions");
-            for (int i = 0; i < exceptions.length; ++i) {
-                cp.newClass(exceptions[i]);
+            for (String exception : exceptions) {
+                cp.newClass(exception);
             }
         }
         return new MethodConstantsCollector(cv.visitMethod(access, name, desc,

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/Constant.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/Constant.java
@@ -225,8 +225,8 @@ class Constant {
         this.objVals = bsmArgs;
 
         int hashCode = 'y' + name.hashCode() * desc.hashCode() * bsm.hashCode();
-        for (int i = 0; i < bsmArgs.length; i++) {
-            hashCode *= bsmArgs[i].hashCode();
+        for (Object bsmArg : bsmArgs) {
+            hashCode *= bsmArg.hashCode();
         }
         this.hashCode = 0x7FFFFFFF & hashCode;
     }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/ConstantPool.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/ConstantPool.java
@@ -218,8 +218,8 @@ public class ConstantPool extends HashMap<Constant, Constant> {
             newNameType(name, desc);
             newHandle(bsm.getTag(), bsm.getOwner(), bsm.getName(),
                     bsm.getDesc());
-            for (int i = 0; i < bsmArgs.length; i++) {
-                newConst(bsmArgs[i]);
+            for (Object bsmArg : bsmArgs) {
+                newConst(bsmArg);
             }
             result = new Constant(key5);
             put(result);

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/JarOptimizer.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/JarOptimizer.java
@@ -99,8 +99,8 @@ public class JarOptimizer {
 
         if (f.isDirectory()) {
             File[] files = f.listFiles();
-            for (int i = 0; i < files.length; ++i) {
-                optimize(files[i]);
+            for (File file : files) {
+                optimize(file);
             }
         } else if (f.getName().endsWith(".jar")) {
             File g = new File(f.getParentFile(), f.getName() + ".new");

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/Shrinker.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/optimizer/Shrinker.java
@@ -100,8 +100,8 @@ public class Shrinker {
             throws IOException {
         if (f.isDirectory()) {
             File[] files = f.listFiles();
-            for (int i = 0; i < files.length; ++i) {
-                optimize(files[i], d, remapper);
+            for (File file : files) {
+                optimize(file, d, remapper);
             }
         } else if (f.getName().endsWith(".class")) {
             ConstantPool cp = new ConstantPool();

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/AnnotationNode.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/AnnotationNode.java
@@ -213,8 +213,8 @@ public class AnnotationNode extends AnnotationVisitor {
             } else if (value instanceof List) {
                 AnnotationVisitor v = av.visitArray(name);
                 List<?> array = (List<?>) value;
-                for (int j = 0; j < array.size(); ++j) {
-                    accept(v, null, array.get(j));
+                for (Object anArray : array) {
+                    accept(v, null, anArray);
                 }
                 v.visitEnd();
             } else {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/LookupSwitchInsnNode.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/LookupSwitchInsnNode.java
@@ -80,8 +80,8 @@ public class LookupSwitchInsnNode extends AbstractInsnNode {
         this.labels = new ArrayList<>(labels == null ? 0
                 : labels.length);
         if (keys != null) {
-            for (int i = 0; i < keys.length; ++i) {
-                this.keys.add(new Integer(keys[i]));
+            for (int key : keys) {
+                this.keys.add(new Integer(key));
             }
         }
         if (labels != null) {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/analysis/Analyzer.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/analysis/Analyzer.java
@@ -29,23 +29,14 @@
  */
 package org.apache.tajo.org.objectweb.asm.tree.analysis;
 
+import org.apache.tajo.org.objectweb.asm.Opcodes;
+import org.apache.tajo.org.objectweb.asm.Type;
+import org.apache.tajo.org.objectweb.asm.tree.*;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.tajo.org.objectweb.asm.Type;
-import org.apache.tajo.org.objectweb.asm.Opcodes;
-import org.apache.tajo.org.objectweb.asm.tree.AbstractInsnNode;
-import org.apache.tajo.org.objectweb.asm.tree.IincInsnNode;
-import org.apache.tajo.org.objectweb.asm.tree.InsnList;
-import org.apache.tajo.org.objectweb.asm.tree.JumpInsnNode;
-import org.apache.tajo.org.objectweb.asm.tree.LabelNode;
-import org.apache.tajo.org.objectweb.asm.tree.LookupSwitchInsnNode;
-import org.apache.tajo.org.objectweb.asm.tree.MethodNode;
-import org.apache.tajo.org.objectweb.asm.tree.TableSwitchInsnNode;
-import org.apache.tajo.org.objectweb.asm.tree.TryCatchBlockNode;
-import org.apache.tajo.org.objectweb.asm.tree.VarInsnNode;
 
 /**
  * A semantic bytecode analyzer. <i>This class does not fully check that JSR and
@@ -164,9 +155,9 @@ public class Analyzer<V extends Value> implements Opcodes {
             Type ctype = Type.getObjectType(owner);
             current.setLocal(local++, interpreter.newValue(ctype));
         }
-        for (int i = 0; i < args.length; ++i) {
-            current.setLocal(local++, interpreter.newValue(args[i]));
-            if (args[i].getSize() == 2) {
+        for (Type arg : args) {
+            current.setLocal(local++, interpreter.newValue(arg));
+            if (arg.getSize() == 2) {
                 current.setLocal(local++, interpreter.newValue(null));
             }
         }
@@ -272,8 +263,7 @@ public class Analyzer<V extends Value> implements Opcodes {
 
                 List<TryCatchBlockNode> insnHandlers = handlers[insn];
                 if (insnHandlers != null) {
-                    for (int i = 0; i < insnHandlers.size(); ++i) {
-                        TryCatchBlockNode tcb = insnHandlers.get(i);
+                    for (TryCatchBlockNode tcb : insnHandlers) {
                         Type type;
                         if (tcb.type == null) {
                             type = Type.getObjectType("java/lang/Throwable");
@@ -342,8 +332,7 @@ public class Analyzer<V extends Value> implements Opcodes {
             // calls findSubroutine recursively on exception handler successors
             List<TryCatchBlockNode> insnHandlers = handlers[insn];
             if (insnHandlers != null) {
-                for (int i = 0; i < insnHandlers.size(); ++i) {
-                    TryCatchBlockNode tcb = insnHandlers.get(i);
+                for (TryCatchBlockNode tcb : insnHandlers) {
                     findSubroutine(insns.indexOf(tcb.handler), sub, calls);
                 }
             }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/analysis/BasicVerifier.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/analysis/BasicVerifier.java
@@ -376,10 +376,10 @@ public class BasicVerifier extends BasicInterpreter {
             final List<? extends BasicValue> values) throws AnalyzerException {
         int opcode = insn.getOpcode();
         if (opcode == MULTIANEWARRAY) {
-            for (int i = 0; i < values.size(); ++i) {
-                if (!BasicValue.INT_VALUE.equals(values.get(i))) {
+            for (BasicValue value : values) {
+                if (!BasicValue.INT_VALUE.equals(value)) {
                     throw new AnalyzerException(insn, null,
-                            BasicValue.INT_VALUE, values.get(i));
+                            BasicValue.INT_VALUE, value);
                 }
             }
         } else {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/analysis/SimpleVerifier.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/tree/analysis/SimpleVerifier.java
@@ -290,8 +290,7 @@ public class SimpleVerifier extends BasicVerifier {
                 return true;
             }
             if (currentClassInterfaces != null) {
-                for (int i = 0; i < currentClassInterfaces.size(); ++i) {
-                    Type v = currentClassInterfaces.get(i);
+                for (Type v : currentClassInterfaces) {
                     if (isAssignableFrom(t, v)) {
                         return true;
                     }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/ASMifier.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/ASMifier.java
@@ -660,8 +660,8 @@ public class ASMifier extends Printer {
     public void visitTableSwitchInsn(final int min, final int max,
             final Label dflt, final Label... labels) {
         buf.setLength(0);
-        for (int i = 0; i < labels.length; ++i) {
-            declareLabel(labels[i]);
+        for (Label label : labels) {
+            declareLabel(label);
         }
         declareLabel(dflt);
 
@@ -681,8 +681,8 @@ public class ASMifier extends Printer {
     public void visitLookupSwitchInsn(final Label dflt, final int[] keys,
             final Label[] labels) {
         buf.setLength(0);
-        for (int i = 0; i < labels.length; ++i) {
-            declareLabel(labels[i]);
+        for (Label label : labels) {
+            declareLabel(label);
         }
         declareLabel(dflt);
 

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckClassAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckClassAdapter.java
@@ -214,12 +214,11 @@ public class CheckClassAdapter extends ClassVisitor {
         List<MethodNode> methods = cn.methods;
 
         List<Type> interfaces = new ArrayList<>();
-        for (Iterator<String> i = cn.interfaces.iterator(); i.hasNext();) {
-            interfaces.add(Type.getObjectType(i.next().toString()));
+        for (String anInterface : cn.interfaces) {
+            interfaces.add(Type.getObjectType(anInterface.toString()));
         }
 
-        for (int i = 0; i < methods.size(); ++i) {
-            MethodNode method = methods.get(i);
+        for (MethodNode method : methods) {
             SimpleVerifier verifier = new SimpleVerifier(
                     Type.getObjectType(cn.name), syperType, interfaces,
                     (cn.access & Opcodes.ACC_INTERFACE) != 0);

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckMethodAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckMethodAdapter.java
@@ -674,8 +674,8 @@ public class CheckMethodAdapter extends MethodVisitor {
             throw new IllegalArgumentException("invalid handle tag "
                     + bsm.getTag());
         }
-        for (int i = 0; i < bsmArgs.length; i++) {
-            checkLDCConstant(bsmArgs[i]);
+        for (Object bsmArg : bsmArgs) {
+            checkLDCConstant(bsmArg);
         }
         super.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
         ++insnCount;
@@ -744,8 +744,8 @@ public class CheckMethodAdapter extends MethodVisitor {
             checkNonDebugLabel(labels[i]);
         }
         super.visitTableSwitchInsn(min, max, dflt, labels);
-        for (int i = 0; i < labels.length; ++i) {
-            usedLabels.add(labels[i]);
+        for (Label label : labels) {
+            usedLabels.add(label);
         }
         ++insnCount;
     }
@@ -767,8 +767,8 @@ public class CheckMethodAdapter extends MethodVisitor {
         }
         super.visitLookupSwitchInsn(dflt, keys, labels);
         usedLabels.add(dflt);
-        for (int i = 0; i < labels.length; ++i) {
-            usedLabels.add(labels[i]);
+        for (Label label : labels) {
+            usedLabels.add(label);
         }
         ++insnCount;
     }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/Printer.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/Printer.java
@@ -488,8 +488,7 @@ public abstract class Printer {
      *            string lists, and so on recursively.
      */
     static void printList(final PrintWriter pw, final List<?> l) {
-        for (int i = 0; i < l.size(); ++i) {
-            Object o = l.get(i);
+        for (Object o : l) {
             if (o instanceof List) {
                 printList(pw, (List<?>) o);
             } else {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/Textifier.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/Textifier.java
@@ -245,8 +245,8 @@ public class Textifier extends Printer {
         }
         if (interfaces != null && interfaces.length > 0) {
             buf.append(" implements ");
-            for (int i = 0; i < interfaces.length; ++i) {
-                appendDescriptor(INTERNAL_NAME, interfaces[i]);
+            for (String anInterface : interfaces) {
+                appendDescriptor(INTERNAL_NAME, anInterface);
                 buf.append(' ');
             }
         }
@@ -408,8 +408,8 @@ public class Textifier extends Printer {
         appendDescriptor(METHOD_DESCRIPTOR, desc);
         if (exceptions != null && exceptions.length > 0) {
             buf.append(" throws ");
-            for (int i = 0; i < exceptions.length; ++i) {
-                appendDescriptor(INTERNAL_NAME, exceptions[i]);
+            for (String exception : exceptions) {
+                appendDescriptor(INTERNAL_NAME, exception);
                 buf.append(' ');
             }
         }
@@ -787,8 +787,7 @@ public class Textifier extends Printer {
             buf.append(" none");
         } else {
             buf.append('\n').append(tab3);
-            for (int i = 0; i < bsmArgs.length; i++) {
-                Object cst = bsmArgs[i];
+            for (Object cst : bsmArgs) {
                 if (cst instanceof String) {
                     Printer.appendString(buf, (String) cst);
                 } else if (cst instanceof Type) {

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/ASMContentHandler.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/ASMContentHandler.java
@@ -466,15 +466,13 @@ public class ASMContentHandler extends DefaultHandler implements Opcodes {
             }
 
             int n = path.lastIndexOf('/');
-            for (Iterator<String> it = lpatterns.iterator(); it.hasNext();) {
-                String pattern = it.next();
+            for (String pattern : lpatterns) {
                 if (path.substring(n).endsWith(pattern)) {
                     return rules.get(pattern);
                 }
             }
 
-            for (Iterator<String> it = rpatterns.iterator(); it.hasNext();) {
-                String pattern = it.next();
+            for (String pattern : rpatterns) {
                 if (path.startsWith(pattern)) {
                     return rules.get(pattern);
                 }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/SAXAnnotationAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/SAXAnnotationAdapter.java
@@ -88,50 +88,50 @@ public final class SAXAnnotationAdapter extends AnnotationVisitor {
             AnnotationVisitor av = visitArray(name);
             if (value instanceof byte[]) {
                 byte[] b = (byte[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, new Byte(b[i]));
+                for (byte aB : b) {
+                    av.visit(null, new Byte(aB));
                 }
 
             } else if (value instanceof char[]) {
                 char[] b = (char[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, new Character(b[i]));
+                for (char aB : b) {
+                    av.visit(null, new Character(aB));
                 }
 
             } else if (value instanceof short[]) {
                 short[] b = (short[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, new Short(b[i]));
+                for (short aB : b) {
+                    av.visit(null, new Short(aB));
                 }
 
             } else if (value instanceof boolean[]) {
                 boolean[] b = (boolean[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, Boolean.valueOf(b[i]));
+                for (boolean aB : b) {
+                    av.visit(null, Boolean.valueOf(aB));
                 }
 
             } else if (value instanceof int[]) {
                 int[] b = (int[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, new Integer(b[i]));
+                for (int aB : b) {
+                    av.visit(null, new Integer(aB));
                 }
 
             } else if (value instanceof long[]) {
                 long[] b = (long[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, new Long(b[i]));
+                for (long aB : b) {
+                    av.visit(null, new Long(aB));
                 }
 
             } else if (value instanceof float[]) {
                 float[] b = (float[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, new Float(b[i]));
+                for (float aB : b) {
+                    av.visit(null, new Float(aB));
                 }
 
             } else if (value instanceof double[]) {
                 double[] b = (double[]) value;
-                for (int i = 0; i < b.length; i++) {
-                    av.visit(null, new Double(b[i]));
+                for (double aB : b) {
+                    av.visit(null, new Double(aB));
                 }
 
             }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/SAXClassAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/SAXClassAdapter.java
@@ -150,9 +150,9 @@ public final class SAXClassAdapter extends ClassVisitor {
 
         sa.addStart("interfaces", new AttributesImpl());
         if (interfaces != null && interfaces.length > 0) {
-            for (int i = 0; i < interfaces.length; i++) {
+            for (String anInterface : interfaces) {
                 AttributesImpl att2 = new AttributesImpl();
-                att2.addAttribute("", "name", "name", "", interfaces[i]);
+                att2.addAttribute("", "name", "name", "", anInterface);
                 sa.addElement("interface", att2);
             }
         }
@@ -197,9 +197,9 @@ public final class SAXClassAdapter extends ClassVisitor {
 
         sa.addStart("exceptions", new AttributesImpl());
         if (exceptions != null && exceptions.length > 0) {
-            for (int i = 0; i < exceptions.length; i++) {
+            for (String exception : exceptions) {
                 AttributesImpl att2 = new AttributesImpl();
-                att2.addAttribute("", "name", "name", "", exceptions[i]);
+                att2.addAttribute("", "name", "name", "", exception);
                 sa.addElement("exception", att2);
             }
         }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/SAXCodeAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/xml/SAXCodeAdapter.java
@@ -193,8 +193,8 @@ public final class SAXCodeAdapter extends MethodVisitor {
         attrs.addAttribute("", "bsm", "bsm", "",
                 SAXClassAdapter.encode(bsm.toString()));
         sa.addStart("INVOKEDYNAMIC", attrs);
-        for (int i = 0; i < bsmArgs.length; i++) {
-            sa.addElement("bsmArg", getConstantAttribute(bsmArgs[i]));
+        for (Object bsmArg : bsmArgs) {
+            sa.addElement("bsmArg", getConstantAttribute(bsmArg));
         }
         sa.addEnd("INVOKEDYNAMIC");
     }
@@ -244,9 +244,9 @@ public final class SAXCodeAdapter extends MethodVisitor {
         attrs.addAttribute("", "dflt", "dflt", "", getLabel(dflt));
         String o = Printer.OPCODES[Opcodes.TABLESWITCH];
         sa.addStart(o, attrs);
-        for (int i = 0; i < labels.length; i++) {
+        for (Label label : labels) {
             AttributesImpl att2 = new AttributesImpl();
-            att2.addAttribute("", "name", "name", "", getLabel(labels[i]));
+            att2.addAttribute("", "name", "name", "", getLabel(label));
             sa.addElement("label", att2);
         }
         sa.addEnd(o);


### PR DESCRIPTION
Reports for loops which iterate over collections or arrays, and can be replaced with the foreach iteration syntax, available in Java 5 and newer, to get the improvement of readability and so on.