### PR TITLE
TAJO-1862: TSQL gives user wrong URL of documentation

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/HelpCommand.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/HelpCommand.java
@@ -107,15 +107,15 @@ public class HelpCommand extends TajoShellCommand {
 
     int delimiterIdx = tajoFullVersion.indexOf("-");
     if (delimiterIdx > -1) {
-      tajoVersion =  tajoFullVersion.substring(0, delimiterIdx);
+      tajoVersion = tajoFullVersion.substring(0, delimiterIdx);
     } else {
       tajoVersion = tajoFullVersion;
     }
     
-    if(tajoVersion.equalsIgnoreCase("")) {
+    if(tajoVersion.equalsIgnoreCase("") || tajoFullVersion.contains("SNAPSHOT")) {
       docVersion = docDefaultVersion;
     } else {
-    	docVersion = tajoVersion;
+      docVersion = tajoVersion;
     }
 
     return docVersion;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -38,6 +38,7 @@ import org.apache.tajo.rpc.RpcConstants;
 import org.apache.tajo.storage.StorageUtil;
 import org.apache.tajo.storage.TablespaceManager;
 import org.apache.tajo.util.FileUtil;
+import org.apache.tajo.util.VersionInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -559,6 +560,18 @@ public class TestTajoCli {
     @Override
     public void printProgress(PrintWriter sout, QueryStatus status) {
       //nothing to do
+    }
+  }
+
+  @Test
+  public void testPrintVersion() {
+    tajoCli.executeMetaCommand("\\?");
+    String consoleResult = new String(out.toByteArray());
+
+    if (VersionInfo.getVersion().contains("SNAPSHOT")) {
+      assertTrue(consoleResult.contains("docs/current/"));
+    } else {
+      assertTrue(consoleResult.contains("docs/" + VersionInfo.getVersion() + "/"));
     }
   }
 }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -567,11 +567,20 @@ public class TestTajoCli {
   public void testPrintVersion() {
     tajoCli.executeMetaCommand("\\?");
     String consoleResult = new String(out.toByteArray());
+    String tajoFullVersion = VersionInfo.getVersion();
+    String tajoVersion;
 
-    if (VersionInfo.getVersion().contains("SNAPSHOT")) {
+    int delimiterIdx = VersionInfo.getVersion().indexOf("-");
+    if (delimiterIdx > -1) {
+      tajoVersion = tajoFullVersion.substring(0, delimiterIdx);
+    } else {
+      tajoVersion = tajoFullVersion;
+    }
+
+    if (tajoVersion.equalsIgnoreCase("") || tajoFullVersion.contains("SNAPSHOT")) {
       assertTrue(consoleResult.contains("docs/current/"));
     } else {
-      assertTrue(consoleResult.contains("docs/" + VersionInfo.getVersion() + "/"));
+      assertTrue(consoleResult.contains("docs/" + tajoVersion + "/"));
     }
   }
 }

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -570,7 +570,7 @@ public class TestTajoCli {
     String tajoFullVersion = VersionInfo.getVersion();
     String tajoVersion;
 
-    int delimiterIdx = VersionInfo.getVersion().indexOf("-");
+    int delimiterIdx = tajoFullVersion.indexOf("-");
     if (delimiterIdx > -1) {
       tajoVersion = tajoFullVersion.substring(0, delimiterIdx);
     } else {


### PR DESCRIPTION
When user build master branch and run TSQL, TSQL gives user wrong url like below.

http://tajo.apache.org/docs/0.12.0/tsql.html

To help beginner or intermediate user, It should be fix.