### PR TITLE
TAJO-1980: Printout the usage of TajoShellCommand

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/TajoShellCommand.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/TajoShellCommand.java
@@ -35,6 +35,7 @@ public abstract class TajoShellCommand {
 
   public void printHelp() {
     context.getOutput().print(getCommand());
+    context.getOutput().print(" " + getUsage());
     context.getOutput().print(" - ");
     context.getOutput().println(getDescription());
   }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -564,7 +564,7 @@ public class TestTajoCli {
   }
 
   @Test
-  public void testHelpCommand() throws IOException, NoSuchMethodException {
+  public void testDefaultPrintHelp() throws IOException, NoSuchMethodException {
     Iterator i = tajoCli.getContext().getCommands().keySet().iterator();
 
     while (i.hasNext()) {

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -46,6 +46,7 @@ import org.junit.rules.TestName;
 
 import java.io.*;
 import java.net.URL;
+import java.util.Iterator;
 import java.util.Properties;
 
 import static org.junit.Assert.*;
@@ -559,6 +560,28 @@ public class TestTajoCli {
     @Override
     public void printProgress(PrintWriter sout, QueryStatus status) {
       //nothing to do
+    }
+  }
+
+  @Test
+  public void testHelpCommand() throws IOException, NoSuchMethodException {
+    Iterator i = tajoCli.getContext().getCommands().keySet().iterator();
+
+    while (i.hasNext()) {
+      String command = i.next().toString();
+
+      if (tajoCli.getContext().getCommands().get(command).getClass().getMethod("printHelp")
+              .getDeclaringClass().toString().equals("class org.apache.tajo.cli.tsql.commands.TajoShellCommand")) {
+        tajoCli.executeMetaCommand("\\help " + command.replace("\\", ""));
+        String result = new String(out.toByteArray());
+        out.reset();
+
+        String expected = tajoCli.getContext().getCommands().get(command).getCommand()
+                + " " + tajoCli.getContext().getCommands().get(command).getUsage()
+                + " - " + tajoCli.getContext().getCommands().get(command).getDescription() + "\n";
+
+        assertEquals(result, expected);
+      }
     }
   }
 }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -567,15 +567,16 @@ public class TestTajoCli {
   @Test
   public void testDefaultPrintHelp() throws IOException, NoSuchMethodException {
     for (Map.Entry<String, TajoShellCommand> entry : tajoCli.getContext().getCommands().entrySet()) {
-      if (entry.getValue().getClass().getMethod("printHelp").getDeclaringClass().toString()
-              .equals("class org.apache.tajo.cli.tsql.commands.TajoShellCommand")) {
+      TajoShellCommand shellCommand = entry.getValue();
+
+      if (!shellCommand.getClass().getMethod("printHelp").getDeclaringClass().equals(shellCommand.getClass())) {
         tajoCli.executeMetaCommand("\\help " + entry.getKey().replace("\\", ""));
         String result = new String(out.toByteArray());
         out.reset();
 
-        String expected = entry.getValue().getCommand()
-                + " " + entry.getValue().getUsage()
-                + " - " + entry.getValue().getDescription() + "\n";
+        String expected = shellCommand.getCommand()
+                + " " + shellCommand.getUsage()
+                + " - " + shellCommand.getDescription() + "\n";
 
         assertEquals(result, expected);
       }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -30,6 +30,7 @@ import org.apache.tajo.TajoTestingCluster;
 import org.apache.tajo.TpchTestBase;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.TableDesc;
+import org.apache.tajo.cli.tsql.commands.TajoShellCommand;
 import org.apache.tajo.client.ClientParameters;
 import org.apache.tajo.client.QueryStatus;
 import org.apache.tajo.client.TajoClient;
@@ -46,7 +47,7 @@ import org.junit.rules.TestName;
 
 import java.io.*;
 import java.net.URL;
-import java.util.Iterator;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.*;
@@ -565,20 +566,16 @@ public class TestTajoCli {
 
   @Test
   public void testDefaultPrintHelp() throws IOException, NoSuchMethodException {
-    Iterator i = tajoCli.getContext().getCommands().keySet().iterator();
-
-    while (i.hasNext()) {
-      String command = i.next().toString();
-
-      if (tajoCli.getContext().getCommands().get(command).getClass().getMethod("printHelp")
-              .getDeclaringClass().toString().equals("class org.apache.tajo.cli.tsql.commands.TajoShellCommand")) {
-        tajoCli.executeMetaCommand("\\help " + command.replace("\\", ""));
+    for (Map.Entry<String, TajoShellCommand> entry : tajoCli.getContext().getCommands().entrySet()) {
+      if (entry.getValue().getClass().getMethod("printHelp").getDeclaringClass().toString()
+              .equals("class org.apache.tajo.cli.tsql.commands.TajoShellCommand")) {
+        tajoCli.executeMetaCommand("\\help " + entry.getKey().replace("\\", ""));
         String result = new String(out.toByteArray());
         out.reset();
 
-        String expected = tajoCli.getContext().getCommands().get(command).getCommand()
-                + " " + tajoCli.getContext().getCommands().get(command).getUsage()
-                + " - " + tajoCli.getContext().getCommands().get(command).getDescription() + "\n";
+        String expected = entry.getValue().getCommand()
+                + " " + entry.getValue().getUsage()
+                + " - " + entry.getValue().getDescription() + "\n";
 
         assertEquals(result, expected);
       }


### PR DESCRIPTION
```TajoShellCommand::getUsage()``` is designed for ```TajoShellCommand::printHelp()``` to printout detailed-usage like ```TajoShellCommand::getDescription()```. But, Currently, It's omitted in ```TajoShellCommand::printHelp()```, so ```TajoShellCommand::getUsage()``` has no usage.