### PR TITLE
TAJO-1992 \set timezone in cli doesn't work because of casesensitive

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/SetCommand.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/commands/SetCommand.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.tajo.SessionVars.TIMEZONE;
 import static org.apache.tajo.SessionVars.VariableMode;
 
 public class SetCommand extends TajoShellCommand {
@@ -54,6 +55,10 @@ public class SetCommand extends TajoShellCommand {
 
   public void set(String key, String val) throws NoSuchSessionVariableException {
     SessionVars sessionVar;
+
+    if (TIMEZONE.name().equalsIgnoreCase(key)) {
+      key = TIMEZONE.name();
+    }
 
     if (SessionVars.exists(key)) { // if the variable is one of the session variables
       sessionVar = SessionVars.get(key);

--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -442,6 +442,22 @@ public class TestTajoCli {
   }
 
   @Test
+  public void testTimeZoneSessionVars3() throws Exception {
+    tajoCli.executeMetaCommand("\\set timezone GMT+1");
+    tajoCli.executeMetaCommand("\\set");
+    String output = new String(out.toByteArray());
+    assertTrue(output.contains("'TIMEZONE'='GMT+1'"));
+  }
+
+  @Test
+  public void testTimeZoneSessionVars4() throws Exception {
+    tajoCli.executeMetaCommand("\\set timeZone GMT+2");
+    tajoCli.executeMetaCommand("\\set");
+    String output = new String(out.toByteArray());
+    assertTrue(output.contains("'TIMEZONE'='GMT+2'"));
+  }
+
+  @Test
   public void testTimeZoneTest1() throws Exception {
     String tableName = "test1";
     tajoCli.executeMetaCommand("\\set TIMEZONE GMT+0");


### PR DESCRIPTION
\set timezone doesn't work.
default> \set timezone GMT-3

but TIMEZONE works.
default> \set TIMEZONE GMT-3

so, this patch change timeZone -> TIMEZONE.name(); 