### PR TITLE
TAJO-1978: Printout message before terminating TSQL

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/ExitCommand.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/ExitCommand.java
@@ -37,7 +37,7 @@ public class ExitCommand extends TajoShellCommand {
   @Override
   public void invoke(String[] cmd) throws Exception {
     context.getOutput().println("bye!");
-    context.getOutput().flush();
+    context.getOutput().close();
     System.exit(0);
   }
 

--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/ExitCommand.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/ExitCommand.java
@@ -37,6 +37,7 @@ public class ExitCommand extends TajoShellCommand {
   @Override
   public void invoke(String[] cmd) throws Exception {
     context.getOutput().println("bye!");
+    context.getOutput().flush();
     System.exit(0);
   }
 


### PR DESCRIPTION
In ExitCommand::invoke, the code line is written that printout "bye!" before terminating. But, There is no sout.flush() before exit(0) so that message is not shown.