### PR TITLE
TAJO-1981: Invalid nulls sort order in VectorizedSorter

### DIFF
--- a/tajo-algebra/src/main/java/org/apache/tajo/algebra/Sort.java
+++ b/tajo-algebra/src/main/java/org/apache/tajo/algebra/Sort.java
@@ -71,8 +71,8 @@ public class Sort extends UnaryOperator {
     private Expr key;
     @Expose @SerializedName("IsAsc")
     private boolean asc = true;
-    @Expose @SerializedName("IsNullFirst")
-    private boolean nullFirst = false;
+    @Expose @SerializedName("IsNullsFirst")
+    private Boolean nullsFirst = null;
 
     public SortSpec(final Expr key) {
       this.key = key;
@@ -82,14 +82,14 @@ public class Sort extends UnaryOperator {
      *
      * @param sortKey a column to sort
      * @param asc true if the sort order is ascending order
-     * @param nullFirst
+     * @param nullsFirst
      * Otherwise, it should be false.
      */
     public SortSpec(final ColumnReferenceExpr sortKey, final boolean asc,
-                    final boolean nullFirst) {
+                    final boolean nullsFirst) {
       this(sortKey);
       this.asc = asc;
-      this.nullFirst = nullFirst;
+      this.nullsFirst = nullsFirst;
     }
 
     public final boolean isAscending() {
@@ -100,12 +100,20 @@ public class Sort extends UnaryOperator {
       this.asc = false;
     }
 
-    public final boolean isNullFirst() {
-      return this.nullFirst;
+    public final boolean isNullsFirst() {
+      if (nullsFirst == null) {
+        return !asc; // nulls last for asc, nulls first for desc
+      } else {
+        return nullsFirst;
+      }
     }
 
-    public final void setNullFirst() {
-      this.nullFirst = true;
+    public final void setNullsFirst() {
+      this.nullsFirst = true;
+    }
+
+    public final void setNullsLast() {
+      this.nullsFirst = false;
     }
 
     public void setKey(Expr expr) {
@@ -118,7 +126,7 @@ public class Sort extends UnaryOperator {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(asc, key, nullFirst);
+      return Objects.hashCode(asc, key, nullsFirst);
     }
 
     @Override
@@ -127,14 +135,14 @@ public class Sort extends UnaryOperator {
         SortSpec other = (SortSpec) obj;
         return TUtil.checkEquals(key, other.key) &&
             TUtil.checkEquals(asc, other.asc) &&
-            TUtil.checkEquals(nullFirst, other.nullFirst);
+            TUtil.checkEquals(nullsFirst, other.nullsFirst);
       }
       return false;
     }
 
     @Override
     public String toString() {
-      return key + " " + (asc ? "asc" : "desc") + " " + (nullFirst ? "null first" :"");
+      return key + " " + (asc ? "asc" : "desc") + " " + (nullsFirst ? "nulls first" : "nulls last");
     }
 
     @Override
@@ -142,7 +150,7 @@ public class Sort extends UnaryOperator {
       SortSpec sortSpec = (SortSpec) super.clone();
       sortSpec.key = (Expr) key.clone();
       sortSpec.asc = asc;
-      sortSpec.nullFirst = nullFirst;
+      sortSpec.nullsFirst = nullsFirst;
       return sortSpec;
     }
   }

--- a/tajo-algebra/src/main/java/org/apache/tajo/algebra/Sort.java
+++ b/tajo-algebra/src/main/java/org/apache/tajo/algebra/Sort.java
@@ -72,6 +72,8 @@ public class Sort extends UnaryOperator {
     @Expose @SerializedName("IsAsc")
     private boolean asc = true;
     @Expose @SerializedName("IsNullsFirst")
+    // The default value for nulls order is decided based on the sort order.
+    // That is, nulls appear at the bottom with asc and the top with desc.
     private Boolean nullsFirst = null;
 
     public SortSpec(final Expr key) {
@@ -102,7 +104,7 @@ public class Sort extends UnaryOperator {
 
     public final boolean isNullsFirst() {
       if (nullsFirst == null) {
-        return !asc; // nulls last for asc, nulls first for desc
+        return !asc;
       } else {
         return nullsFirst;
       }
@@ -142,7 +144,7 @@ public class Sort extends UnaryOperator {
 
     @Override
     public String toString() {
-      return key + " " + (asc ? "asc" : "desc") + " " + (nullsFirst ? "nulls first" : "nulls last");
+      return key + " " + (asc ? "asc" : "desc") + " " + (isNullsFirst() ? "nulls first" : "nulls last");
     }
 
     @Override

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/DDLBuilder.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/DDLBuilder.java
@@ -88,7 +88,7 @@ public class DDLBuilder {
     for (SortSpec sortSpec : desc.getKeySortSpecs()) {
       sb.append(sortSpec.getSortKey().getQualifiedName()).append(" ");
       sb.append(sortSpec.isAscending() ? "asc" : "desc").append(" ");
-      sb.append(sortSpec.isNullFirst() ? "null first" : "null last").append(", ");
+      sb.append(sortSpec.isNullsFirst() ? "null first" : "null last").append(", ");
     }
     sb.replace(sb.length() - 2, sb.length() - 1, " )");
 

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/IndexMeta.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/IndexMeta.java
@@ -64,7 +64,7 @@ public class IndexMeta implements Cloneable {
     this.keySortSpecs = new SortSpec[keySortSpecs.length];
     for (int i = 0; i < keySortSpecs.length; i++) {
       this.keySortSpecs[i] = new SortSpec(keySortSpecs[i].getSortKey(), keySortSpecs[i].isAscending(),
-          keySortSpecs[i].isNullFirst());
+          keySortSpecs[i].isNullsFirst());
     }
     Arrays.sort(this.keySortSpecs, new Comparator<SortSpec>() {
       @Override

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SortSpec.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SortSpec.java
@@ -30,7 +30,7 @@ import static org.apache.tajo.catalog.proto.CatalogProtos.SortSpecProto;
 public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProto> {
   @Expose private Column sortKey;
   @Expose private boolean ascending = true;
-  @Expose private boolean nullFirst = false;
+  @Expose private boolean nullsFirst = false;
 
   public SortSpec(final Column sortKey) {
     this.sortKey = sortKey;
@@ -40,19 +40,19 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
    *
    * @param sortKey columns to sort
    * @param asc true if the sort order is ascending order
-   * @param nullFirst
+   * @param nullsFirst
    * Otherwise, it should be false.
    */
-  public SortSpec(final Column sortKey, final boolean asc, final boolean nullFirst) {
+  public SortSpec(final Column sortKey, final boolean asc, final boolean nullsFirst) {
     this(sortKey);
     this.ascending = asc;
-    this.nullFirst = nullFirst;
+    this.nullsFirst = nullsFirst;
   }
 
   public SortSpec(SortSpecProto sortSpec) {
     this.sortKey = new Column(sortSpec.getColumn());
     this.ascending = sortSpec.getAscending();
-    this.nullFirst = sortSpec.getNullFirst();
+    this.nullsFirst = sortSpec.getNullFirst();
   }
 
   public final boolean isAscending() {
@@ -63,12 +63,12 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
     this.ascending = false;
   }
 
-  public final boolean isNullFirst() {
-    return this.nullFirst;
+  public final boolean isNullsFirst() {
+    return this.nullsFirst;
   }
 
-  public final void setNullFirst() {
-    this.nullFirst = true;
+  public final void setNullsFirst() {
+    this.nullsFirst = true;
   }
 
   public final Column getSortKey() {
@@ -80,14 +80,14 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
     SortSpec key = (SortSpec) super.clone();
     key.sortKey = sortKey;
     key.ascending = ascending;
-    key.nullFirst = nullFirst;
+    key.nullsFirst = nullsFirst;
 
     return key;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(Objects.hashCode(sortKey), ascending, nullFirst);
+    return Objects.hashCode(Objects.hashCode(sortKey), ascending, nullsFirst);
   }
 
   @Override
@@ -96,7 +96,7 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
       SortSpec other = (SortSpec) object;
       return sortKey.equals(other.sortKey) &&
           ascending == other.ascending &&
-          nullFirst == other.nullFirst;
+          nullsFirst == other.nullsFirst;
     } else {
       return false;
     }
@@ -108,7 +108,7 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
   }
 
   public String toString() {
-    return sortKey + " ("+(ascending ? "asc" : "desc")+")";
+    return sortKey + " ("+(ascending ? "asc" : "desc") + ", " + (nullsFirst ? "nulls first" : "nulls last") +")";
   }
 
   @Override
@@ -116,7 +116,7 @@ public class SortSpec implements Cloneable, GsonObject, ProtoObject<SortSpecProt
     SortSpecProto.Builder builder = SortSpecProto.newBuilder();
     builder.setColumn(sortKey.getProto());
     builder.setAscending(ascending);
-    builder.setNullFirst(nullFirst);
+    builder.setNullFirst(nullsFirst);
     return builder.build();
   }
 }

--- a/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestIndexDesc.java
+++ b/tajo-catalog/tajo-catalog-common/src/test/java/org/apache/tajo/catalog/TestIndexDesc.java
@@ -79,7 +79,7 @@ public class TestIndexDesc {
     assertEquals(1, desc1.getKeySortSpecs().length);
     assertEquals(new Column("id", Type.INT4), desc1.getKeySortSpecs()[0].getSortKey());
     assertEquals(true, desc1.getKeySortSpecs()[0].isAscending());
-    assertEquals(true, desc1.getKeySortSpecs()[0].isNullFirst());
+    assertEquals(true, desc1.getKeySortSpecs()[0].isNullsFirst());
     assertEquals(IndexMethod.TWO_LEVEL_BIN_TREE, desc1.getIndexMethod());
     assertEquals(new URI("idx_test"), desc1.getIndexPath());
     assertEquals(true, desc1.isUnique());
@@ -90,7 +90,7 @@ public class TestIndexDesc {
     assertEquals(1, desc2.getKeySortSpecs().length);
     assertEquals(new Column("score", Type.FLOAT8), desc2.getKeySortSpecs()[0].getSortKey());
     assertEquals(false, desc2.getKeySortSpecs()[0].isAscending());
-    assertEquals(false, desc2.getKeySortSpecs()[0].isNullFirst());
+    assertEquals(false, desc2.getKeySortSpecs()[0].isNullsFirst());
     assertEquals(IndexMethod.TWO_LEVEL_BIN_TREE, desc2.getIndexMethod());
     assertEquals(new URI("idx_test2"), desc2.getIndexPath());
     assertEquals(false, desc2.isUnique());

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -2532,7 +2532,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
         columnNamesBuilder.append(columnSpec.getSortKey().getSimpleName()).append(",");
         dataTypesBuilder.append(columnSpec.getSortKey().getDataType().getType().name()).append(",");
         ordersBuilder.append(columnSpec.isAscending()).append(",");
-        nullOrdersBuilder.append(columnSpec.isNullFirst()).append(",");
+        nullOrdersBuilder.append(columnSpec.isNullsFirst()).append(",");
       }
       columnNamesBuilder.deleteCharAt(columnNamesBuilder.length()-1);
       dataTypesBuilder.deleteCharAt(dataTypesBuilder.length()-1);

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSortQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSortQuery.java
@@ -299,6 +299,62 @@ public class TestSortQuery extends QueryTestCaseBase {
   }
 
   @Test
+  public final void testSortOnNullColumn4() throws Exception {
+    KeyValueSet tableOptions = new KeyValueSet();
+    tableOptions.set(StorageConstants.TEXT_DELIMITER, StorageConstants.DEFAULT_FIELD_DELIMITER);
+    tableOptions.set(StorageConstants.TEXT_NULL, "\\\\N");
+
+    Schema schema = new Schema();
+    schema.addColumn("id", Type.INT4);
+    schema.addColumn("name", Type.TEXT);
+    String[] data = new String[]{ "1|111", "2|\\N", "3|333" };
+    TajoTestingCluster.createTable("testSortOnNullColumn4".toLowerCase(), schema, tableOptions, data, 1);
+
+    try {
+      ResultSet res = executeString("select * from testSortOnNullColumn4 order by name desc nulls last");
+      String ascExpected = "id,name\n" +
+          "-------------------------------\n" +
+          "3,333\n" +
+          "1,111\n" +
+          "2,null\n";
+
+      assertEquals(ascExpected, resultSetToString(res));
+      res.close();
+
+    } finally {
+      executeString("DROP TABLE testSortOnNullColumn4 PURGE");
+    }
+  }
+
+  @Test
+  public final void testSortOnNullColumn5() throws Exception {
+    KeyValueSet tableOptions = new KeyValueSet();
+    tableOptions.set(StorageConstants.TEXT_DELIMITER, StorageConstants.DEFAULT_FIELD_DELIMITER);
+    tableOptions.set(StorageConstants.TEXT_NULL, "\\\\N");
+
+    Schema schema = new Schema();
+    schema.addColumn("id", Type.INT4);
+    schema.addColumn("name", Type.TEXT);
+    String[] data = new String[]{ "1|111", "2|\\N", "3|333" };
+    TajoTestingCluster.createTable("testSortOnNullColumn5".toLowerCase(), schema, tableOptions, data, 1);
+
+    try {
+      ResultSet res = executeString("select * from testSortOnNullColumn5 order by name asc nulls first");
+      String ascExpected = "id,name\n" +
+          "-------------------------------\n" +
+          "2,null\n" +
+          "1,111\n" +
+          "3,333\n";
+
+      assertEquals(ascExpected, resultSetToString(res));
+      res.close();
+
+    } finally {
+      executeString("DROP TABLE testSortOnNullColumn5 PURGE");
+    }
+  }
+
+  @Test
   public final void testSortOnUnicodeTextAsc() throws Exception {
     try {
       testingCluster.setAllTajoDaemonConfValue(ConfVars.$TEST_MIN_TASK_NUM.varname, "2");

--- a/tajo-core-tests/src/test/resources/results/TestCaseByCases/testTAJO_1600.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCaseByCases/testTAJO_1600.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    GROUP_BY(5)(c_custkey,o_orderkey,o_orderstatus,o_orderdate)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT), default.orders.o_orderdate (TEXT)
      => out schema:{(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.region.r_name (TEXT), num=32)
 
 SORT(10)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.region.r_name (TEXT), num=32)
 
 SORT(10)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.nation.n_name (TEXT) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoin.5.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinAndCaseWhen.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk2.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.customer.c_name (TEXT), default.region.r_regionkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk3.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.customer.c_name (TEXT), default.region.r_regionkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.customer.c_name (TEXT) (asc),default.region.r_regionkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.customer.c_name (TEXT) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(11) default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -41,7 +41,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -66,7 +66,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithAsterisk4.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -70,7 +70,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    JOIN(6)(CROSS)
      => target list: ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
@@ -93,7 +93,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(2)
-  => Sort Keys: len (INT4) (asc),default.region.r_regionkey (INT4) (asc),default.region.r_name (TEXT) (asc),default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: len (INT4) (asc, nulls last),default.region.r_regionkey (INT4) (asc, nulls last),default.region.r_name (TEXT) (asc, nulls last),default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}
      => in schema: {(13) ?multiply (INT4), default.customer.c_acctbal (FLOAT8), default.customer.c_address (TEXT), default.customer.c_comment (TEXT), default.customer.c_custkey (INT4), default.customer.c_mktsegment (TEXT), default.customer.c_name (TEXT), default.customer.c_nationkey (INT4), default.customer.c_phone (TEXT), default.region.r_comment (TEXT), default.region.r_name (TEXT), default.region.r_regionkey (INT4), len (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestCrossJoin/testCrossJoinWithEmptyTable1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=default.part
 
 SORT(26)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}
      => in schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}
      => in schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=default.part
 
 SORT(26)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}
      => in schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testBroadcastTwoPartJoin.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.orders.o_custkey (INT4) = default.customer.c_custkey (INT4)
      => target list: default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.part.p_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}
      => in schema: {(3) default.lineitem.l_orderkey (INT4), default.nation.n_name (TEXT), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition2.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = name (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition3.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: ?lower_1 (TEXT) = ?lower_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testComplexJoinCondition4.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinAndCaseWhen.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}
      => in schema: {(3) cond (TEXT), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testInnerJoinWithEmptyTable.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}
      => in schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}
      => in schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}
      => in schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvals1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_regionkey (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: default.region.r_regionkey (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}
      => in schema: {(3) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Hash.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       JOIN(7)(INNER)
         => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
         => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -47,7 +47,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -78,7 +78,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
         => in schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Hash_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       JOIN(7)(INNER)
         => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
         => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -77,7 +77,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), v1 (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -105,7 +105,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
         => in schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Sort.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       JOIN(7)(INNER)
         => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
         => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -47,7 +47,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -78,7 +78,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
         => in schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs1.Sort_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       JOIN(7)(INNER)
         => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
         => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -77,7 +77,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), v1 (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.region.r_regionkey (INT4) = default.nation.n_regionkey (INT4)
      => target list: default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) / 2 as result, default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), v1 (INT4), default.region.r_regionkey (INT4) + default.nation.n_regionkey (INT4) as plus1
@@ -105,7 +105,7 @@ PROJECTION(4)
   => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), v1 (INT4)}
   => in  schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
    SORT(3)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}
         => in schema: {(5) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Hash.plan
@@ -5,7 +5,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
         => exprs: (sum(?plus (INT4)))
         => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -84,7 +84,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), v1 (INT4), num=32)
 
 SORT(14)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
      => exprs: (sum(?sum_3 (INT8)))
      => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -109,7 +109,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(15) on eb_0000000000000_0000_000004
         => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
         => in schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Hash_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
         => exprs: (sum(?plus (INT4)))
         => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -111,7 +111,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), v1 (INT4), num=32)
 
 SORT(14)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
      => exprs: (sum(?sum_3 (INT8)))
      => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -136,7 +136,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(15) on eb_0000000000000_0000_000004
         => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
         => in schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Sort.plan
@@ -5,7 +5,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
         => exprs: (sum(?plus (INT4)))
         => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -84,7 +84,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), v1 (INT4), num=32)
 
 SORT(14)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
      => exprs: (sum(?sum_3 (INT8)))
      => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -109,7 +109,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(15) on eb_0000000000000_0000_000004
         => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
         => in schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinCoReferredEvalsWithSameExprs2.Sort_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
         => exprs: (sum(?plus (INT4)))
         => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -111,7 +111,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.nation.n_regionkey (INT4), v1 (INT4), num=32)
 
 SORT(14)
-  => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+  => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
    GROUP_BY(3)(v1,n_regionkey,r_regionkey,?plus,result)
      => exprs: (sum(?sum_3 (INT8)))
      => target list: v1 (INT4), default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), ?plus (INT4) as plus1, result (INT4), total (INT8)
@@ -136,7 +136,7 @@ PROJECTION(5)
   => out schema: {(7) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), plus2 (INT4), result (INT4), total (INT8), v1 (INT4)}
   => in  schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
    SORT(4)
-     => Sort Keys: v1 (INT4) (asc),default.nation.n_regionkey (INT4) (asc)
+     => Sort Keys: v1 (INT4) (asc, nulls last),default.nation.n_regionkey (INT4) (asc, nulls last)
       SCAN(15) on eb_0000000000000_0000_000004
         => out schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}
         => in schema: {(6) default.nation.n_regionkey (INT4), default.region.r_regionkey (INT4), plus1 (INT4), result (INT4), total (INT8), v1 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=joins.supplier_
 
 SORT(26)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=joins.supplier_
 
 SORT(26)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinOnMultipleDatabases.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: joins.supplier_.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc),joins.supplier_.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),joins.part_.p_partkey (INT4) (asc)
+  => Sort Keys: joins.supplier_.s_acctbal (FLOAT8) (asc, nulls last),joins.supplier_.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),joins.part_.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), joins.part_.p_mfgr (TEXT), joins.part_.p_partkey (INT4), joins.supplier_.s_acctbal (FLOAT8), joins.supplier_.s_address (TEXT), joins.supplier_.s_comment (TEXT), joins.supplier_.s_name (TEXT), joins.supplier_.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=default.s
 
 SORT(26)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}
      => in schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.n.n_name (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}
      => in schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=default.s
 
 SORT(26)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}
      => in schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithMultipleJoinQual1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.n.n_name (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: (default.n.n_regionkey (INT4) = default.ps.ps_suppkey (INT4) AND default.s.s_nationkey (INT4) = default.n.n_nationkey (INT4))
      => target list: default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(10)
-  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc),default.s.s_name (TEXT) (asc),default.n.n_name (TEXT) (asc),default.p.p_partkey (INT4) (asc)
+  => Sort Keys: default.s.s_acctbal (FLOAT8) (asc, nulls last),default.s.s_name (TEXT) (asc, nulls last),default.n.n_name (TEXT) (asc, nulls last),default.p.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}
      => in schema: {(8) default.n.n_name (TEXT), default.p.p_mfgr (TEXT), default.p.p_partkey (INT4), default.s.s_acctbal (FLOAT8), default.s.s_address (TEXT), default.s.s_comment (TEXT), default.s.s_name (TEXT), default.s.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Hash.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SELECTION(2)
         => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
          JOIN(7)(INNER)
@@ -48,7 +48,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(11)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SELECTION(2)
      => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
       JOIN(7)(INNER)
@@ -80,7 +80,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
         => in schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Hash_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SELECTION(2)
         => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
          JOIN(7)(INNER)
@@ -77,7 +77,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SELECTION(2)
      => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
       JOIN(7)(INNER)
@@ -107,7 +107,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
         => in schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Sort.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SELECTION(2)
         => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
          JOIN(7)(INNER)
@@ -48,7 +48,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(11)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SELECTION(2)
      => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
       JOIN(7)(INNER)
@@ -80,7 +80,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
         => in schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testJoinWithOrPredicates.Sort_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SELECTION(2)
         => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
          JOIN(7)(INNER)
@@ -77,7 +77,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SELECTION(2)
      => Search Cond: (default.n1.n_nationkey (INT4) IN (1, 2) OR default.n2.n_nationkey (INT4) IN (2))
       JOIN(7)(INNER)
@@ -107,7 +107,7 @@ PROJECTION(4)
   => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
   => in  schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
    SORT(3)
-     => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+     => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
       SCAN(12) on eb_0000000000000_0000_000003
         => out schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}
         => in schema: {(4) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), default.n2.n_nationkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}
      => in schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n2.n_name (TEXT), num=32)
 
 SORT(10)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}
      => in schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.n1
 
 SORT(10)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}
      => in schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testNaturalJoin.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n2.n_name (TEXT), num=32)
 
 SORT(10)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: (default.n1.n_comment (TEXT) = default.n2.n_comment (TEXT) AND (default.n1.n_name (TEXT) = default.n2.n_name (TEXT) AND (default.n1.n_nationkey (INT4) = default.n2.n_nationkey (INT4) AND default.n1.n_regionkey (INT4) = default.n2.n_regionkey (INT4))))
      => target list: default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}
      => in schema: {(2) default.n1.n_name (TEXT), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=default.supplier
 
 SORT(26)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000009 [LEAF]
  3: type=Broadcast, tables=default.supplier
 
 SORT(26)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testTPCHQ2Join.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -215,7 +215,7 @@ Block Id: eb_0000000000000_0000_000009 [INTERMEDIATE]
 [q_0000000000000_0000] 9 => 10 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT), num=32)
 
 SORT(26)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(16)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)
@@ -239,7 +239,7 @@ Block Id: eb_0000000000000_0000_000010 [ROOT]
  0: sorted input=eb_0000000000000_0000_000009
 
 SORT(6)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.nation.n_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(27) on eb_0000000000000_0000_000009
      => out schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}
      => in schema: {(8) default.nation.n_name (TEXT), default.part.p_mfgr (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_address (TEXT), default.supplier.s_comment (TEXT), default.supplier.s_name (TEXT), default.supplier.s_phone (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin2.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(2) default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin3.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.region.r_name (TEXT), p1 (INT4), p2 (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.region
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin4.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), num=32)
 
 SORT(11)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(7)(INNER)
      => Join Cond: default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.nation.n_name (TEXT), default.region.r_name (TEXT), default.nation.n_nationkey (INT4) + default.region.r_regionkey (INT4) as ?plus
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}
      => in schema: {(3) ?plus (INT4), default.nation.n_name (TEXT), default.region.r_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -52,7 +52,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.supplier
 
 SORT(16)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(17) on eb_0000000000000_0000_000005
      => out schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT), num=32)
 
 SORT(16)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(17) on eb_0000000000000_0000_000005
      => out schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -52,7 +52,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.supplier
 
 SORT(16)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(17) on eb_0000000000000_0000_000005
      => out schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin5.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT), num=32)
 
 SORT(16)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    JOIN(10)(INNER)
      => Join Cond: default.part.p_partkey (INT4) = default.partsupp.ps_partkey (INT4)
      => target list: default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(4)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last)
    SCAN(17) on eb_0000000000000_0000_000005
      => out schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(3) default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -62,7 +62,7 @@ Block Id: eb_0000000000000_0000_000007 [LEAF]
  2: type=Broadcast, tables=default.supplier
 
 SORT(21)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -106,7 +106,7 @@ Block Id: eb_0000000000000_0000_000008 [ROOT]
  0: sorted input=eb_0000000000000_0000_000007
 
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000007
      => out schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -167,7 +167,7 @@ Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]
 [q_0000000000000_0000] 7 => 8 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT), num=32)
 
 SORT(21)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -191,7 +191,7 @@ Block Id: eb_0000000000000_0000_000008 [ROOT]
  0: sorted input=eb_0000000000000_0000_000007
 
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000007
      => out schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -62,7 +62,7 @@ Block Id: eb_0000000000000_0000_000007 [LEAF]
  2: type=Broadcast, tables=default.supplier
 
 SORT(21)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -106,7 +106,7 @@ Block Id: eb_0000000000000_0000_000008 [ROOT]
  0: sorted input=eb_0000000000000_0000_000007
 
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000007
      => out schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinQuery/testWhereClauseJoin6.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -167,7 +167,7 @@ Block Id: eb_0000000000000_0000_000007 [INTERMEDIATE]
 [q_0000000000000_0000] 7 => 8 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT), num=32)
 
 SORT(21)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(13)(INNER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)
@@ -191,7 +191,7 @@ Block Id: eb_0000000000000_0000_000008 [ROOT]
  0: sorted input=eb_0000000000000_0000_000007
 
 SORT(5)
-  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc),default.supplier.s_name (TEXT) (asc),default.part.p_partkey (INT4) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.supplier.s_acctbal (FLOAT8) (asc, nulls last),default.supplier.s_name (TEXT) (asc, nulls last),default.part.p_partkey (INT4) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000007
      => out schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}
      => in schema: {(4) default.nation.n_name (TEXT), default.part.p_partkey (INT4), default.supplier.s_acctbal (FLOAT8), default.supplier.s_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -56,7 +56,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.part
 
 SORT(18)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000005
      => out schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}
      => in schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -131,7 +131,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT), num=32)
 
 SORT(18)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -155,7 +155,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000005
      => out schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}
      => in schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -56,7 +56,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.part
 
 SORT(18)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000005
      => out schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}
      => in schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testBroadcastSubquery.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -131,7 +131,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT), num=32)
 
 SORT(18)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    JOIN(12)(INNER)
      => Join Cond: default.lineitem.l_orderkey (INT4) = default.a.o_orderkey (INT4)
      => target list: default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)
@@ -155,7 +155,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(6)
-  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc),default.a.o_custkey (INT4) (asc),default.part.p_name (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_orderkey (INT4) (asc, nulls last),default.a.o_custkey (INT4) (asc, nulls last),default.part.p_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000005
      => out schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}
      => in schema: {(3) default.a.o_custkey (INT4), default.lineitem.l_orderkey (INT4), default.part.p_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -46,7 +46,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.small_nation
 
 SORT(12)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -80,7 +80,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(13) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -83,7 +83,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(12)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -107,7 +107,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(13) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -46,7 +46,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.small_nation
 
 SORT(12)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -80,7 +80,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(13) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition5.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -83,7 +83,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(12)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(8)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -107,7 +107,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(5)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(13) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -60,7 +60,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  1: type=Broadcast, tables=default.nation
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -111,7 +111,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 5 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -135,7 +135,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -60,7 +60,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  1: type=Broadcast, tables=default.nation
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition6.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -111,7 +111,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 5 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: name1 (TEXT) = name2 (TEXT)
      => target list: default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)
@@ -135,7 +135,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), name1 (TEXT), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -60,7 +60,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  1: type=Broadcast, tables=default.nation
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -111,7 +111,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 5 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), num=32)
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -135,7 +135,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -60,7 +60,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  1: type=Broadcast, tables=default.nation
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testComplexJoinCondition7.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -111,7 +111,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 5 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), default.n2.n_name (TEXT), num=32)
 
 SORT(18)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: ?substr_1 (TEXT) = ?substr_2 (TEXT)
      => target list: default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)
@@ -135,7 +135,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(8)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc),default.n2.n_name (TEXT) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last),default.n2.n_name (TEXT) (asc, nulls last)
    SCAN(19) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_name (TEXT), default.n1.n_nationkey (INT4), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -96,7 +96,7 @@ Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]
  0: type=Broadcast, tables=default.n
 
 SORT(21)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -136,7 +136,7 @@ Block Id: eb_0000000000000_0000_000007 [ROOT]
  0: sorted input=eb_0000000000000_0000_000006
 
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000006
      => out schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}
      => in schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -164,7 +164,7 @@ Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]
 [q_0000000000000_0000] 6 => 7 (type=RANGE_SHUFFLE, key=default.n.n_nationkey (INT4), num=32)
 
 SORT(21)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -190,7 +190,7 @@ Block Id: eb_0000000000000_0000_000007 [ROOT]
  0: sorted input=eb_0000000000000_0000_000006
 
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000006
      => out schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}
      => in schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -96,7 +96,7 @@ Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]
  0: type=Broadcast, tables=default.n
 
 SORT(21)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -136,7 +136,7 @@ Block Id: eb_0000000000000_0000_000007 [ROOT]
  0: sorted input=eb_0000000000000_0000_000006
 
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000006
      => out schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}
      => in schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}

--- a/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestInnerJoinWithSubQuery/testThetaJoinKeyPairs.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -164,7 +164,7 @@ Block Id: eb_0000000000000_0000_000006 [INTERMEDIATE]
 [q_0000000000000_0000] 6 => 7 (type=RANGE_SHUFFLE, key=default.n.n_nationkey (INT4), num=32)
 
 SORT(21)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SELECTION(11)
      => Search Cond: CAST (default.n.n_nationkey (INT4) AS INT8) > default.t.cnt (INT8)
       JOIN(13)(INNER)
@@ -190,7 +190,7 @@ Block Id: eb_0000000000000_0000_000007 [ROOT]
  0: sorted input=eb_0000000000000_0000_000006
 
 SORT(8)
-  => Sort Keys: default.n.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n.n_nationkey (INT4) (asc, nulls last)
    SCAN(22) on eb_0000000000000_0000_000006
      => out schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}
      => in schema: {(4) default.n.n_name (TEXT), default.n.n_nationkey (INT4), default.n.n_regionkey (INT4), default.t.cnt (INT8)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -52,7 +52,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.supplier
 
 SORT(15)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.region.r_name (TEXT), s1 (TEXT), num=32)
 
 SORT(15)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -52,7 +52,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.supplier
 
 SORT(15)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.region.r_name (TEXT), s1 (TEXT), num=32)
 
 SORT(15)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.supplier.s_nationkey (INT4) = default.nation.n_nationkey (INT4)
      => target list: CASE WHEN default.supplier.s_name (TEXT) IS NULL THEN N/O ELSE default.supplier.s_name (TEXT) END as s1, default.region.r_name (TEXT)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -56,7 +56,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.supplier
 
 SORT(17)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -131,7 +131,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.region.r_name (TEXT), s1 (TEXT), num=32)
 
 SORT(17)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -155,7 +155,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -56,7 +56,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.supplier
 
 SORT(17)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestMultipleJoinTypes/testComplexJoinsWithCaseWhen2.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -131,7 +131,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.region.r_name (TEXT), s1 (TEXT), num=32)
 
 SORT(17)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    JOIN(11)(INNER)
      => Join Cond: default.t.n_regionkey (INT4) = default.region.r_regionkey (INT4)
      => target list: default.region.r_name (TEXT), s1 (TEXT)
@@ -155,7 +155,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.region.r_name (TEXT) (asc),s1 (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),s1 (TEXT) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}
      => in schema: {(2) default.region.r_name (TEXT), s1 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoin1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t4.id (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}
      => in schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t4.id (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}
      => in schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t4.id (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}
      => in schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinPredicationCaseByCase1.1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t4.id (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    JOIN(9)(FULL_OUTER)
      => Join Cond: default.t1.id (INT4) = default.t3.id (INT4)
      => target list: default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.t4.id (INT4) (asc)
+  => Sort Keys: default.t4.id (INT4) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}
      => in schema: {(4) default.t1.id (INT4), default.t1.name (TEXT), default.t3.id (INT4), default.t4.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testFullOuterJoinWithEmptyTable1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(FULL_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.nation
 
 SORT(10)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.region.r_name (TEXT), num=32)
 
 SORT(10)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.nation
 
 SORT(10)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testJoinFilterOfRowPreservedTable1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.nation.n_name (TEXT), default.region.r_name (TEXT), num=32)
 
 SORT(10)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: (default.nation.n_regionkey (INT4) = default.region.r_regionkey (INT4) AND default.region.r_name (TEXT) IN (AMERICA, ASIA))
      => target list: default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.region.r_name (TEXT) (asc),default.nation.n_name (TEXT) (asc)
+  => Sort Keys: default.region.r_name (TEXT) (asc, nulls last),default.nation.n_name (TEXT) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}
      => in schema: {(4) default.nation.n_name (TEXT), default.nation.n_regionkey (INT4), default.region.r_name (TEXT), default.region.r_regionkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoin1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4), default.orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.a.id (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.a.id (INT4), default.b.name (TEXT)}
      => in schema: {(2) default.a.id (INT4), default.b.name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.a.id (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.a.id (INT4), default.b.name (TEXT)}
      => in schema: {(2) default.a.id (INT4), default.b.name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.a.id (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.a.id (INT4), default.b.name (TEXT)}
      => in schema: {(2) default.a.id (INT4), default.b.name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinLeftSideSmallTable.1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.a.id (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.name (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.a.id (INT4), default.b.name (TEXT)}
      => in schema: {(2) default.a.id (INT4), default.b.name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Hash.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       JOIN(6)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -46,7 +46,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -76,7 +76,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       SCAN(11) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Hash_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       JOIN(6)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -75,7 +75,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -103,7 +103,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       SCAN(11) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Sort.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       JOIN(6)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -46,7 +46,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -76,7 +76,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       SCAN(11) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithConstantExpr1.Sort_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       JOIN(6)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -75,7 +75,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -103,7 +103,7 @@ PROJECTION(4)
   => out schema: {(3) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
    SORT(3)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
       SCAN(11) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}
      => in schema: {(4) default.customer.c_custkey (INT4), default.empty_orders.o_orderdate (TEXT), default.empty_orders.o_orderkey (INT4), default.empty_orders.o_orderstatus (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -78,7 +78,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(?sum_5 (INT8)),max(?max_6 (TEXT)),max(?max_7 (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}
      => in schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -105,7 +105,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(?sum_5 (INT8)),max(?max_6 (TEXT)),max(?max_7 (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -126,7 +126,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}
      => in schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -78,7 +78,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(?sum_5 (INT8)),max(?max_6 (TEXT)),max(?max_7 (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}
      => in schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable2.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -105,7 +105,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(3)(c_custkey)
      => exprs: (sum(?sum_5 (INT8)),max(?max_6 (TEXT)),max(?max_7 (TEXT)))
      => target list: default.customer.c_custkey (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT)
@@ -126,7 +126,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}
      => in schema: {(4) ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), default.customer.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Hash.plan
@@ -5,7 +5,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       GROUP_BY(6)(c_custkey)
         => exprs: (count())
         => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t1.c_custkey (INT4), num=32)
 
 SORT(18)
-  => Sort Keys: default.t1.c_custkey (INT4) (asc)
+  => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(6)(c_custkey)
      => exprs: (count(?count_6 (INT8)))
      => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -150,7 +150,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       SCAN(19) on eb_0000000000000_0000_000005
         => out schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
         => in schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Hash_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       GROUP_BY(6)(c_custkey)
         => exprs: (count())
         => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -152,7 +152,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t1.c_custkey (INT4), num=32)
 
 SORT(18)
-  => Sort Keys: default.t1.c_custkey (INT4) (asc)
+  => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(6)(c_custkey)
      => exprs: (count(?count_6 (INT8)))
      => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -177,7 +177,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       SCAN(19) on eb_0000000000000_0000_000005
         => out schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
         => in schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Sort.plan
@@ -5,7 +5,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       GROUP_BY(6)(c_custkey)
         => exprs: (count())
         => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -125,7 +125,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t1.c_custkey (INT4), num=32)
 
 SORT(18)
-  => Sort Keys: default.t1.c_custkey (INT4) (asc)
+  => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(6)(c_custkey)
      => exprs: (count(?count_6 (INT8)))
      => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -150,7 +150,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       SCAN(19) on eb_0000000000000_0000_000005
         => out schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
         => in schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable3.Sort_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       GROUP_BY(6)(c_custkey)
         => exprs: (count())
         => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -152,7 +152,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.t1.c_custkey (INT4), num=32)
 
 SORT(18)
-  => Sort Keys: default.t1.c_custkey (INT4) (asc)
+  => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
    GROUP_BY(6)(c_custkey)
      => exprs: (count(?count_6 (INT8)))
      => target list: default.t1.c_custkey (INT4), ?count (INT8)
@@ -177,7 +177,7 @@ PROJECTION(8)
   => out schema: {(1) ?count (INT8)}
   => in  schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
    SORT(7)
-     => Sort Keys: default.t1.c_custkey (INT4) (asc)
+     => Sort Keys: default.t1.c_custkey (INT4) (asc, nulls last)
       SCAN(19) on eb_0000000000000_0000_000005
         => out schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}
         => in schema: {(2) ?count (INT8), default.t1.c_custkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)),avg(default.lineitem.l_quantity (FLOAT8)),sum(default.lineitem.l_quantity (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -78,7 +78,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.lineitem.l_linenumber (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(?sum_7 (INT8)),max(?max_8 (TEXT)),max(?max_9 (TEXT)),avg(?avg_10 (PROTOBUF)),sum(?sum_11 (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}
      => in schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)),avg(default.lineitem.l_quantity (FLOAT8)),sum(default.lineitem.l_quantity (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -105,7 +105,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.lineitem.l_linenumber (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(?sum_7 (INT8)),max(?max_8 (TEXT)),max(?max_9 (TEXT)),avg(?avg_10 (PROTOBUF)),sum(?sum_11 (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -126,7 +126,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}
      => in schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)),avg(default.lineitem.l_quantity (FLOAT8)),sum(default.lineitem.l_quantity (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -78,7 +78,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.lineitem.l_linenumber (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(?sum_7 (INT8)),max(?max_8 (TEXT)),max(?max_9 (TEXT)),avg(?avg_10 (PROTOBUF)),sum(?sum_11 (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}
      => in schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithEmptyTable5.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(default.empty_orders.o_orderkey (INT4)),max(default.empty_orders.o_orderstatus (TEXT)),max(default.empty_orders.o_orderdate (TEXT)),avg(default.lineitem.l_quantity (FLOAT8)),sum(default.lineitem.l_quantity (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -105,7 +105,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.lineitem.l_linenumber (INT4), num=32)
 
 SORT(13)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    GROUP_BY(3)(l_linenumber)
      => exprs: (sum(?sum_7 (INT8)),max(?max_8 (TEXT)),max(?max_9 (TEXT)),avg(?avg_10 (PROTOBUF)),sum(?sum_11 (FLOAT8)))
      => target list: default.lineitem.l_linenumber (INT4), ?sum (INT8), ?max_1 (TEXT), ?max_2 (TEXT), ?avg_3 (FLOAT8), ?sum_4 (FLOAT8)
@@ -126,7 +126,7 @@ Block Id: eb_0000000000000_0000_000005 [ROOT]
  0: sorted input=eb_0000000000000_0000_000004
 
 SORT(4)
-  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc)
+  => Sort Keys: default.lineitem.l_linenumber (INT4) (asc, nulls last)
    SCAN(14) on eb_0000000000000_0000_000004
      => out schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}
      => in schema: {(6) ?avg_3 (FLOAT8), ?max_1 (TEXT), ?max_2 (TEXT), ?sum (INT8), ?sum_4 (FLOAT8), default.lineitem.l_linenumber (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -44,7 +44,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -73,7 +73,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -44,7 +44,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -73,7 +73,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) IS NULL
       JOIN(7)(LEFT_OUTER)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -44,7 +44,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -73,7 +73,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -44,7 +44,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull2.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -73,7 +73,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: (default.orders.o_orderdate (TEXT) IS NOT NULL AND default.orders.o_orderdate (TEXT)LIKE'1996%')
       JOIN(7)(LEFT_OUTER)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -44,7 +44,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -73,7 +73,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -44,7 +44,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -72,7 +72,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testLeftOuterJoinWithNull3.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -73,7 +73,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(11)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SELECTION(3)
      => Search Cond: default.orders.o_orderkey (INT4) = 100
       JOIN(7)(LEFT_OUTER)
@@ -99,7 +99,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(4)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(12) on eb_0000000000000_0000_000003
      => out schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}
      => in schema: {(4) ?coalesce (TEXT), default.customer.c_custkey (INT4), default.orders.o_orderdate (TEXT), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -52,7 +52,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.c
 
 SORT(15)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}
      => in schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.a.id (INT4), default.a.name (TEXT), num=32)
 
 SORT(15)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}
      => in schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -52,7 +52,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.c
 
 SORT(15)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}
      => in schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testOuterJoinAndCaseWhen1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -119,7 +119,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.a.id (INT4), default.a.name (TEXT), num=32)
 
 SORT(15)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: CASE WHEN default.b.name (TEXT) IS NULL THEN 9991231 ELSE default.b.name (TEXT) END as c1, CASE WHEN default.c.name (TEXT) IS NULL THEN 9991231 ELSE default.c.name (TEXT) END as c2, default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)
@@ -143,7 +143,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(5)
-  => Sort Keys: default.a.id (INT4) (asc),default.a.name (TEXT) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last),default.a.name (TEXT) (asc, nulls last)
    SCAN(16) on eb_0000000000000_0000_000005
      => out schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}
      => in schema: {(6) c1 (TEXT), c2 (TEXT), default.a.id (INT4), default.a.name (TEXT), id2 (INT4), name2 (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoin1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -42,7 +42,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.empty_orders
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -68,7 +68,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinQuery/testRightOuterJoinWithEmptyTable1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -71,7 +71,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    JOIN(6)(RIGHT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.empty_orders.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)
@@ -95,7 +95,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.empty_orders.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.empty_orders.o_orderkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}
      => in schema: {(2) default.customer.c_custkey (INT4), default.empty_orders.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Hash.plan
@@ -5,7 +5,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       JOIN(8)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -50,7 +50,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(12)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
    JOIN(8)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -88,7 +88,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       SCAN(13) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Hash_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       JOIN(8)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), num=32)
 
 SORT(12)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
    JOIN(8)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -115,7 +115,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       SCAN(13) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Sort.plan
@@ -5,7 +5,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       JOIN(8)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -50,7 +50,7 @@ Block Id: eb_0000000000000_0000_000003 [LEAF]
  0: type=Broadcast, tables=default.orders
 
 SORT(12)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
    JOIN(8)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -88,7 +88,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       SCAN(13) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr2.Sort_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       JOIN(8)(LEFT_OUTER)
         => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
         => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -87,7 +87,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), num=32)
 
 SORT(12)
-  => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+  => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
    JOIN(8)(LEFT_OUTER)
      => Join Cond: default.customer.c_custkey (INT4) = default.o.o_orderkey (INT4)
      => target list: default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)
@@ -115,7 +115,7 @@ PROJECTION(6)
   => out schema: {(3) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4), val (TEXT)}
   => in  schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
    SORT(5)
-     => Sort Keys: default.customer.c_custkey (INT4) (asc),default.o.o_orderkey (INT4) (asc)
+     => Sort Keys: default.customer.c_custkey (INT4) (asc, nulls last),default.o.o_orderkey (INT4) (asc, nulls last)
       SCAN(13) on eb_0000000000000_0000_000003
         => out schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}
         => in schema: {(2) default.customer.c_custkey (INT4), default.o.o_orderkey (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Hash.plan
@@ -5,7 +5,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       JOIN(9)(LEFT_OUTER)
         => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
         => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -118,7 +118,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.a.c_custkey (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.a.c_custkey (INT4) (asc)
+  => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
      => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -146,7 +146,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       SCAN(16) on eb_0000000000000_0000_000004
         => out schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
         => in schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Hash_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       JOIN(9)(LEFT_OUTER)
         => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
         => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -118,7 +118,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.a.c_custkey (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.a.c_custkey (INT4) (asc)
+  => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
      => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -146,7 +146,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       SCAN(16) on eb_0000000000000_0000_000004
         => out schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
         => in schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Sort.plan
@@ -5,7 +5,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       JOIN(9)(LEFT_OUTER)
         => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
         => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -118,7 +118,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.a.c_custkey (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.a.c_custkey (INT4) (asc)
+  => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
      => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -146,7 +146,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       SCAN(16) on eb_0000000000000_0000_000004
         => out schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
         => in schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithConstantExpr3.Sort_NoBroadcast.plan
@@ -5,7 +5,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       JOIN(9)(LEFT_OUTER)
         => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
         => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -118,7 +118,7 @@ Block Id: eb_0000000000000_0000_000004 [INTERMEDIATE]
 [q_0000000000000_0000] 4 => 5 (type=RANGE_SHUFFLE, key=default.a.c_custkey (INT4), num=32)
 
 SORT(15)
-  => Sort Keys: default.a.c_custkey (INT4) (asc)
+  => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
    JOIN(9)(LEFT_OUTER)
      => Join Cond: default.a.c_custkey (INT4) = default.b.c_custkey (INT4)
      => target list: default.a.c_custkey (INT4), default.b.min_name (TEXT)
@@ -146,7 +146,7 @@ PROJECTION(7)
   => out schema: {(3) const_val (INT8), default.a.c_custkey (INT4), default.b.min_name (TEXT)}
   => in  schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
    SORT(6)
-     => Sort Keys: default.a.c_custkey (INT4) (asc)
+     => Sort Keys: default.a.c_custkey (INT4) (asc, nulls last)
       SCAN(16) on eb_0000000000000_0000_000004
         => out schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}
         => in schema: {(2) default.a.c_custkey (INT4), default.b.min_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Hash.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Hash.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -57,7 +57,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.lineitem
 
 SORT(17)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -101,7 +101,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.a.id (INT4), default.b.id (INT4)}
      => in schema: {(2) default.a.id (INT4), default.b.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Hash_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Hash_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -133,7 +133,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.a.id (INT4), num=32)
 
 SORT(17)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -157,7 +157,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.a.id (INT4), default.b.id (INT4)}
      => in schema: {(2) default.a.id (INT4), default.b.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Sort.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Sort.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -57,7 +57,7 @@ Block Id: eb_0000000000000_0000_000005 [LEAF]
  1: type=Broadcast, tables=default.lineitem
 
 SORT(17)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -101,7 +101,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.a.id (INT4), default.b.id (INT4)}
      => in schema: {(2) default.a.id (INT4), default.b.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Sort_NoBroadcast.plan
+++ b/tajo-core-tests/src/test/resources/results/TestOuterJoinWithSubQuery/testLeftOuterJoinWithEmptySubquery1.1.Sort_NoBroadcast.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -133,7 +133,7 @@ Block Id: eb_0000000000000_0000_000005 [INTERMEDIATE]
 [q_0000000000000_0000] 5 => 6 (type=RANGE_SHUFFLE, key=default.a.id (INT4), num=32)
 
 SORT(17)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    JOIN(11)(LEFT_OUTER)
      => Join Cond: default.a.id (INT4) = default.b.id (INT4)
      => target list: default.a.id (INT4), default.b.id (INT4)
@@ -157,7 +157,7 @@ Block Id: eb_0000000000000_0000_000006 [ROOT]
  0: sorted input=eb_0000000000000_0000_000005
 
 SORT(7)
-  => Sort Keys: default.a.id (INT4) (asc)
+  => Sort Keys: default.a.id (INT4) (asc, nulls last)
    SCAN(18) on eb_0000000000000_0000_000005
      => out schema: {(2) default.a.id (INT4), default.b.id (INT4)}
      => in schema: {(2) default.a.id (INT4), default.b.id (INT4)}

--- a/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window4.result
+++ b/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window4.result
@@ -17,8 +17,7 @@
                 "ColumnName": "dt",
                 "OpType": "Column"
               },
-              "IsAsc": true,
-              "IsNullFirst": false
+              "IsAsc": true
             }
           ]
         },

--- a/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window5.result
+++ b/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window5.result
@@ -47,7 +47,7 @@
                 "OpType": "Function"
               },
               "IsAsc": true,
-              "IsNullFirst": false
+              "IsNullsFirst": false
             }
           ]
         },

--- a/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window6.result
+++ b/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window6.result
@@ -47,7 +47,7 @@
                 "OpType": "Function"
               },
               "IsAsc": true,
-              "IsNullFirst": false
+              "IsNullsFirst": false
             }
           ],
           "windowFrame": {

--- a/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window7.result
+++ b/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window7.result
@@ -47,7 +47,7 @@
                 "OpType": "Function"
               },
               "IsAsc": true,
-              "IsNullFirst": false
+              "IsNullsFirst": false
             }
           ],
           "windowFrame": {

--- a/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window8.result
+++ b/tajo-core-tests/src/test/resources/results/TestSQLAnalyzer/window8.result
@@ -47,7 +47,7 @@
                 "OpType": "Function"
               },
               "IsAsc": true,
-              "IsNullFirst": false
+              "IsNullsFirst": false
             }
           ],
           "windowFrame": {

--- a/tajo-core-tests/src/test/resources/results/TestSelectQuery/testExplainSelectPhysical.2.result
+++ b/tajo-core-tests/src/test/resources/results/TestSelectQuery/testExplainSelectPhysical.2.result
@@ -54,7 +54,7 @@ Block Id: eb_0000000000000_0000_000003 [INTERMEDIATE]
 [q_0000000000000_0000] 3 => 4 (type=RANGE_SHUFFLE, key=default.n1.n_nationkey (INT4), num=32)
 
 SORT(10)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    JOIN(6)(INNER)
      => Join Cond: default.n1.n_name (TEXT) = ?upper_1 (TEXT)
      => target list: default.n1.n_nationkey (INT4), default.n1.n_name (TEXT), default.n2.n_name (TEXT)
@@ -78,7 +78,7 @@ Block Id: eb_0000000000000_0000_000004 [ROOT]
  0: sorted input=eb_0000000000000_0000_000003
 
 SORT(3)
-  => Sort Keys: default.n1.n_nationkey (INT4) (asc)
+  => Sort Keys: default.n1.n_nationkey (INT4) (asc, nulls last)
    SCAN(11) on eb_0000000000000_0000_000003
      => out schema: {(3) default.n1.n_nationkey (INT4), default.n1.n_name (TEXT), default.n2.n_name (TEXT)}
      => in schema: {(3) default.n1.n_nationkey (INT4), default.n1.n_name (TEXT), default.n2.n_name (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestSortQuery/testSubQuerySortAfterGroupMultiBlocks.plan
+++ b/tajo-core-tests/src/test/resources/results/TestSortQuery/testSubQuerySortAfterGroupMultiBlocks.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(6)
-  => Sort Keys: default.l2.l_orderkey (INT4) (asc)
+  => Sort Keys: default.l2.l_orderkey (INT4) (asc, nulls last)
    TABLE_SUBQUERY(5) as default.l2
      => Targets: default.l2.l_orderkey (INT4), default.l2.revenue (FLOAT8)
      => out schema: {(2) default.l2.l_orderkey (INT4), default.l2.revenue (FLOAT8)}
@@ -65,7 +65,7 @@ Block Id: eb_0000000000000_0000_000002 [INTERMEDIATE]
 [q_0000000000000_0000] 2 => 3 (type=RANGE_SHUFFLE, key=default.l2.l_orderkey (INT4), num=32)
 
 SORT(12)
-  => Sort Keys: default.l2.l_orderkey (INT4) (asc)
+  => Sort Keys: default.l2.l_orderkey (INT4) (asc, nulls last)
    TABLE_SUBQUERY(5) as default.l2
      => Targets: default.l2.l_orderkey (INT4), default.l2.revenue (FLOAT8)
      => out schema: {(2) default.l2.l_orderkey (INT4), default.l2.revenue (FLOAT8)}
@@ -102,7 +102,7 @@ Block Id: eb_0000000000000_0000_000003 [ROOT]
  0: sorted input=eb_0000000000000_0000_000002
 
 SORT(6)
-  => Sort Keys: default.l2.l_orderkey (INT4) (asc)
+  => Sort Keys: default.l2.l_orderkey (INT4) (asc, nulls last)
    SCAN(13) on eb_0000000000000_0000_000002
      => out schema: {(2) default.l2.l_orderkey (INT4), default.l2.revenue (FLOAT8)}
      => in schema: {(2) default.l2.l_orderkey (INT4), default.l2.revenue (FLOAT8)}

--- a/tajo-core-tests/src/test/resources/results/TestTPCH/testQ1OrderBy.plan
+++ b/tajo-core-tests/src/test/resources/results/TestTPCH/testQ1OrderBy.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(2)
-  => Sort Keys: default.lineitem.l_returnflag (TEXT) (asc),default.lineitem.l_linestatus (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_returnflag (TEXT) (asc, nulls last),default.lineitem.l_linestatus (TEXT) (asc, nulls last)
    GROUP_BY(1)(l_returnflag,l_linestatus)
      => exprs: (count())
      => target list: default.lineitem.l_returnflag (TEXT), default.lineitem.l_linestatus (TEXT), count_order (INT8)
@@ -57,7 +57,7 @@ Block Id: eb_0000000000000_0000_000002 [INTERMEDIATE]
 [q_0000000000000_0000] 2 => 3 (type=RANGE_SHUFFLE, key=default.lineitem.l_linestatus (TEXT), default.lineitem.l_returnflag (TEXT), num=32)
 
 SORT(8)
-  => Sort Keys: default.lineitem.l_returnflag (TEXT) (asc),default.lineitem.l_linestatus (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_returnflag (TEXT) (asc, nulls last),default.lineitem.l_linestatus (TEXT) (asc, nulls last)
    GROUP_BY(1)(l_returnflag,l_linestatus)
      => exprs: (count(?count (INT8)))
      => target list: default.lineitem.l_returnflag (TEXT), default.lineitem.l_linestatus (TEXT), count_order (INT8)
@@ -78,7 +78,7 @@ Block Id: eb_0000000000000_0000_000003 [ROOT]
  0: sorted input=eb_0000000000000_0000_000002
 
 SORT(2)
-  => Sort Keys: default.lineitem.l_returnflag (TEXT) (asc),default.lineitem.l_linestatus (TEXT) (asc)
+  => Sort Keys: default.lineitem.l_returnflag (TEXT) (asc, nulls last),default.lineitem.l_linestatus (TEXT) (asc, nulls last)
    SCAN(9) on eb_0000000000000_0000_000002
      => out schema: {(3) count_order (INT8), default.lineitem.l_linestatus (TEXT), default.lineitem.l_returnflag (TEXT)}
      => in schema: {(3) count_order (INT8), default.lineitem.l_linestatus (TEXT), default.lineitem.l_returnflag (TEXT)}

--- a/tajo-core-tests/src/test/resources/results/TestTPCH/testTPCHQ5.plan
+++ b/tajo-core-tests/src/test/resources/results/TestTPCH/testTPCHQ5.plan
@@ -1,7 +1,7 @@
 explain
 -------------------------------
 SORT(8)
-  => Sort Keys: revenue (FLOAT8) (desc)
+  => Sort Keys: revenue (FLOAT8) (desc, nulls first)
    GROUP_BY(7)(n_name)
      => exprs: (sum(?multiply (FLOAT8)))
      => target list: default.nation.n_name (TEXT), revenue (FLOAT8)
@@ -301,7 +301,7 @@ Block Id: eb_0000000000000_0000_000012 [INTERMEDIATE]
 [q_0000000000000_0000] 12 => 13 (type=RANGE_SHUFFLE, key=revenue (FLOAT8), num=32)
 
 SORT(34)
-  => Sort Keys: revenue (FLOAT8) (desc)
+  => Sort Keys: revenue (FLOAT8) (desc, nulls first)
    GROUP_BY(7)(n_name)
      => exprs: (sum(?sum_7 (FLOAT8)))
      => target list: default.nation.n_name (TEXT), revenue (FLOAT8)
@@ -322,7 +322,7 @@ Block Id: eb_0000000000000_0000_000013 [ROOT]
  0: sorted input=eb_0000000000000_0000_000012
 
 SORT(8)
-  => Sort Keys: revenue (FLOAT8) (desc)
+  => Sort Keys: revenue (FLOAT8) (desc, nulls first)
    SCAN(35) on eb_0000000000000_0000_000012
      => out schema: {(2) default.nation.n_name (TEXT), revenue (FLOAT8)}
      => in schema: {(2) default.nation.n_name (TEXT), revenue (FLOAT8)}

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ComparableVector.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ComparableVector.java
@@ -53,10 +53,11 @@ public class ComparableVector {
     vectors = new TupleVector[sortKeys.length];
     for (int i = 0; i < vectors.length; i++) {
       TajoDataTypes.Type type = sortKeys[i].getSortKey().getDataType().getType();
-      boolean nullFirst = sortKeys[i].isNullFirst();
-      boolean ascending = sortKeys[i].isAscending();
-      boolean nullInvert = nullFirst && ascending || !nullFirst && !ascending;
-      vectors[i] = new TupleVector(vectorType(type), tuples.length, nullInvert, ascending);
+//      boolean nullFirst = sortKeys[i].isNullsFirst();
+//      boolean ascending = sortKeys[i].isAscending();
+//      boolean nullsFirst = nullFirst && ascending || !nullFirst && !ascending;
+      vectors[i] = new TupleVector(vectorType(type), tuples.length,
+          sortKeys[i].isNullsFirst(), sortKeys[i].isAscending());
     }
     this.keyIndex = keyIndex;
   }
@@ -81,7 +82,7 @@ public class ComparableVector {
 
     private final int type;
     private final BitSet nulls;
-    private final boolean nullInvert;
+    private final boolean nullsFirst;
     private final boolean ascending;
 
     private boolean[] booleans;
@@ -95,10 +96,10 @@ public class ComparableVector {
 
     private int index;
 
-    private TupleVector(int type, int length, boolean nullInvert, boolean ascending) {
+    private TupleVector(int type, int length, boolean nullsFirst, boolean ascending) {
       this.type = type;
       this.nulls = new BitSet(length);
-      this.nullInvert = nullInvert;
+      this.nullsFirst = nullsFirst;
       this.ascending = ascending;
       switch (type) {
         case 0: booleans = new boolean[length]; break;
@@ -148,8 +149,9 @@ public class ComparableVector {
         return 0;
       }
       if (n1 ^ n2) {
-        int compVal = n1 ? 1 : -1;
-        return nullInvert ? -compVal : compVal;
+//        int compVal = n1 ? 1 : -1;
+//        return nullsFirst ? -compVal : compVal;
+        return nullsFirst ? (n1 ? -1 : 1) : (n1 ? 1 : -1);
       }
       int compare;
       switch (type) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ComparableVector.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ComparableVector.java
@@ -53,9 +53,6 @@ public class ComparableVector {
     vectors = new TupleVector[sortKeys.length];
     for (int i = 0; i < vectors.length; i++) {
       TajoDataTypes.Type type = sortKeys[i].getSortKey().getDataType().getType();
-//      boolean nullFirst = sortKeys[i].isNullsFirst();
-//      boolean ascending = sortKeys[i].isAscending();
-//      boolean nullsFirst = nullFirst && ascending || !nullFirst && !ascending;
       vectors[i] = new TupleVector(vectorType(type), tuples.length,
           sortKeys[i].isNullsFirst(), sortKeys[i].isAscending());
     }
@@ -149,8 +146,6 @@ public class ComparableVector {
         return 0;
       }
       if (n1 ^ n2) {
-//        int compVal = n1 ? 1 : -1;
-//        return nullsFirst ? -compVal : compVal;
         return nullsFirst ? (n1 ? -1 : 1) : (n1 ? 1 : -1);
       }
       int compare;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/utils/TupleUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/utils/TupleUtil.java
@@ -95,8 +95,6 @@ public class TupleUtil {
           Tuple rangeTuple = ranges[0].getStart();
           rangeTuple.put(i, NullDatum.get());
         } else {
-//          int rangeIndex = sortSpecs[i].isAscending() ? ranges.length - 1 : 0;
-//          VTuple rangeTuple = sortSpecs[i].isAscending() ? (VTuple) ranges[rangeIndex].getEnd() : (VTuple) ranges[rangeIndex].getStart();
           Tuple rangeTuple = ranges[ranges.length - 1].getEnd();
           if (LOG.isDebugEnabled()) {
             LOG.debug("Set null into range: " + col.getQualifiedName() + ", previous tuple is " + rangeTuple);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/utils/TupleUtil.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/utils/TupleUtil.java
@@ -31,6 +31,7 @@ import org.apache.tajo.datum.DatumFactory;
 import org.apache.tajo.datum.NullDatum;
 import org.apache.tajo.storage.RowStoreUtil;
 import org.apache.tajo.storage.RowStoreUtil.RowStoreEncoder;
+import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.storage.TupleRange;
 import org.apache.tajo.storage.VTuple;
 
@@ -90,13 +91,13 @@ public class TupleUtil {
         continue;
       }
       if (columnStat.hasNullValue()) {
-        if (sortSpecs[i].isNullFirst()) {
-          int rangeIndex = 0;
-          VTuple rangeTuple = (VTuple) ranges[rangeIndex].getStart();
+        if (sortSpecs[i].isNullsFirst()) {
+          Tuple rangeTuple = ranges[0].getStart();
           rangeTuple.put(i, NullDatum.get());
         } else {
-          int rangeIndex = sortSpecs[i].isAscending() ? ranges.length - 1 : 0;
-          VTuple rangeTuple = sortSpecs[i].isAscending() ? (VTuple) ranges[rangeIndex].getEnd() : (VTuple) ranges[rangeIndex].getStart();
+//          int rangeIndex = sortSpecs[i].isAscending() ? ranges.length - 1 : 0;
+//          VTuple rangeTuple = sortSpecs[i].isAscending() ? (VTuple) ranges[rangeIndex].getEnd() : (VTuple) ranges[rangeIndex].getStart();
+          Tuple rangeTuple = ranges[ranges.length - 1].getEnd();
           if (LOG.isDebugEnabled()) {
             LOG.debug("Set null into range: " + col.getQualifiedName() + ", previous tuple is " + rangeTuple);
           }

--- a/tajo-core/src/main/java/org/apache/tajo/parser/sql/SQLAnalyzer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/parser/sql/SQLAnalyzer.java
@@ -559,7 +559,9 @@ public class SQLAnalyzer extends SQLParserBaseVisitor<Expr> {
 
       if (specContext.null_ordering() != null) {
         if (specContext.null_ordering().FIRST() != null) {
-          specs[i].setNullFirst();
+          specs[i].setNullsFirst();
+        } else if (specContext.null_ordering().LAST() != null) {
+          specs[i].setNullsLast();
         }
       }
     }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
@@ -701,7 +701,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
           } else {
             throw new IllegalStateException("Unexpected State: " + StringUtils.join(sortSpecs));
           }
-          annotatedSortSpecs[i] = new SortSpec(column, sortSpecs[i].isAscending(), sortSpecs[i].isNullFirst());
+          annotatedSortSpecs[i] = new SortSpec(column, sortSpecs[i].isAscending(), sortSpecs[i].isNullsFirst());
         }
 
         sortGroups[winSpecIdx] = annotatedSortSpecs;
@@ -929,7 +929,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
       } else {
         throw new IllegalStateException("Unexpected State: " + StringUtils.join(rawSortSpecs));
       }
-      annotatedSortSpecs.add(new SortSpec(column, rawSortSpecs[i].isAscending(), rawSortSpecs[i].isNullFirst()));
+      annotatedSortSpecs.add(new SortSpec(column, rawSortSpecs[i].isAscending(), rawSortSpecs[i].isNullsFirst()));
     }
     return annotatedSortSpecs.toArray(new SortSpec[annotatedSortSpecs.size()]);
   }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
@@ -573,14 +573,14 @@ public class ProjectionPushDownRule extends
       Target target = context.targetListMgr.getTarget(sortKey);
       if (context.targetListMgr.isEvaluated(sortKey)) {
         Column c = target.getNamedColumn();
-        SortSpec sortSpec = new SortSpec(c, node.getSortKeys()[i].isAscending(), node.getSortKeys()[i].isNullFirst());
+        SortSpec sortSpec = new SortSpec(c, node.getSortKeys()[i].isAscending(), node.getSortKeys()[i].isNullsFirst());
         if (!sortSpecs.contains(sortSpec)) {
           sortSpecs.add(sortSpec);
         }
       } else {
         if (target.getEvalTree().getType() == EvalType.FIELD) {
           Column c = ((FieldEval)target.getEvalTree()).getColumnRef();
-          SortSpec sortSpec = new SortSpec(c, node.getSortKeys()[i].isAscending(), node.getSortKeys()[i].isNullFirst());
+          SortSpec sortSpec = new SortSpec(c, node.getSortKeys()[i].isAscending(), node.getSortKeys()[i].isNullsFirst());
           if (!sortSpecs.contains(sortSpec)) {
             sortSpecs.add(sortSpec);
           }

--- a/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/BaseTupleComparator.java
+++ b/tajo-storage/tajo-storage-common/src/main/java/org/apache/tajo/storage/BaseTupleComparator.java
@@ -18,7 +18,6 @@
 
 package org.apache.tajo.storage;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import org.apache.tajo.catalog.Schema;
 import org.apache.tajo.catalog.SortSpec;
@@ -68,7 +67,7 @@ public class BaseTupleComparator extends TupleComparator implements ProtoObject<
       }
           
       this.asc[i] = sortKeys[i].isAscending();
-      this.nullFirsts[i]= sortKeys[i].isNullFirst();
+      this.nullFirsts[i]= sortKeys[i].isNullsFirst();
     }
   }
 


### PR DESCRIPTION
I'm sorry for a large patch. Here are the highlights of this patch.
* Fix the problem of invalid sort order of nulls in VectorizedSorter
* Change the name of ```nullFirst``` variable to ```nullsFirst```
* Change the string representation of ```SortSpec``` to print out the nulls order

Most changes of this patch is due to the changed string representation of ```SortSpec```, and there are only very minor changes.
Please review this patch.