### PR TITLE
TAJO-1999: TUtil.newList/newLinkedHashMap should be replaced by Java's diamond operator

### DIFF
--- a/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
+++ b/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
@@ -782,7 +782,7 @@ public abstract class AbstractCatalogClient implements CatalogService, Closeable
       final IndexListResponse response = stub.getAllIndexesByTable(null, proto);
       ensureOk(response.getState());
 
-      List<IndexDesc> indexDescs = TUtil.newList();
+      List<IndexDesc> indexDescs = new ArrayList<>();
       for (IndexDescProto descProto : response.getIndexDescList()) {
         indexDescs.add(new IndexDesc(descProto));
       }

--- a/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
+++ b/tajo-catalog/tajo-catalog-client/src/main/java/org/apache/tajo/catalog/AbstractCatalogClient.java
@@ -33,7 +33,6 @@ import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos.NullProto;
 import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos.ReturnState;
 import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos.StringListResponse;
 import org.apache.tajo.util.ProtoUtil;
-import org.apache.tajo.util.TUtil;
 
 import java.io.Closeable;
 import java.util.ArrayList;

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
@@ -873,7 +873,7 @@ public class CatalogUtil {
    */
   public static Pair<List<PartitionKeyProto>, String> getPartitionKeyNamePair(String[] columns, String[] values) {
     Pair<List<PartitionKeyProto>, String> pair = null;
-    List<PartitionKeyProto> partitionKeyList = TUtil.newList();
+    List<PartitionKeyProto> partitionKeyList = new ArrayList<>();
 
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < columns.length; i++) {

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
@@ -21,6 +21,7 @@ package org.apache.tajo.catalog;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.annotations.Expose;
+import org.apache.avro.generic.GenericData;
 import org.apache.tajo.catalog.SchemaUtil.ColumnVisitor;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos.ColumnProto;
@@ -56,7 +57,7 @@ public class Schema implements ProtoObject<SchemaProto>, Cloneable, GsonObject {
 	public Schema(SchemaProto proto) {
     init();
 
-    List<Column> toBeAdded = TUtil.newList();
+    List<Column> toBeAdded = new ArrayList<>();
     for (int i = 0; i < proto.getFieldsCount(); i++) {
       deserializeColumn(toBeAdded, proto.getFieldsList(), i);
     }
@@ -83,7 +84,8 @@ public class Schema implements ProtoObject<SchemaProto>, Cloneable, GsonObject {
       // where is start index of nested fields?
       int childStartIndex = tobeAdded.size() - childNum;
       // Extract nested fields
-      List<Column> nestedColumns = TUtil.newList(tobeAdded.subList(childStartIndex, childStartIndex + childNum));
+      List<Column> nestedColumns = new ArrayList<>();
+      nestedColumns.addAll(tobeAdded.subList(childStartIndex, childStartIndex + childNum));
 
       // Remove nested fields from the the current level
       for (int i = 0; i < childNum; i++) {
@@ -309,7 +311,7 @@ public class Schema implements ProtoObject<SchemaProto>, Cloneable, GsonObject {
    * @return A list of all columns
    */
   public List<Column> getAllColumns() {
-    final List<Column> columnList = TUtil.newList();
+    final List<Column> columnList = new ArrayList<>();
 
     SchemaUtil.visitSchema(this, new ColumnVisitor() {
       @Override
@@ -423,7 +425,9 @@ public class Schema implements ProtoObject<SchemaProto>, Cloneable, GsonObject {
     Column newCol = new Column(normalized, typeDesc);
     fields.add(newCol);
     fieldsByQualifiedName.put(newCol.getQualifiedName(), fields.size() - 1);
-    fieldsByName.put(newCol.getSimpleName(), TUtil.newList(fields.size() - 1));
+    List inputList = new ArrayList<>();
+    inputList.add(fields.size() - 1);
+    fieldsByName.put(newCol.getSimpleName(), inputList);
 
     return this;
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
@@ -84,8 +84,7 @@ public class Schema implements ProtoObject<SchemaProto>, Cloneable, GsonObject {
       // where is start index of nested fields?
       int childStartIndex = tobeAdded.size() - childNum;
       // Extract nested fields
-      List<Column> nestedColumns = new ArrayList<>();
-      nestedColumns.addAll(tobeAdded.subList(childStartIndex, childStartIndex + childNum));
+      List<Column> nestedColumns = new ArrayList<>(tobeAdded.subList(childStartIndex, childStartIndex + childNum));
 
       // Remove nested fields from the the current level
       for (int i = 0; i < childNum; i++) {

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
@@ -21,7 +21,6 @@ package org.apache.tajo.catalog;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.annotations.Expose;
-import org.apache.avro.generic.GenericData;
 import org.apache.tajo.catalog.SchemaUtil.ColumnVisitor;
 import org.apache.tajo.catalog.json.CatalogGsonHelper;
 import org.apache.tajo.catalog.proto.CatalogProtos.ColumnProto;
@@ -33,7 +32,6 @@ import org.apache.tajo.exception.DuplicateColumnException;
 import org.apache.tajo.exception.TajoRuntimeException;
 import org.apache.tajo.json.GsonObject;
 import org.apache.tajo.util.StringUtils;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 
@@ -424,9 +422,7 @@ public class Schema implements ProtoObject<SchemaProto>, Cloneable, GsonObject {
     Column newCol = new Column(normalized, typeDesc);
     fields.add(newCol);
     fieldsByQualifiedName.put(newCol.getQualifiedName(), fields.size() - 1);
-    List inputList = new ArrayList<>();
-    inputList.add(fields.size() - 1);
-    fieldsByName.put(newCol.getSimpleName(), inputList);
+    fieldsByName.put(newCol.getSimpleName(), new ArrayList<Integer>(fields.size() - 1));
 
     return this;
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/Schema.java
@@ -422,7 +422,9 @@ public class Schema implements ProtoObject<SchemaProto>, Cloneable, GsonObject {
     Column newCol = new Column(normalized, typeDesc);
     fields.add(newCol);
     fieldsByQualifiedName.put(newCol.getQualifiedName(), fields.size() - 1);
-    fieldsByName.put(newCol.getSimpleName(), new ArrayList<Integer>(fields.size() - 1));
+    List<Integer> inputList = new ArrayList<>();
+    inputList.add(fields.size() - 1);
+    fieldsByName.put(newCol.getSimpleName(), inputList);
 
     return this;
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SchemaUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SchemaUtil.java
@@ -24,6 +24,7 @@ import org.apache.tajo.exception.TajoRuntimeException;
 import org.apache.tajo.exception.UnsupportedDataTypeException;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -183,7 +184,8 @@ public class SchemaUtil {
 
     if (column.getDataType().getType() == Type.RECORD) {
       for (Column nestedColumn : column.typeDesc.nestedRecordSchema.getRootColumns()) {
-        List<String> newPath = TUtil.newList(path);
+        List<String> newPath = new ArrayList<>();
+        newPath.addAll(path);
         newPath.add(column.getQualifiedName());
 
         visitInDepthFirstOrder(depth + 1, newPath, function, nestedColumn);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SchemaUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/SchemaUtil.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.apache.tajo.exception.TajoRuntimeException;
 import org.apache.tajo.exception.UnsupportedDataTypeException;
-import org.apache.tajo.util.TUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -184,8 +183,7 @@ public class SchemaUtil {
 
     if (column.getDataType().getType() == Type.RECORD) {
       for (Column nestedColumn : column.typeDesc.nestedRecordSchema.getRootColumns()) {
-        List<String> newPath = new ArrayList<>();
-        newPath.addAll(path);
+        List<String> newPath = new ArrayList<>(path);
         newPath.add(column.getQualifiedName());
 
         visitInDepthFirstOrder(depth + 1, newPath, function, nestedColumn);

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/TableStats.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/statistics/TableStats.java
@@ -55,7 +55,7 @@ public class TableStats implements ProtoObject<TableStatsProto>, Cloneable, Gson
     numShuffleOutputs = 0;
     avgRows = 0l;
     readBytes = 0l;
-    columnStatses = TUtil.newList();
+    columnStatses = new ArrayList<>();
   }
 
   public TableStats(CatalogProtos.TableStatsProto proto) {
@@ -83,7 +83,7 @@ public class TableStats implements ProtoObject<TableStatsProto>, Cloneable, Gson
       this.readBytes = 0l;
     }
 
-    this.columnStatses = TUtil.newList();
+    this.columnStatses = new ArrayList<>();
     for (CatalogProtos.ColumnStatsProto colProto : proto.getColStatList()) {
       if (colProto.getColumn().getDataType().getType() == TajoDataTypes.Type.PROTOBUF) {
         continue;

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -24,9 +24,7 @@ import org.apache.tajo.annotation.NotNull;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionSignatureProto;
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionType;

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -24,6 +24,7 @@ import org.apache.tajo.annotation.NotNull;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionSignatureProto;
@@ -111,7 +112,7 @@ public class FunctionSignature implements Comparable<FunctionSignature>, ProtoOb
     FunctionSignatureProto.Builder builder = FunctionSignatureProto.newBuilder();
     builder.setType(functionType);
     builder.setName(name);
-    builder.addAllParameterTypes(Arrays.asList(paramTypes));
+    builder.addAllParameterTypes(new ArrayList<>(Arrays.asList(paramTypes)));
     builder.setReturnType(returnType);
     return builder.build();
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -112,7 +112,7 @@ public class FunctionSignature implements Comparable<FunctionSignature>, ProtoOb
     FunctionSignatureProto.Builder builder = FunctionSignatureProto.newBuilder();
     builder.setType(functionType);
     builder.setName(name);
-    builder.addAllParameterTypes(new ArrayList<>(Arrays.asList(paramTypes)));
+    builder.addAllParameterTypes(Arrays.asList(paramTypes));
     builder.setReturnType(returnType);
     return builder.build();
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -113,9 +113,7 @@ public class FunctionSignature implements Comparable<FunctionSignature>, ProtoOb
     FunctionSignatureProto.Builder builder = FunctionSignatureProto.newBuilder();
     builder.setType(functionType);
     builder.setName(name);
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList(paramTypes));
-    builder.addAllParameterTypes(inputList);
+    builder.addAllParameterTypes(Arrays.asList(paramTypes));
     builder.setReturnType(returnType);
     return builder.build();
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -25,6 +25,7 @@ import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionSignatureProto;
@@ -113,7 +114,7 @@ public class FunctionSignature implements Comparable<FunctionSignature>, ProtoOb
     builder.setType(functionType);
     builder.setName(name);
     List inputList = new ArrayList<>();
-    inputList.add(paramTypes);
+    inputList.addAll(Arrays.asList(paramTypes));
     builder.addAllParameterTypes(inputList);
     builder.setReturnType(returnType);
     return builder.build();

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -24,6 +24,9 @@ import org.apache.tajo.annotation.NotNull;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionSignatureProto;
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionType;
 import static org.apache.tajo.common.TajoDataTypes.DataType;
@@ -109,7 +112,9 @@ public class FunctionSignature implements Comparable<FunctionSignature>, ProtoOb
     FunctionSignatureProto.Builder builder = FunctionSignatureProto.newBuilder();
     builder.setType(functionType);
     builder.setName(name);
-    builder.addAllParameterTypes(TUtil.newList(paramTypes));
+    List inputList = new ArrayList<>();
+    inputList.add(paramTypes);
+    builder.addAllParameterTypes(inputList);
     builder.setReturnType(returnType);
     return builder.build();
   }

--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/function/FunctionSignature.java
@@ -24,7 +24,6 @@ import org.apache.tajo.annotation.NotNull;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.apache.tajo.catalog.proto.CatalogProtos.FunctionSignatureProto;

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
@@ -55,7 +55,6 @@ import org.apache.tajo.plan.expr.AlgebraicUtil;
 import org.apache.tajo.plan.util.PartitionFilterAlgebraVisitor;
 import org.apache.tajo.storage.StorageConstants;
 import org.apache.tajo.util.KeyValueSet;
-import org.apache.tajo.util.TUtil;
 import org.apache.thrift.TException;
 import parquet.hadoop.ParquetOutputFormat;
 

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/main/java/org/apache/tajo/catalog/store/HiveCatalogStore.java
@@ -1020,7 +1020,7 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
     List<ColumnProto> parititonColumns = null;
 
     try {
-      partitions = TUtil.newList();
+      partitions = new ArrayList<>();
       client = clientPool.getClient();
 
       List<Partition> hivePartitions = client.getHiveClient().listPartitionsByFilter(databaseName, tableName
@@ -1243,7 +1243,7 @@ public class HiveCatalogStore extends CatalogConstants implements CatalogStore {
   public void addPartitions(String databaseName, String tableName, List<CatalogProtos.PartitionDescProto> partitions
     , boolean ifNotExists) {
     HiveCatalogStoreClientPool.HiveCatalogStoreClient client = null;
-    List<Partition> addPartitions = TUtil.newList();
+    List<Partition> addPartitions = new ArrayList<>();
     CatalogProtos.PartitionDescProto existingPartition = null;
 
     try {

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/test/java/org/apache/tajo/catalog/store/TestHiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/test/java/org/apache/tajo/catalog/store/TestHiveCatalogStore.java
@@ -297,7 +297,7 @@ public class TestHiveCatalogStore {
     testAddPartition(table1.getUri(), NATION, "n_nationkey=30/n_date=20150101");
     testAddPartition(table1.getUri(), NATION, "n_nationkey=30/n_date=20150102");
 
-    List<String> partitionNames = TUtil.newList();
+    List<String> partitionNames = new ArrayList<>();
     partitionNames.add("n_nationkey=40/n_date=20150801");
     partitionNames.add("n_nationkey=40/n_date=20150802");
     partitionNames.add("n_nationkey=50/n_date=20150801");
@@ -445,7 +445,7 @@ public class TestHiveCatalogStore {
   }
 
   private void testAddPartitions(URI uri, String tableName, List<String> partitionNames) throws Exception {
-    List<CatalogProtos.PartitionDescProto> partitions = TUtil.newList();
+    List<CatalogProtos.PartitionDescProto> partitions = new ArrayList<>();
     for (String partitionName : partitionNames) {
       CatalogProtos.PartitionDescProto.Builder builder = CatalogProtos.PartitionDescProto.newBuilder();
       builder.setPartitionName(partitionName);

--- a/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/test/java/org/apache/tajo/catalog/store/TestHiveCatalogStore.java
+++ b/tajo-catalog/tajo-catalog-drivers/tajo-hive/src/test/java/org/apache/tajo/catalog/store/TestHiveCatalogStore.java
@@ -39,7 +39,6 @@ import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.storage.StorageConstants;
 import org.apache.tajo.util.CommonTestingUtil;
 import org.apache.tajo.util.KeyValueSet;
-import org.apache.tajo.util.TUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/dictionary/InfoSchemaMetadataDictionary.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/dictionary/InfoSchemaMetadataDictionary.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.tajo.exception.UndefinedTableException;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.catalog.proto.CatalogProtos.DataFormat;
-import org.apache.tajo.util.TUtil;
 
 public class InfoSchemaMetadataDictionary {
   private static final String DATABASE_NAME = "information_schema";

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/dictionary/InfoSchemaMetadataDictionary.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/dictionary/InfoSchemaMetadataDictionary.java
@@ -79,7 +79,7 @@ public class InfoSchemaMetadataDictionary {
   }
   
   public List<String> getAllSystemTables() {
-    List<String> systemTableNames = TUtil.newList();
+    List<String> systemTableNames = new ArrayList<>();
     
     for (TableDescriptor descriptor: schemaInfoTableDescriptors) {
       systemTableNames.add(descriptor.getTableNameString());

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -39,7 +39,6 @@ import org.apache.tajo.util.JavaResourceUtil;
 import org.apache.tajo.plan.expr.*;
 import org.apache.tajo.plan.util.PartitionFilterAlgebraVisitor;
 import org.apache.tajo.util.Pair;
-import org.apache.tajo.util.TUtil;
 
 import java.io.IOException;
 import java.net.URI;

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -431,7 +431,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   
   @Override
   public List<TablespaceProto> getTablespaces() {
-    List<TablespaceProto> tablespaces = TUtil.newList();
+    List<TablespaceProto> tablespaces = new ArrayList<>();
 
     String sql = "SELECT SPACE_ID, SPACE_NAME, SPACE_HANDLER, SPACE_URI FROM " + TB_SPACES ;
 
@@ -2138,7 +2138,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     String selectStatement = null;
     Pair<String, List<PartitionFilterSet>> pair = null;
 
-    List<PartitionDescProto> partitions = TUtil.newList();
+    List<PartitionDescProto> partitions = new ArrayList<>();
     List<PartitionFilterSet> filterSets = null;
 
     int databaseId = getDatabaseId(request.getDatabaseName());
@@ -2250,7 +2250,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     Expr[] exprs = null;
 
     try {
-      List<PartitionFilterSet> filterSets = TUtil.newList();
+      List<PartitionFilterSet> filterSets = new ArrayList<>();
 
       if (json != null && !json.isEmpty()) {
         Expr algebra = JsonHelper.fromJson(json, Expr.class);
@@ -2297,7 +2297,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
         PartitionFilterSet filterSet = new PartitionFilterSet();
         filterSet.setColumnName(target.getSimpleName());
 
-        List<Pair<Type, Object>> list = TUtil.newList();
+        List<Pair<Type, Object>> list = new ArrayList<>();
         list.addAll(visitor.getParameters());
         filterSet.addParameters(list);
 
@@ -2321,7 +2321,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
       PartitionFilterSet filterSet = new PartitionFilterSet();
       filterSet.setColumnName(target.getSimpleName());
 
-      List<Pair<Type, Object>> list = TUtil.newList();
+      List<Pair<Type, Object>> list = new ArrayList<>();
       list.addAll(visitor.getParameters());
       filterSet.addParameters(list);
 
@@ -2872,7 +2872,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
 
   @Override
   public List<IndexDescProto> getAllIndexes() throws UndefinedDatabaseException {
-    List<IndexDescProto> indexDescProtos = TUtil.newList();
+    List<IndexDescProto> indexDescProtos = new ArrayList<>();
     for (String databaseName : getAllDatabaseNames()) {
       for (String tableName : getAllTableNames(databaseName)) {
         try {
@@ -3029,7 +3029,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     private List<Pair<Type, Object>> parameters;
 
     public PartitionFilterSet() {
-      parameters = TUtil.newList();
+      parameters = new ArrayList<>();
     }
 
     public String getColumnName() {

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
@@ -24,7 +24,6 @@ import org.apache.tajo.catalog.CatalogConstants;
 import org.apache.tajo.catalog.CatalogUtil;
 import org.apache.tajo.catalog.store.object.*;
 import org.apache.tajo.exception.TajoInternalError;
-import org.apache.tajo.util.TUtil;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/XMLCatalogSchemaManager.java
@@ -336,7 +336,7 @@ public class XMLCatalogSchemaManager {
   public boolean catalogAlreadyExists(Connection conn) {
     boolean result = false;
     try {
-      List<String> constants = TUtil.newList();
+      List<String> constants = new ArrayList<>();
       constants.add(CatalogConstants.TB_META);
       constants.add(CatalogConstants.TB_SPACES);
       constants.add(CatalogConstants.TB_DATABASES);

--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tools/TajoDump.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tools/TajoDump.java
@@ -169,8 +169,7 @@ public class TajoDump {
     writer.write("\n\n");
 
     // returned list is immutable.
-    List<String> tableNames = new ArrayList<>();
-    tableNames.addAll(client.getTableList(databaseName));
+    List<String> tableNames = new ArrayList<>(client.getTableList(databaseName));
     Collections.sort(tableNames);
     for (String tableName : tableNames) {
       try {

--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tools/TajoDump.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tools/TajoDump.java
@@ -28,7 +28,6 @@ import org.apache.tajo.client.TajoClientImpl;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.service.ServiceTrackerFactory;
 import org.apache.tajo.util.Pair;
-import org.apache.tajo.util.TUtil;
 
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tools/TajoDump.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tools/TajoDump.java
@@ -169,7 +169,8 @@ public class TajoDump {
     writer.write("\n\n");
 
     // returned list is immutable.
-    List<String> tableNames = TUtil.newList(client.getTableList(databaseName));
+    List<String> tableNames = new ArrayList<>();
+    tableNames.addAll(client.getTableList(databaseName));
     Collections.sort(tableNames);
     for (String tableName : tableNames) {
       try {

--- a/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleSession.java
+++ b/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleSession.java
@@ -23,7 +23,6 @@ import java.util.Map.Entry;
 
 import org.apache.tajo.rule.EvaluationResult.EvaluationResultCode;
 import org.apache.tajo.rule.SelfDiagnosisRuleEngine.RuleWrapper;
-import org.apache.tajo.util.TUtil;
 
 public class SelfDiagnosisRuleSession {
   

--- a/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleSession.java
+++ b/tajo-common/src/main/java/org/apache/tajo/rule/SelfDiagnosisRuleSession.java
@@ -67,7 +67,7 @@ public class SelfDiagnosisRuleSession {
   
   protected List<RuleWrapper> getCandidateRules() {
     Map<String, Map<String, RuleWrapper>> wrapperMap = null;
-    List<RuleWrapper> candidateRules = TUtil.newList();
+    List<RuleWrapper> candidateRules = new ArrayList<>();
     
     wrapperMap = ruleEngine.getRules();
     Class<?> callerClazz = getCallerClassName();

--- a/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
@@ -44,7 +44,7 @@ public class BaseServiceTracker implements ServiceTracker {
     tajoMasterInfo.setCatalogAddress(conf.getSocketAddrVar(TajoConf.ConfVars.CATALOG_ADDRESS));
     tajoMasterInfo.setWebServerAddress(conf.getSocketAddrVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS));
 
-    tajoMasterInfos = new ArrayList<>(Arrays.asList(tajoMasterInfo));
+    tajoMasterInfos = Arrays.asList(tajoMasterInfo);
   }
 
   @Override

--- a/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
@@ -44,7 +44,7 @@ public class BaseServiceTracker implements ServiceTracker {
     tajoMasterInfo.setCatalogAddress(conf.getSocketAddrVar(TajoConf.ConfVars.CATALOG_ADDRESS));
     tajoMasterInfo.setWebServerAddress(conf.getSocketAddrVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS));
 
-    tajoMasterInfos = Arrays.asList(tajoMasterInfo);
+    tajoMasterInfos = new ArrayList<>(Arrays.asList(tajoMasterInfo));
   }
 
   @Override

--- a/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
@@ -19,11 +19,11 @@
 package org.apache.tajo.service;
 
 import org.apache.tajo.conf.TajoConf;
-import org.apache.tajo.util.TUtil;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class BaseServiceTracker implements ServiceTracker {
@@ -44,8 +44,7 @@ public class BaseServiceTracker implements ServiceTracker {
     tajoMasterInfo.setCatalogAddress(conf.getSocketAddrVar(TajoConf.ConfVars.CATALOG_ADDRESS));
     tajoMasterInfo.setWebServerAddress(conf.getSocketAddrVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS));
 
-    tajoMasterInfos = new ArrayList<>();
-    tajoMasterInfos.add(tajoMasterInfo);
+    tajoMasterInfos = Arrays.asList(tajoMasterInfo);
   }
 
   @Override

--- a/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
+++ b/tajo-common/src/main/java/org/apache/tajo/service/BaseServiceTracker.java
@@ -23,6 +23,7 @@ import org.apache.tajo.util.TUtil;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.List;
 
 public class BaseServiceTracker implements ServiceTracker {
@@ -43,7 +44,8 @@ public class BaseServiceTracker implements ServiceTracker {
     tajoMasterInfo.setCatalogAddress(conf.getSocketAddrVar(TajoConf.ConfVars.CATALOG_ADDRESS));
     tajoMasterInfo.setWebServerAddress(conf.getSocketAddrVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS));
 
-    tajoMasterInfos = TUtil.newList(tajoMasterInfo);
+    tajoMasterInfos = new ArrayList<>();
+    tajoMasterInfos.add(tajoMasterInfo);
   }
 
   @Override
@@ -94,7 +96,7 @@ public class BaseServiceTracker implements ServiceTracker {
 
   @Override
   public List<String> getMasters(TajoConf conf) throws ServiceTrackerException {
-    List<String> list = TUtil.newList();
+    List<String> list = new ArrayList<>();
     list.add(getMasterAddress());
     return list;
   }

--- a/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
@@ -155,9 +155,9 @@ public class TUtil {
     if (map.containsKey(k1)) {
       map.get(k1).addAll(list);
     } else {
-      List input = new ArrayList<>();
-      input.addAll(list);
-      map.put(k1, input);
+      List inputList = new ArrayList<>();
+      inputList.addAll(list);
+      map.put(k1, inputList);
     }
   }
 

--- a/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
@@ -122,40 +122,8 @@ public class TUtil {
     return result;
   }
 
-  public static <K,V> Map<K,V> newLinkedHashMap() {
-    return new LinkedHashMap<>();
-  }
-
-  public static <K, V> Map<K,V> newLinkedHashMap(K k, V v) {
-    HashMap<K, V> newMap = new LinkedHashMap<>();
-    newMap.put(k, v);
-    return newMap;
-  }
-
   public static <K,V> Map<K,V> newConcurrentHashMap() {
     return new ConcurrentHashMap<>();
-  }
-
-  public static <T> List<T> newList() {
-    return new ArrayList<>();
-  }
-
-  public static <T> List<T> newList(T...items) {
-    List<T> list = new ArrayList<>();
-    for (T t : items) {
-      list.add(t);
-    }
-
-    return list;
-  }
-
-  public static <T> List<T> newList(Collection<T> items) {
-    List<T> list = new ArrayList<>();
-    for (T t : items) {
-      list.add(t);
-    }
-
-    return list;
   }
 
   /**
@@ -176,7 +144,9 @@ public class TUtil {
     if (map.containsKey(k1)) {
       map.get(k1).add(value);
     } else {
-      map.put(k1, TUtil.newList(value));
+      List inputList = new ArrayList<>();
+      inputList.add(value);
+      map.put(k1, inputList);
     }
   }
 
@@ -185,7 +155,9 @@ public class TUtil {
     if (map.containsKey(k1)) {
       map.get(k1).addAll(list);
     } else {
-      map.put(k1, TUtil.newList(list));
+      List input = new ArrayList<>();
+      input.addAll(list);
+      map.put(k1, input);
     }
   }
 
@@ -194,7 +166,9 @@ public class TUtil {
     if (map.containsKey(k1)) {
       map.get(k1).put(k2, value);
     } else {
-      map.put(k1, TUtil.newLinkedHashMap(k2, value));
+      HashMap<KEY2, VALUE> newMap = new LinkedHashMap<>();
+      newMap.put(k2, value);
+      map.put(k1, newMap);
     }
   }
 

--- a/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/TUtil.java
@@ -155,9 +155,7 @@ public class TUtil {
     if (map.containsKey(k1)) {
       map.get(k1).addAll(list);
     } else {
-      List inputList = new ArrayList<>();
-      inputList.addAll(list);
-      map.put(k1, inputList);
+      map.put(k1, new ArrayList<>(list));
     }
   }
 

--- a/tajo-common/src/main/java/org/apache/tajo/util/graph/SimpleDirectedGraph.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/graph/SimpleDirectedGraph.java
@@ -33,9 +33,9 @@ import java.util.*;
  */
 public class SimpleDirectedGraph<V, E> implements DirectedGraph<V,E> {
   /** map: child -> parent */
-  protected Map<V, Map<V, E>> directedEdges = TUtil.newLinkedHashMap();
+  protected Map<V, Map<V, E>> directedEdges = new LinkedHashMap<>();
   /** map: parent -> child */
-  protected Map<V, Map<V, E>> reversedEdges = TUtil.newLinkedHashMap();
+  protected Map<V, Map<V, E>> reversedEdges = new LinkedHashMap<>();
 
   public void clear() {
     for (Map<V, E> eachEdge : directedEdges.values()) {

--- a/tajo-common/src/main/java/org/apache/tajo/validation/PathListValidator.java
+++ b/tajo-common/src/main/java/org/apache/tajo/validation/PathListValidator.java
@@ -20,6 +20,7 @@ package org.apache.tajo.validation;
 
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 public class PathListValidator extends AbstractValidator {
@@ -57,7 +58,7 @@ public class PathListValidator extends AbstractValidator {
 
   @Override
   protected Collection<Validator> getDependantValidators() {
-    return TUtil.newList();
+    return new ArrayList<>();
   }
 
 }

--- a/tajo-common/src/main/java/org/apache/tajo/validation/PathListValidator.java
+++ b/tajo-common/src/main/java/org/apache/tajo/validation/PathListValidator.java
@@ -18,8 +18,6 @@
 
 package org.apache.tajo.validation;
 
-import org.apache.tajo.util.TUtil;
-
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleEngine.java
+++ b/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleEngine.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
@@ -68,7 +69,9 @@ public class TestRuleEngine {
 
     @Override
     public List<SelfDiagnosisRule> getDefinedRules() {
-      List<SelfDiagnosisRule> ruleList = TUtil.newList(new TestRule1(), new TestRule2());
+      List<SelfDiagnosisRule> ruleList = new ArrayList<>();
+      ruleList.add(new TestRule1());
+      ruleList.add(new TestRule2());
       return ruleList;
     }
     

--- a/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleEngine.java
+++ b/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleEngine.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.tajo.rule.EvaluationResult.EvaluationResultCode;
 import org.apache.tajo.rule.SelfDiagnosisRuleEngine.RuleWrapper;
 import org.apache.tajo.util.CommonTestingUtil;
-import org.apache.tajo.util.TUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleSession.java
+++ b/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleSession.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
@@ -69,7 +70,7 @@ public class TestRuleSession {
 
     @Override
     public List<SelfDiagnosisRule> getDefinedRules() {
-      List<SelfDiagnosisRule> ruleList = TUtil.newList();
+      List<SelfDiagnosisRule> ruleList = new ArrayList<>();
       ruleList.add(new TestRule1());
       ruleList.add(new TestRule2());
       ruleList.add(new TestRule3());
@@ -214,7 +215,7 @@ public class TestRuleSession {
 
     @Override
     public List<SelfDiagnosisRule> getDefinedRules() {
-      List<SelfDiagnosisRule> ruleList = TUtil.newList();
+      List<SelfDiagnosisRule> ruleList = new ArrayList<>();
       ruleList.add(new TestPriorityRule1());
       ruleList.add(new TestPriorityRule2());
       ruleList.add(new TestPriorityRule3());
@@ -320,7 +321,7 @@ public class TestRuleSession {
 
     @Override
     public List<SelfDiagnosisRule> getDefinedRules() {
-      List<SelfDiagnosisRule> ruleList = TUtil.newList();
+      List<SelfDiagnosisRule> ruleList = new ArrayList<>();
       ruleList.add(new TestExecRule1());
       ruleList.add(new TestExecRule2());
       ruleList.add(new TestExecRule3());

--- a/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleSession.java
+++ b/tajo-common/src/test/java/org/apache/tajo/rule/TestRuleSession.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.tajo.rule.EvaluationResult.EvaluationResultCode;
 import org.apache.tajo.rule.SelfDiagnosisRuleEngine.RuleWrapper;
 import org.apache.tajo.util.CommonTestingUtil;
-import org.apache.tajo.util.TUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/tajo-common/src/test/java/org/apache/tajo/validation/TestValidators.java
+++ b/tajo-common/src/test/java/org/apache/tajo/validation/TestValidators.java
@@ -27,7 +27,6 @@ import java.math.BigInteger;
 import java.math.MathContext;
 import java.util.*;
 
-import org.apache.tajo.util.TUtil;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
@@ -744,9 +744,7 @@ public class TestPhysicalPlanner {
       assertEquals(expectedFileNum, fileStatuses.length);
     }
     TableMeta outputMeta = CatalogUtil.newTableMeta("TEXT");
-    List inputList = new ArrayList<>();
-    inputList.addAll(fragments);
-    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, inputList);
+    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, new ArrayList<>(fragments));
     scanner.init();
 
     long rowNum = 0;
@@ -810,9 +808,7 @@ public class TestPhysicalPlanner {
 
     assertEquals(numPartitions, fragments.size());
 
-    List inputList = new ArrayList<>();
-    inputList.addAll(fragments);
-    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, inputList);
+    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, new ArrayList<>(fragments));
     scanner.init();
     Tuple tuple;
     int i = 0;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
@@ -674,9 +674,7 @@ public class TestPhysicalPlanner {
     }
 
     assertEquals(numPartitions, fragments.size());
-    List inputList = new ArrayList<>();
-    inputList.addAll(fragments);
-    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, inputList);
+    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, new ArrayList<>(fragments));
     scanner.init();
 
     Tuple tuple;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
@@ -674,7 +674,9 @@ public class TestPhysicalPlanner {
     }
 
     assertEquals(numPartitions, fragments.size());
-    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, TUtil.newList(fragments));
+    List inputList = new ArrayList<>();
+    inputList.addAll(fragments);
+    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, inputList);
     scanner.init();
 
     Tuple tuple;
@@ -745,7 +747,9 @@ public class TestPhysicalPlanner {
       assertEquals(expectedFileNum, fileStatuses.length);
     }
     TableMeta outputMeta = CatalogUtil.newTableMeta("TEXT");
-    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, TUtil.newList(fragments));
+    List inputList = new ArrayList<>();
+    inputList.addAll(fragments);
+    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, inputList);
     scanner.init();
 
     long rowNum = 0;
@@ -809,7 +813,9 @@ public class TestPhysicalPlanner {
 
     assertEquals(numPartitions, fragments.size());
 
-    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, TUtil.newList(fragments));
+    List inputList = new ArrayList<>();
+    inputList.addAll(fragments);
+    Scanner scanner = new MergeScanner(conf, rootNode.getOutSchema(), outputMeta, inputList);
     scanner.init();
     Tuple tuple;
     int i = 0;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/planner/physical/TestPhysicalPlanner.java
@@ -56,7 +56,6 @@ import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.unit.StorageUnit;
 import org.apache.tajo.util.CommonTestingUtil;
 import org.apache.tajo.util.KeyValueSet;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.worker.TaskAttemptContext;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
@@ -57,7 +57,7 @@ public class TestGroupByQuery extends QueryTestCaseBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    client.unsetSessionVariables(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
+    client.unsetSessionVariables(new ArrayList<>(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname())));
   }
 
   @Parameters

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
@@ -58,9 +58,7 @@ public class TestGroupByQuery extends QueryTestCaseBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
-    client.unsetSessionVariables(inputList);
+    client.unsetSessionVariables(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
   }
 
   @Parameters

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
@@ -58,7 +58,9 @@ public class TestGroupByQuery extends QueryTestCaseBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    client.unsetSessionVariables(TUtil.newList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
+    List listInput = new ArrayList<>();
+    listInput.addAll(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
+    client.unsetSessionVariables(listInput);
   }
 
   @Parameters

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
@@ -57,7 +57,7 @@ public class TestGroupByQuery extends QueryTestCaseBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    client.unsetSessionVariables(new ArrayList<>(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname())));
+    client.unsetSessionVariables(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
   }
 
   @Parameters

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
@@ -24,7 +24,6 @@ import org.apache.tajo.common.TajoDataTypes.Type;
 import org.apache.tajo.conf.TajoConf.ConfVars;
 import org.apache.tajo.storage.StorageConstants;
 import org.apache.tajo.util.KeyValueSet;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.history.QueryHistory;
 import org.apache.tajo.util.history.StageHistory;
 import org.junit.AfterClass;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestGroupByQuery.java
@@ -58,9 +58,9 @@ public class TestGroupByQuery extends QueryTestCaseBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    List listInput = new ArrayList<>();
-    listInput.addAll(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
-    client.unsetSessionVariables(listInput);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList(SessionVars.GROUPBY_MULTI_LEVEL_ENABLED.keyname()));
+    client.unsetSessionVariables(inputList);
   }
 
   @Parameters

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
@@ -1312,9 +1312,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
     } finally {
       executeString("DROP TABLE hbase_mapped_table PURGE").close();
 
-      List inputList = new ArrayList<>();
-      inputList.addAll(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE));
-      client.unsetSessionVariables(inputList);
+      client.unsetSessionVariables(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE));
 
       if (scanner != null) {
         scanner.close();

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
@@ -1311,7 +1311,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
     } finally {
       executeString("DROP TABLE hbase_mapped_table PURGE").close();
 
-      client.unsetSessionVariables(new ArrayList<>(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE)));
+      client.unsetSessionVariables(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE));
 
       if (scanner != null) {
         scanner.close();

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
@@ -1311,7 +1311,7 @@ public class TestHBaseTable extends QueryTestCaseBase {
     } finally {
       executeString("DROP TABLE hbase_mapped_table PURGE").close();
 
-      client.unsetSessionVariables(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE));
+      client.unsetSessionVariables(new ArrayList<>(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE)));
 
       if (scanner != null) {
         scanner.close();

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
@@ -50,7 +50,6 @@ import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.storage.hbase.*;
 import org.apache.tajo.util.Bytes;
 import org.apache.tajo.util.KeyValueSet;
-import org.apache.tajo.util.TUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
@@ -1312,9 +1312,9 @@ public class TestHBaseTable extends QueryTestCaseBase {
     } finally {
       executeString("DROP TABLE hbase_mapped_table PURGE").close();
 
-      List listInput = new ArrayList<>();
-      listInput.addAll(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE));
-      client.unsetSessionVariables(listInput);
+      List inputList = new ArrayList<>();
+      inputList.addAll(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE));
+      client.unsetSessionVariables(inputList);
 
       if (scanner != null) {
         scanner.close();

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestHBaseTable.java
@@ -1312,7 +1312,9 @@ public class TestHBaseTable extends QueryTestCaseBase {
     } finally {
       executeString("DROP TABLE hbase_mapped_table PURGE").close();
 
-      client.unsetSessionVariables(TUtil.newList(HBaseStorageConstants.INSERT_PUT_MODE));
+      List listInput = new ArrayList<>();
+      listInput.addAll(Arrays.asList(HBaseStorageConstants.INSERT_PUT_MODE));
+      client.unsetSessionVariables(listInput);
 
       if (scanner != null) {
         scanner.close();

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
@@ -33,7 +33,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect0() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample1");
-    assertEquals(new ArrayList<>(Arrays.asList("sample1")), tables);
+    assertEquals(Arrays.asList("sample1"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -43,7 +43,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect1() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample2");
-    assertEquals(new ArrayList<>(Arrays.asList("sample2")), tables);
+    assertEquals(Arrays.asList("sample2"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -53,7 +53,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect2() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(new ArrayList<>(Arrays.asList("tweets")), tables);
+    assertEquals(Arrays.asList("tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -63,7 +63,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect3() throws Exception {
     List<String> tables = executeDDL("sample2_ddl.sql", "sample2", "sample5");
-    assertEquals(new ArrayList<>(Arrays.asList("sample5")), tables);
+    assertEquals(Arrays.asList("sample5"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -74,7 +74,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testTAJO_1610() throws Exception {
     executeString("CREATE DATABASE tweets").close();
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets.tweets");
-    assertEquals(new ArrayList<>(Arrays.asList("tweets.tweets")), tables);
+    assertEquals(Arrays.asList("tweets.tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -84,7 +84,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsGroupbyKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(new ArrayList<>(Arrays.asList("tweets")), tables);
+    assertEquals(Arrays.asList("tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -94,7 +94,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsJoinKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(new ArrayList<>(Arrays.asList("tweets")), tables);
+    assertEquals(Arrays.asList("tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -105,7 +105,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType1() throws Exception {
     // all columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample3");
-    assertEquals(new ArrayList<>(Arrays.asList("sample3")), tables);
+    assertEquals(Arrays.asList("sample3"), tables);
 
     executeString("CREATE TABLE clone (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 
@@ -119,7 +119,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType2() throws Exception {
     // some columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample4");
-    assertEquals(new ArrayList<>(Arrays.asList("sample4")), tables);
+    assertEquals(Arrays.asList("sample4"), tables);
 
     executeString("CREATE TABLE clone2 (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
@@ -120,9 +120,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType1() throws Exception {
     // all columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample3");
-    List listInput = new ArrayList<>();
-    listInput.addAll(Arrays.asList("sample3"));
-    assertEquals(listInput, tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("sample3"));
+    assertEquals(inputList, tables);
 
     executeString("CREATE TABLE clone (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 
@@ -136,9 +136,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType2() throws Exception {
     // some columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample4");
-    List listInput = new ArrayList<>();
-    listInput.addAll(Arrays.asList("sample4"));
-    assertEquals(listInput, tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("sample4"));
+    assertEquals(inputList, tables);
 
     executeString("CREATE TABLE clone2 (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
@@ -23,6 +23,8 @@ import org.apache.tajo.util.TUtil;
 import org.junit.Test;
 
 import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -32,7 +34,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect0() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample1");
-    assertEquals(TUtil.newList("sample1"), tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("sample1"));
+    assertEquals(inputList, tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -42,7 +46,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect1() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample2");
-    assertEquals(TUtil.newList("sample2"), tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("sample2"));
+    assertEquals(inputList, tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -52,7 +58,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect2() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(TUtil.newList("tweets"), tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("tweets"));
+    assertEquals(inputList, tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -62,7 +70,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect3() throws Exception {
     List<String> tables = executeDDL("sample2_ddl.sql", "sample2", "sample5");
-    assertEquals(TUtil.newList("sample5"), tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("sample5"));
+    assertEquals(inputList, tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -73,7 +83,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testTAJO_1610() throws Exception {
     executeString("CREATE DATABASE tweets").close();
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets.tweets");
-    assertEquals(TUtil.newList("tweets.tweets"), tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("tweets.tweets"));
+    assertEquals(inputList, tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -83,7 +95,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsGroupbyKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(TUtil.newList("tweets"), tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("tweets"));
+    assertEquals(inputList, tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -93,7 +107,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsJoinKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(TUtil.newList("tweets"), tables);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList("tweets"));
+    assertEquals(inputList, tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -104,7 +120,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType1() throws Exception {
     // all columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample3");
-    assertEquals(TUtil.newList("sample3"), tables);
+    List listInput = new ArrayList<>();
+    listInput.addAll(Arrays.asList("sample3"));
+    assertEquals(listInput, tables);
 
     executeString("CREATE TABLE clone (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 
@@ -118,7 +136,9 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType2() throws Exception {
     // some columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample4");
-    assertEquals(TUtil.newList("sample4"), tables);
+    List listInput = new ArrayList<>();
+    listInput.addAll(Arrays.asList("sample4"));
+    assertEquals(listInput, tables);
 
     executeString("CREATE TABLE clone2 (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
@@ -19,11 +19,9 @@
 package org.apache.tajo.engine.query;
 
 import org.apache.tajo.QueryTestCaseBase;
-import org.apache.tajo.util.TUtil;
 import org.junit.Test;
 
 import java.sql.ResultSet;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -44,9 +42,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect1() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample2");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("sample2"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("sample2"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -56,9 +52,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect2() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("tweets"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -68,9 +62,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect3() throws Exception {
     List<String> tables = executeDDL("sample2_ddl.sql", "sample2", "sample5");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("sample5"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("sample5"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -81,9 +73,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testTAJO_1610() throws Exception {
     executeString("CREATE DATABASE tweets").close();
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets.tweets");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("tweets.tweets"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("tweets.tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -93,9 +83,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsGroupbyKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("tweets"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -105,9 +93,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsJoinKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("tweets"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("tweets"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -118,9 +104,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType1() throws Exception {
     // all columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample3");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("sample3"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("sample3"), tables);
 
     executeString("CREATE TABLE clone (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 
@@ -134,9 +118,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType2() throws Exception {
     // some columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample4");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("sample4"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("sample4"), tables);
 
     executeString("CREATE TABLE clone2 (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
@@ -22,7 +22,6 @@ import org.apache.tajo.QueryTestCaseBase;
 import org.junit.Test;
 
 import java.sql.ResultSet;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
@@ -34,9 +34,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect0() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample1");
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList("sample1"));
-    assertEquals(inputList, tables);
+    assertEquals(Arrays.asList("sample1"), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);

--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/query/TestSelectNestedRecord.java
@@ -22,6 +22,7 @@ import org.apache.tajo.QueryTestCaseBase;
 import org.junit.Test;
 
 import java.sql.ResultSet;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -32,7 +33,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect0() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample1");
-    assertEquals(Arrays.asList("sample1"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("sample1")), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -42,7 +43,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect1() throws Exception {
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample2");
-    assertEquals(Arrays.asList("sample2"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("sample2")), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -52,7 +53,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect2() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(Arrays.asList("tweets"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("tweets")), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -62,7 +63,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testSelect3() throws Exception {
     List<String> tables = executeDDL("sample2_ddl.sql", "sample2", "sample5");
-    assertEquals(Arrays.asList("sample5"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("sample5")), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -73,7 +74,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testTAJO_1610() throws Exception {
     executeString("CREATE DATABASE tweets").close();
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets.tweets");
-    assertEquals(Arrays.asList("tweets.tweets"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("tweets.tweets")), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -83,7 +84,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsGroupbyKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(Arrays.asList("tweets"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("tweets")), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -93,7 +94,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   @Test
   public final void testNestedFieldAsJoinKey1() throws Exception {
     List<String> tables = executeDDL("tweets_ddl.sql", "tweets", "tweets");
-    assertEquals(Arrays.asList("tweets"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("tweets")), tables);
 
     ResultSet res = executeQuery();
     assertResultSet(res);
@@ -104,7 +105,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType1() throws Exception {
     // all columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample3");
-    assertEquals(Arrays.asList("sample3"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("sample3")), tables);
 
     executeString("CREATE TABLE clone (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 
@@ -118,7 +119,7 @@ public class TestSelectNestedRecord extends QueryTestCaseBase {
   public final void testInsertType2() throws Exception {
     // some columns
     List<String> tables = executeDDL("sample1_ddl.sql", "sample1", "sample4");
-    assertEquals(Arrays.asList("sample4"), tables);
+    assertEquals(new ArrayList<>(Arrays.asList("sample4")), tables);
 
     executeString("CREATE TABLE clone2 (title TEXT, name RECORD (first_name TEXT, last_name TEXT)) USING JSON;").close();
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
@@ -52,6 +52,7 @@ import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.tajo.exception.ErrorUtil.isOk;
@@ -208,7 +209,7 @@ public class TestQueryResultResource extends QueryTestCaseBase {
     assertNotNull(queryResultSetInputStream);
 
     boolean isFinished = false;
-    List<Tuple> tupleList = TUtil.newList();
+    List<Tuple> tupleList = new ArrayList<>();
     RowStoreUtil.RowStoreDecoder decoder = RowStoreUtil.createDecoder(response.getSchema());
     while (!isFinished) {
       try {
@@ -274,7 +275,7 @@ public class TestQueryResultResource extends QueryTestCaseBase {
     assertNotNull(queryResultSetInputStream);
 
     boolean isFinished = false;
-    List<Tuple> tupleList = TUtil.newList();
+    List<Tuple> tupleList = new ArrayList<>();
     int receviedSize = 0;
     RowStoreUtil.RowStoreDecoder decoder = RowStoreUtil.createDecoder(response.getSchema());
     while (!isFinished) {

--- a/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/ws/rs/resources/TestQueryResultResource.java
@@ -25,7 +25,6 @@ import org.apache.tajo.error.Errors.ResultCode;
 import org.apache.tajo.exception.ErrorUtil;
 import org.apache.tajo.storage.RowStoreUtil;
 import org.apache.tajo.storage.Tuple;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.ws.rs.netty.gson.GsonFeature;
 import org.apache.tajo.ws.rs.requests.NewSessionRequest;
 import org.apache.tajo.ws.rs.requests.SubmitQueryRequest;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/FunctionLoader.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/FunctionLoader.java
@@ -40,7 +40,6 @@ import org.apache.tajo.exception.AmbiguousFunctionException;
 import org.apache.tajo.function.*;
 import org.apache.tajo.plan.function.python.PythonScriptEngine;
 import org.apache.tajo.util.ClassUtil;
-import org.apache.tajo.util.TUtil;
 
 import java.io.IOException;
 import java.lang.reflect.Method;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/function/FunctionLoader.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/function/FunctionLoader.java
@@ -108,7 +108,7 @@ public class FunctionLoader {
           continue;
         }
 
-        List<Path> filePaths = TUtil.newList();
+        List<Path> filePaths = new ArrayList<>();
         if (localFS.isDirectory(codePath)) {
           for (FileStatus file : localFS.listStatus(codePath,
               (Path path) -> path.getName().endsWith(PythonScriptEngine.FILE_EXTENSION))) {

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
@@ -61,6 +61,7 @@ import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Stack;
 
@@ -928,11 +929,11 @@ public class PhysicalPlannerImpl implements PhysicalPlanner {
 
         if (broadcastFlag) {
           PartitionedTableScanNode partitionedTableScanNode = (PartitionedTableScanNode) scanNode;
-          List<Fragment> fileFragments = TUtil.newList();
+          List<Fragment> fileFragments = new ArrayList<>();
 
           FileTablespace space = (FileTablespace) TablespaceManager.get(scanNode.getTableDesc().getUri());
           for (Path path : partitionedTableScanNode.getInputPaths()) {
-            fileFragments.addAll(TUtil.newList(space.split(scanNode.getCanonicalName(), path)));
+            fileFragments.addAll(Arrays.asList(space.split(scanNode.getCanonicalName(), path)));
           }
 
           FragmentProto[] fragments =

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
@@ -933,7 +933,7 @@ public class PhysicalPlannerImpl implements PhysicalPlanner {
 
           FileTablespace space = (FileTablespace) TablespaceManager.get(scanNode.getTableDesc().getUri());
           for (Path path : partitionedTableScanNode.getInputPaths()) {
-            fileFragments.addAll(new ArrayList<>(Arrays.asList(space.split(scanNode.getCanonicalName(), path))));
+            fileFragments.addAll(Arrays.asList(space.split(scanNode.getCanonicalName(), path)));
           }
 
           FragmentProto[] fragments =

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/PhysicalPlannerImpl.java
@@ -933,7 +933,7 @@ public class PhysicalPlannerImpl implements PhysicalPlanner {
 
           FileTablespace space = (FileTablespace) TablespaceManager.get(scanNode.getTableDesc().getUri());
           for (Path path : partitionedTableScanNode.getInputPaths()) {
-            fileFragments.addAll(Arrays.asList(space.split(scanNode.getCanonicalName(), path)));
+            fileFragments.addAll(new ArrayList<>(Arrays.asList(space.split(scanNode.getCanonicalName(), path))));
           }
 
           FragmentProto[] fragments =

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/enforce/Enforcer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/enforce/Enforcer.java
@@ -24,6 +24,7 @@ import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.common.ProtoObject;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -212,7 +213,7 @@ public class Enforcer implements ProtoObject<EnforcerProto> {
     if (proto != null) {
       return proto.getPropertiesList();
     } else {
-      List<EnforceProperty> list = TUtil.newList();
+      List<EnforceProperty> list = new ArrayList<>();
       for (List<EnforceProperty> propertyList : properties.values()) {
         list.addAll(propertyList);
       }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/BaseGlobalPlanRewriteRuleProvider.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/BaseGlobalPlanRewriteRuleProvider.java
@@ -21,7 +21,6 @@ package org.apache.tajo.engine.planner.global.rewriter;
 import com.google.common.collect.Lists;
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.engine.planner.global.rewriter.rules.BroadcastJoinRule;
-import org.apache.tajo.util.TUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/BaseGlobalPlanRewriteRuleProvider.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/BaseGlobalPlanRewriteRuleProvider.java
@@ -23,12 +23,13 @@ import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.engine.planner.global.rewriter.rules.BroadcastJoinRule;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 @SuppressWarnings("unused")
 public class BaseGlobalPlanRewriteRuleProvider extends GlobalPlanRewriteRuleProvider {
-  private static final List<Class<? extends GlobalPlanRewriteRule>> EMPTY_RULES = TUtil.newList();
+  private static final List<Class<? extends GlobalPlanRewriteRule>> EMPTY_RULES = new ArrayList<>();
 
   public BaseGlobalPlanRewriteRuleProvider(TajoConf conf) {
     super(conf);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
@@ -143,8 +143,7 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
         // When every child is a broadcast candidate, enforce non-broadcast for the largest relation for the join to be
         // computed at the node who stores such largest relation.
         if (isFullyBroadcastable(current)) {
-          List<ScanNode> broadcastCandidates = new ArrayList<>();
-          broadcastCandidates.addAll(current.getBroadcastRelations());
+          List<ScanNode> broadcastCandidates = new ArrayList<>(current.getBroadcastRelations());
           Collections.sort(broadcastCandidates, relSizeComparator);
 
           current.removeBroadcastRelation(broadcastCandidates.remove(broadcastCandidates.size()-1));
@@ -245,8 +244,7 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
             context.estimatedEbOutputSize.put(current.getId(), outputVolume);
           }
         } else {
-          List<ScanNode> relations = new ArrayList<>();
-          relations.addAll(current.getBroadcastRelations());
+          List<ScanNode> relations = new ArrayList<>(current.getBroadcastRelations());
           for (ScanNode eachRelation : relations) {
             current.removeBroadcastRelation(eachRelation);
           }
@@ -389,8 +387,7 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
      * @param block
      */
     private void checkTotalSizeOfBroadcastableRelations(Context context, ExecutionBlock block) {
-      List<ScanNode> broadcastCandidates = new ArrayList<>();
-      broadcastCandidates.addAll(block.getBroadcastRelations());
+      List<ScanNode> broadcastCandidates = new ArrayList<>(block.getBroadcastRelations());
       Collections.sort(broadcastCandidates, relSizeComparator);
 
       // Enforce broadcast for candidates in ascending order of relation size

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
@@ -143,7 +143,8 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
         // When every child is a broadcast candidate, enforce non-broadcast for the largest relation for the join to be
         // computed at the node who stores such largest relation.
         if (isFullyBroadcastable(current)) {
-          List<ScanNode> broadcastCandidates = TUtil.newList(current.getBroadcastRelations());
+          List<ScanNode> broadcastCandidates = new ArrayList<>();
+          broadcastCandidates.addAll(current.getBroadcastRelations());
           Collections.sort(broadcastCandidates, relSizeComparator);
 
           current.removeBroadcastRelation(broadcastCandidates.remove(broadcastCandidates.size()-1));
@@ -244,7 +245,8 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
             context.estimatedEbOutputSize.put(current.getId(), outputVolume);
           }
         } else {
-          List<ScanNode> relations = TUtil.newList(current.getBroadcastRelations());
+          List<ScanNode> relations = new ArrayList<>();
+          relations.addAll(current.getBroadcastRelations());
           for (ScanNode eachRelation : relations) {
             current.removeBroadcastRelation(eachRelation);
           }
@@ -387,7 +389,8 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
      * @param block
      */
     private void checkTotalSizeOfBroadcastableRelations(Context context, ExecutionBlock block) {
-      List<ScanNode> broadcastCandidates = TUtil.newList(block.getBroadcastRelations());
+      List<ScanNode> broadcastCandidates = new ArrayList<>();
+      broadcastCandidates.addAll(block.getBroadcastRelations());
       Collections.sort(broadcastCandidates, relSizeComparator);
 
       // Enforce broadcast for candidates in ascending order of relation size
@@ -449,7 +452,7 @@ public class BroadcastJoinRule implements GlobalPlanRewriteRule {
     private void addUnionNodeIfNecessary(Map<ExecutionBlockId, ExecutionBlockId> unionScanMap, MasterPlan plan,
                                          ExecutionBlock child, ExecutionBlock current) {
       if (unionScanMap != null) {
-        List<ExecutionBlockId> unionScans = TUtil.newList();
+        List<ExecutionBlockId> unionScans = new ArrayList<>();
         ExecutionBlockId representativeId = null;
         if (unionScanMap.containsKey(child.getId())) {
           representativeId = unionScanMap.get(child.getId());

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/global/rewriter/rules/BroadcastJoinRule.java
@@ -33,7 +33,6 @@ import org.apache.tajo.plan.joinorder.GreedyHeuristicJoinOrderAlgorithm;
 import org.apache.tajo.plan.logical.*;
 import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.unit.StorageUnit;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.graph.DirectedGraphVisitor;
 
 import java.util.*;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
@@ -72,7 +72,7 @@ public class DistinctGroupbyHashAggregationExec extends UnaryPhysicalExec {
   public void init() throws IOException {
     super.init();
 
-    distinctGroupingKeyColumnSet = TUtil.newList();
+    distinctGroupingKeyColumnSet = new ArrayList<>();
     for (Column col : plan.getGroupingColumns()) {
       if (!distinctGroupingKeyColumnSet.contains(col)) {
         distinctGroupingKeyColumnSet.add(col);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyHashAggregationExec.java
@@ -32,7 +32,6 @@ import org.apache.tajo.plan.logical.GroupbyNode;
 import org.apache.tajo.storage.NullTuple;
 import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.storage.VTuple;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ExternalSortExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ExternalSortExec.java
@@ -54,6 +54,7 @@ import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -139,7 +140,7 @@ public class ExternalSortExec extends SortExec {
                           final CatalogProtos.FragmentProto[] fragments) throws PhysicalPlanningException {
     this(context, plan);
 
-    mergedInputFragments = TUtil.newList();
+    mergedInputFragments = new ArrayList<>();
     for (CatalogProtos.FragmentProto proto : fragments) {
       FileFragment fragment = FragmentConvertor.convert(FileFragment.class, proto);
       mergedInputFragments.add(new Chunk(inSchema, fragment, scanNode.getTableDesc().getMeta()));
@@ -212,7 +213,7 @@ public class ExternalSortExec extends SortExec {
    */
   private List<Chunk> sortAndStoreAllChunks() throws IOException {
     Tuple tuple;
-    List<Chunk> chunkPaths = TUtil.newList();
+    List<Chunk> chunkPaths = new ArrayList<>();
 
     int chunkId = 0;
     long runStartTime = System.currentTimeMillis();
@@ -333,8 +334,9 @@ public class ExternalSortExec extends SortExec {
 
   private Scanner externalMergeAndSort(List<Chunk> chunks) throws Exception {
     int level = 0;
-    final List<Chunk> inputFiles = TUtil.newList(chunks);
-    final List<Chunk> outputFiles = TUtil.newList();
+    final List<Chunk> inputFiles = new ArrayList<>();
+    inputFiles.addAll(chunks);
+    final List<Chunk> outputFiles = new ArrayList<>();
     int remainRun = inputFiles.size();
     int chunksSize = chunks.size();
 
@@ -347,9 +349,9 @@ public class ExternalSortExec extends SortExec {
       int remainInputRuns = inputFiles.size();
       int outChunkId = 0;
       int outputFileNum = 0;
-      List<Future<Chunk>> futures = TUtil.newList();
+      List<Future<Chunk>> futures = new ArrayList<>();
       // the number of files being merged in threads.
-      List<Integer> numberOfMergingFiles = TUtil.newList();
+      List<Integer> numberOfMergingFiles = new ArrayList<>();
 
       for (int startIdx = 0; startIdx < inputFiles.size();) {
 
@@ -376,7 +378,7 @@ public class ExternalSortExec extends SortExec {
           info(LOG, "Unbalanced merge possibility detected: number of remain input (" + remainInputRuns
               + ") and output files (" + outputFileNum + ") <= " + defaultFanout);
 
-          List<Chunk> switched = TUtil.newList();
+          List<Chunk> switched = new ArrayList<>();
           // switch the remain inputs to the next outputs
           for (int j = startIdx; j < inputFiles.size(); j++) {
             switched.add(inputFiles.get(j));

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ExternalSortExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ExternalSortExec.java
@@ -49,7 +49,6 @@ import org.apache.tajo.tuple.memory.UnSafeTuple;
 import org.apache.tajo.tuple.memory.UnSafeTupleList;
 import org.apache.tajo.unit.StorageUnit;
 import org.apache.tajo.util.FileUtil;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.File;

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ExternalSortExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/ExternalSortExec.java
@@ -334,8 +334,7 @@ public class ExternalSortExec extends SortExec {
 
   private Scanner externalMergeAndSort(List<Chunk> chunks) throws Exception {
     int level = 0;
-    final List<Chunk> inputFiles = new ArrayList<>();
-    inputFiles.addAll(chunks);
+    final List<Chunk> inputFiles = new ArrayList<>(chunks);
     final List<Chunk> outputFiles = new ArrayList<>();
     int remainRun = inputFiles.size();
     int chunksSize = chunks.size();

--- a/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
@@ -501,7 +501,7 @@ public class HdfsServiceTracker extends HAServiceTracker {
       FSDataInputStream stream = fs.open(activeMasterEntry);
       String data = stream.readUTF();
       stream.close();
-      addressElements.addAll(Arrays.asList(data.split("_"))); // Add remains entries to elements
+      addressElements.addAll(new ArrayList<>(Arrays.asList(data.split("_")))); // Add remains entries to elements
 
       // ensure the number of entries
       Preconditions.checkState(addressElements.size() == 5, "Fewer service addresses than necessary.");

--- a/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
@@ -501,7 +501,7 @@ public class HdfsServiceTracker extends HAServiceTracker {
       FSDataInputStream stream = fs.open(activeMasterEntry);
       String data = stream.readUTF();
       stream.close();
-      addressElements.addAll(new ArrayList<>(Arrays.asList(data.split("_")))); // Add remains entries to elements
+      addressElements.addAll(Arrays.asList(data.split("_"))); // Add remains entries to elements
 
       // ensure the number of entries
       Preconditions.checkState(addressElements.size() == 5, "Fewer service addresses than necessary.");

--- a/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
@@ -33,7 +33,6 @@ import org.apache.tajo.service.HAServiceTracker;
 import org.apache.tajo.service.ServiceTrackerException;
 import org.apache.tajo.service.TajoMasterInfo;
 import org.apache.tajo.util.FileUtil;
-import org.apache.tajo.util.TUtil;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
+++ b/tajo-core/src/main/java/org/apache/tajo/ha/HdfsServiceTracker.java
@@ -38,6 +38,7 @@ import org.apache.tajo.util.TUtil;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -302,7 +303,7 @@ public class HdfsServiceTracker extends HAServiceTracker {
 
   @Override
   public List<TajoMasterInfo> getMasters() throws IOException {
-    List<TajoMasterInfo> list = TUtil.newList();
+    List<TajoMasterInfo> list = new ArrayList<>();
 
     FileStatus[] files = fs.listStatus(activePath);
     for(FileStatus status : files) {
@@ -496,12 +497,12 @@ public class HdfsServiceTracker extends HAServiceTracker {
         throw new ServiceTrackerException("Active master entry must be a file, but it is a directory.");
       }
 
-      List<String> addressElements = TUtil.newList();
+      List<String> addressElements = new ArrayList<>();
 
       FSDataInputStream stream = fs.open(activeMasterEntry);
       String data = stream.readUTF();
       stream.close();
-      addressElements.addAll(TUtil.newList(data.split("_"))); // Add remains entries to elements
+      addressElements.addAll(Arrays.asList(data.split("_"))); // Add remains entries to elements
 
       // ensure the number of entries
       Preconditions.checkState(addressElements.size() == 5, "Fewer service addresses than necessary.");

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
@@ -48,7 +48,6 @@ import org.apache.tajo.storage.Tablespace;
 import org.apache.tajo.storage.TablespaceManager;
 import org.apache.tajo.util.Pair;
 import org.apache.tajo.util.StringUtils;
-import org.apache.tajo.util.TUtil;
 
 import java.io.File;
 import java.io.IOException;

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
@@ -612,7 +612,7 @@ public class DDLExecutor {
 
     // Find missing partitions from filesystem
     List<PartitionDescProto> existingPartitions = catalog.getPartitionsOfTable(databaseName, simpleTableName);
-    List<String> existingPartitionNames = TUtil.newList();
+    List<String> existingPartitionNames = new ArrayList<>();
     Path existingPartitionPath = null;
 
     for(PartitionDescProto existingPartition : existingPartitions) {
@@ -624,7 +624,7 @@ public class DDLExecutor {
     }
 
     // Find missing partitions from CatalogStore
-    List<PartitionDescProto> targetPartitions = TUtil.newList();
+    List<PartitionDescProto> targetPartitions = new ArrayList<>();
     for(Path filteredPath : filteredPaths) {
 
       int startIdx = filteredPath.toString().indexOf(PartitionedTableRewriter.getColumnPartitionPathPrefix

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultSystemScanner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultSystemScanner.java
@@ -767,7 +767,7 @@ public class NonForwardQueryResultSystemScanner implements NonForwardQueryResult
         this.qual.bind(null, inSchema);
       }
 
-      cachedData = TUtil.newList();
+      cachedData = new ArrayList<>();
       currentRow = 0;
       isClosed = false;
       

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultSystemScanner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/NonForwardQueryResultSystemScanner.java
@@ -60,7 +60,6 @@ import org.apache.tajo.storage.VTuple;
 import org.apache.tajo.tuple.memory.MemoryBlock;
 import org.apache.tajo.tuple.memory.MemoryRowBlock;
 import org.apache.tajo.util.KeyValueSet;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
@@ -50,7 +50,6 @@ import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.storage.StorageConstants;
 import org.apache.tajo.storage.Tablespace;
 import org.apache.tajo.storage.TablespaceManager;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.history.QueryHistory;
 import org.apache.tajo.util.history.StageHistory;
 

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
@@ -540,7 +540,7 @@ public class Query implements EventHandler<QueryEvent> {
 
     private List<PartitionDescProto> getPartitionsWithContentsSummary(TajoConf conf, Path outputDir,
         List<PartitionDescProto> partitions) throws IOException {
-      List<PartitionDescProto> finalPartitions = TUtil.newList();
+      List<PartitionDescProto> finalPartitions = new ArrayList<>();
 
       FileSystem fileSystem = outputDir.getFileSystem(conf);
       for (PartitionDescProto partition : partitions) {
@@ -560,7 +560,7 @@ public class Query implements EventHandler<QueryEvent> {
     }
 
     private static class QueryHookExecutor {
-      private List<QueryHook> hookList = TUtil.newList();
+      private List<QueryHook> hookList = new ArrayList<>();
       private QueryMaster.QueryMasterContext context;
 
       public QueryHookExecutor(QueryMaster.QueryMasterContext context) {

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -321,12 +321,12 @@ public class Repartitioner {
             if (tbNameToInterm.containsKey(scanEbId)) {
               tbNameToInterm.get(scanEbId).add(intermediateEntry);
             } else {
-              tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
+              tbNameToInterm.put(scanEbId, new ArrayList<>(Arrays.asList(intermediateEntry)));
             }
           } else {
             Map<ExecutionBlockId, List<IntermediateEntry>> tbNameToInterm =
                     new HashMap<>();
-            tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
+            tbNameToInterm.put(scanEbId, new ArrayList<>(Arrays.asList(intermediateEntry)));
             hashEntries.put(intermediateEntry.getPartId(), tbNameToInterm);
           }
         }

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -321,12 +321,12 @@ public class Repartitioner {
             if (tbNameToInterm.containsKey(scanEbId)) {
               tbNameToInterm.get(scanEbId).add(intermediateEntry);
             } else {
-              tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
+              tbNameToInterm.put(scanEbId, new ArrayList<>(Arrays.asList(intermediateEntry)));
             }
           } else {
             Map<ExecutionBlockId, List<IntermediateEntry>> tbNameToInterm =
                     new HashMap<>();
-            tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
+            tbNameToInterm.put(scanEbId, new ArrayList<>(Arrays.asList(intermediateEntry)));
             hashEntries.put(intermediateEntry.getPartId(), tbNameToInterm);
           }
         }
@@ -1078,7 +1078,7 @@ public class Repartitioner {
           fetchListVolume = 0;
         }
         FetchImpl fetch = new FetchImpl(fetchName, currentInterm.getPullHost(), SCATTERED_HASH_SHUFFLE,
-            ebId, currentInterm.getPartId(), Arrays.asList(currentInterm));
+            ebId, currentInterm.getPartId(), new ArrayList<>(Arrays.asList(currentInterm)));
         fetch.setOffset(eachSplit.getFirst());
         fetch.setLength(eachSplit.getSecond());
         fetchListForSingleTask.add(fetch.getProto());
@@ -1219,7 +1219,7 @@ public class Repartitioner {
       if (hashed.containsKey(entry.getPartId())) {
         hashed.get(entry.getPartId()).add(entry);
       } else {
-        hashed.put(entry.getPartId(), Arrays.asList(entry));
+        hashed.put(entry.getPartId(), new ArrayList<>(Arrays.asList(entry)));
       }
     }
 
@@ -1235,7 +1235,7 @@ public class Repartitioner {
       if (hashed.containsKey(host)) {
         hashed.get(host).add(entry);
       } else {
-        hashed.put(host, Arrays.asList(entry));
+        hashed.put(host, new ArrayList<>(Arrays.asList(entry)));
       }
     }
 

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -321,9 +321,9 @@ public class Repartitioner {
             if (tbNameToInterm.containsKey(scanEbId)) {
               tbNameToInterm.get(scanEbId).add(intermediateEntry);
             } else {
-              List listInput = new ArrayList<>();
-              listInput.addAll(Arrays.asList(intermediateEntry));
-              tbNameToInterm.put(scanEbId, listInput);
+              List inputList = new ArrayList<>();
+              inputList.addAll(Arrays.asList(intermediateEntry));
+              tbNameToInterm.put(scanEbId, inputList);
             }
           } else {
             Map<ExecutionBlockId, List<IntermediateEntry>> tbNameToInterm =
@@ -1082,10 +1082,10 @@ public class Repartitioner {
           fetchListForSingleTask = new ArrayList<>();
           fetchListVolume = 0;
         }
-        List listInput = new ArrayList<>();
-        listInput.addAll(Arrays.asList(currentInterm));
+        List inputList = new ArrayList<>();
+        inputList.addAll(Arrays.asList(currentInterm));
         FetchImpl fetch = new FetchImpl(fetchName, currentInterm.getPullHost(), SCATTERED_HASH_SHUFFLE,
-            ebId, currentInterm.getPartId(), listInput);
+            ebId, currentInterm.getPartId(), inputList);
         fetch.setOffset(eachSplit.getFirst());
         fetch.setLength(eachSplit.getSecond());
         fetchListForSingleTask.add(fetch.getProto());
@@ -1226,9 +1226,9 @@ public class Repartitioner {
       if (hashed.containsKey(entry.getPartId())) {
         hashed.get(entry.getPartId()).add(entry);
       } else {
-        List listInput = new ArrayList<>();
-        listInput.addAll(Arrays.asList(entry));
-        hashed.put(entry.getPartId(), listInput);
+        List inputList = new ArrayList<>();
+        inputList.addAll(Arrays.asList(entry));
+        hashed.put(entry.getPartId(), inputList);
       }
     }
 
@@ -1244,9 +1244,9 @@ public class Repartitioner {
       if (hashed.containsKey(host)) {
         hashed.get(host).add(entry);
       } else {
-        List listInput = new ArrayList<>();
-        listInput.addAll(Arrays.asList(entry));
-        hashed.put(host, listInput);
+        List inputList = new ArrayList<>();
+        inputList.addAll(Arrays.asList(entry));
+        hashed.put(host, inputList);
       }
     }
 

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -321,16 +321,12 @@ public class Repartitioner {
             if (tbNameToInterm.containsKey(scanEbId)) {
               tbNameToInterm.get(scanEbId).add(intermediateEntry);
             } else {
-              List inputList = new ArrayList<>();
-              inputList.addAll(Arrays.asList(intermediateEntry));
-              tbNameToInterm.put(scanEbId, inputList);
+              tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
             }
           } else {
             Map<ExecutionBlockId, List<IntermediateEntry>> tbNameToInterm =
                     new HashMap<>();
-            List inputList = new ArrayList<>();
-            inputList.addAll(Arrays.asList(intermediateEntry));
-            tbNameToInterm.put(scanEbId, inputList);
+            tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
             hashEntries.put(intermediateEntry.getPartId(), tbNameToInterm);
           }
         }
@@ -1003,8 +999,7 @@ public class Repartitioner {
         int partId = eachInterm.getPartId();
         List<IntermediateEntry> partitionInterms = partitionIntermMap.get(partId);
         if (partitionInterms == null) {
-          partitionInterms = new ArrayList<>();
-          partitionInterms.addAll(Arrays.asList(eachInterm));
+          partitionInterms = new ArrayList<>(Arrays.asList(eachInterm));
           partitionIntermMap.put(partId, partitionInterms);
         } else {
           partitionInterms.add(eachInterm);
@@ -1082,10 +1077,8 @@ public class Repartitioner {
           fetchListForSingleTask = new ArrayList<>();
           fetchListVolume = 0;
         }
-        List inputList = new ArrayList<>();
-        inputList.addAll(Arrays.asList(currentInterm));
         FetchImpl fetch = new FetchImpl(fetchName, currentInterm.getPullHost(), SCATTERED_HASH_SHUFFLE,
-            ebId, currentInterm.getPartId(), inputList);
+            ebId, currentInterm.getPartId(), Arrays.asList(currentInterm));
         fetch.setOffset(eachSplit.getFirst());
         fetch.setLength(eachSplit.getSecond());
         fetchListForSingleTask.add(fetch.getProto());
@@ -1226,9 +1219,7 @@ public class Repartitioner {
       if (hashed.containsKey(entry.getPartId())) {
         hashed.get(entry.getPartId()).add(entry);
       } else {
-        List inputList = new ArrayList<>();
-        inputList.addAll(Arrays.asList(entry));
-        hashed.put(entry.getPartId(), inputList);
+        hashed.put(entry.getPartId(), Arrays.asList(entry));
       }
     }
 
@@ -1244,9 +1235,7 @@ public class Repartitioner {
       if (hashed.containsKey(host)) {
         hashed.get(host).add(entry);
       } else {
-        List inputList = new ArrayList<>();
-        inputList.addAll(Arrays.asList(entry));
-        hashed.put(host, inputList);
+        hashed.put(host, Arrays.asList(entry));
       }
     }
 

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -321,12 +321,16 @@ public class Repartitioner {
             if (tbNameToInterm.containsKey(scanEbId)) {
               tbNameToInterm.get(scanEbId).add(intermediateEntry);
             } else {
-              tbNameToInterm.put(scanEbId, TUtil.newList(intermediateEntry));
+              List listInput = new ArrayList<>();
+              listInput.addAll(Arrays.asList(intermediateEntry));
+              tbNameToInterm.put(scanEbId, listInput);
             }
           } else {
             Map<ExecutionBlockId, List<IntermediateEntry>> tbNameToInterm =
                     new HashMap<>();
-            tbNameToInterm.put(scanEbId, TUtil.newList(intermediateEntry));
+            List inputList = new ArrayList<>();
+            inputList.addAll(Arrays.asList(intermediateEntry));
+            tbNameToInterm.put(scanEbId, inputList);
             hashEntries.put(intermediateEntry.getPartId(), tbNameToInterm);
           }
         }
@@ -999,7 +1003,8 @@ public class Repartitioner {
         int partId = eachInterm.getPartId();
         List<IntermediateEntry> partitionInterms = partitionIntermMap.get(partId);
         if (partitionInterms == null) {
-          partitionInterms = TUtil.newList(eachInterm);
+          partitionInterms = new ArrayList<>();
+          partitionInterms.addAll(Arrays.asList(eachInterm));
           partitionIntermMap.put(partId, partitionInterms);
         } else {
           partitionInterms.add(eachInterm);
@@ -1077,8 +1082,10 @@ public class Repartitioner {
           fetchListForSingleTask = new ArrayList<>();
           fetchListVolume = 0;
         }
+        List listInput = new ArrayList<>();
+        listInput.addAll(Arrays.asList(currentInterm));
         FetchImpl fetch = new FetchImpl(fetchName, currentInterm.getPullHost(), SCATTERED_HASH_SHUFFLE,
-            ebId, currentInterm.getPartId(), TUtil.newList(currentInterm));
+            ebId, currentInterm.getPartId(), listInput);
         fetch.setOffset(eachSplit.getFirst());
         fetch.setLength(eachSplit.getSecond());
         fetchListForSingleTask.add(fetch.getProto());
@@ -1219,7 +1226,9 @@ public class Repartitioner {
       if (hashed.containsKey(entry.getPartId())) {
         hashed.get(entry.getPartId()).add(entry);
       } else {
-        hashed.put(entry.getPartId(), TUtil.newList(entry));
+        List listInput = new ArrayList<>();
+        listInput.addAll(Arrays.asList(entry));
+        hashed.put(entry.getPartId(), listInput);
       }
     }
 
@@ -1235,7 +1244,9 @@ public class Repartitioner {
       if (hashed.containsKey(host)) {
         hashed.get(host).add(entry);
       } else {
-        hashed.put(host, TUtil.newList(entry));
+        List listInput = new ArrayList<>();
+        listInput.addAll(Arrays.asList(entry));
+        hashed.put(host, listInput);
       }
     }
 

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Repartitioner.java
@@ -321,12 +321,12 @@ public class Repartitioner {
             if (tbNameToInterm.containsKey(scanEbId)) {
               tbNameToInterm.get(scanEbId).add(intermediateEntry);
             } else {
-              tbNameToInterm.put(scanEbId, new ArrayList<>(Arrays.asList(intermediateEntry)));
+              tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
             }
           } else {
             Map<ExecutionBlockId, List<IntermediateEntry>> tbNameToInterm =
                     new HashMap<>();
-            tbNameToInterm.put(scanEbId, new ArrayList<>(Arrays.asList(intermediateEntry)));
+            tbNameToInterm.put(scanEbId, Arrays.asList(intermediateEntry));
             hashEntries.put(intermediateEntry.getPartId(), tbNameToInterm);
           }
         }
@@ -999,7 +999,7 @@ public class Repartitioner {
         int partId = eachInterm.getPartId();
         List<IntermediateEntry> partitionInterms = partitionIntermMap.get(partId);
         if (partitionInterms == null) {
-          partitionInterms = new ArrayList<>(Arrays.asList(eachInterm));
+          partitionInterms = Arrays.asList(eachInterm);
           partitionIntermMap.put(partId, partitionInterms);
         } else {
           partitionInterms.add(eachInterm);
@@ -1078,7 +1078,7 @@ public class Repartitioner {
           fetchListVolume = 0;
         }
         FetchImpl fetch = new FetchImpl(fetchName, currentInterm.getPullHost(), SCATTERED_HASH_SHUFFLE,
-            ebId, currentInterm.getPartId(), new ArrayList<>(Arrays.asList(currentInterm)));
+            ebId, currentInterm.getPartId(), Arrays.asList(currentInterm));
         fetch.setOffset(eachSplit.getFirst());
         fetch.setLength(eachSplit.getSecond());
         fetchListForSingleTask.add(fetch.getProto());
@@ -1219,7 +1219,7 @@ public class Repartitioner {
       if (hashed.containsKey(entry.getPartId())) {
         hashed.get(entry.getPartId()).add(entry);
       } else {
-        hashed.put(entry.getPartId(), new ArrayList<>(Arrays.asList(entry)));
+        hashed.put(entry.getPartId(), Arrays.asList(entry));
       }
     }
 
@@ -1235,7 +1235,7 @@ public class Repartitioner {
       if (hashed.containsKey(host)) {
         hashed.get(host).add(entry);
       } else {
-        hashed.put(host, new ArrayList<>(Arrays.asList(entry)));
+        hashed.put(host, Arrays.asList(entry));
       }
     }
 

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskAttemptContext.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskAttemptContext.java
@@ -120,7 +120,7 @@ public class TaskAttemptContext {
 
     this.partitionOutputVolume = Maps.newHashMap();
 
-    this.partitions = TUtil.newList();
+    this.partitions = new ArrayList<>();
   }
 
   @VisibleForTesting
@@ -292,7 +292,7 @@ public class TaskAttemptContext {
   }
 
   private List<Path> fragmentToPath(List<FragmentProto> tableFragments) {
-    List<Path> list = TUtil.newList();
+    List<Path> list = new ArrayList<>();
 
     for (FragmentProto proto : tableFragments) {
       FileFragment fragment = FragmentConvertor.convert(FileFragment.class, proto);

--- a/tajo-core/src/main/java/org/apache/tajo/worker/TaskAttemptContext.java
+++ b/tajo-core/src/main/java/org/apache/tajo/worker/TaskAttemptContext.java
@@ -39,7 +39,6 @@ import org.apache.tajo.storage.HashShuffleAppenderManager;
 import org.apache.tajo.storage.fragment.FileFragment;
 import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.storage.fragment.FragmentConvertor;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.worker.TajoWorker.WorkerContext;
 
 import java.io.File;

--- a/tajo-core/src/main/resources/webapps/admin/cluster.jsp
+++ b/tajo-core/src/main/resources/webapps/admin/cluster.jsp
@@ -72,7 +72,7 @@
   String deadQueryMastersHtml = deadQueryMasters.isEmpty() ? "0": "<font color='red'>" + deadQueryMasters.size() + "</font>";
 
   ServiceTracker haService = master.getContext().getHAService();
-  List<TajoMasterInfo> masters = TUtil.newList();
+  List<TajoMasterInfo> masters = new ArrayList<>();
 
   String activeLabel = "";
   if (haService != null) {

--- a/tajo-core/src/main/resources/webapps/admin/index.jsp
+++ b/tajo-core/src/main/resources/webapps/admin/index.jsp
@@ -35,6 +35,7 @@
 <%@ page import="java.net.InetSocketAddress" %>
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.util.ArrayList" %>
 
 <%
   TajoMaster master = (TajoMaster) StaticHttpServer.getInstance().getAttribute("tajo.info.server.object");
@@ -80,7 +81,7 @@
   String numDeadQueryMastersHtml = numDeadQueryMasters == 0 ? "0" : "<font color='red'>" + numDeadQueryMasters + "</font>";
 
   ServiceTracker haService = master.getContext().getHAService();
-  List<TajoMasterInfo> masters = TUtil.newList();
+  List<TajoMasterInfo> masters = new ArrayList<>();
 
   String activeLabel = "";
   if (haService != null) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
@@ -594,9 +594,7 @@ public class ExprAnnotator extends BaseAlgebraVisitor<ExprAnnotator.Context, Eva
     FunctionDesc funcDesc = catalog.getFunction(expr.getSignature(), paramTypes);
 
     // trying the implicit type conversion between actual parameter types and the definition types.
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList(funcDesc.getParamTypes()));
-    if (CatalogUtil.checkIfVariableLengthParamDefinition(inputList)) {
+    if (CatalogUtil.checkIfVariableLengthParamDefinition(Arrays.asList(funcDesc.getParamTypes()))) {
       DataType lastDataType = funcDesc.getParamTypes()[0];
       for (int i = 0; i < givenArgs.length; i++) {
         if (i < (funcDesc.getParamTypes().length - 1)) { // variable length

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
@@ -45,7 +45,10 @@ import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.datetime.DateTimeUtil;
 import org.apache.tajo.util.datetime.TimeMeta;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TimeZone;
 
 import static org.apache.tajo.algebra.WindowSpec.WindowFrameEndBoundType;
 import static org.apache.tajo.algebra.WindowSpec.WindowFrameStartBoundType;
@@ -594,7 +597,7 @@ public class ExprAnnotator extends BaseAlgebraVisitor<ExprAnnotator.Context, Eva
     FunctionDesc funcDesc = catalog.getFunction(expr.getSignature(), paramTypes);
 
     // trying the implicit type conversion between actual parameter types and the definition types.
-    if (CatalogUtil.checkIfVariableLengthParamDefinition(new ArrayList<>(Arrays.asList(funcDesc.getParamTypes())))) {
+    if (CatalogUtil.checkIfVariableLengthParamDefinition(Arrays.asList(funcDesc.getParamTypes()))) {
       DataType lastDataType = funcDesc.getParamTypes()[0];
       for (int i = 0; i < givenArgs.length; i++) {
         if (i < (funcDesc.getParamTypes().length - 1)) { // variable length

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
@@ -594,7 +594,7 @@ public class ExprAnnotator extends BaseAlgebraVisitor<ExprAnnotator.Context, Eva
     FunctionDesc funcDesc = catalog.getFunction(expr.getSignature(), paramTypes);
 
     // trying the implicit type conversion between actual parameter types and the definition types.
-    if (CatalogUtil.checkIfVariableLengthParamDefinition(Arrays.asList(funcDesc.getParamTypes()))) {
+    if (CatalogUtil.checkIfVariableLengthParamDefinition(new ArrayList<>(Arrays.asList(funcDesc.getParamTypes())))) {
       DataType lastDataType = funcDesc.getParamTypes()[0];
       for (int i = 0; i < givenArgs.length; i++) {
         if (i < (funcDesc.getParamTypes().length - 1)) { // variable length

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/ExprAnnotator.java
@@ -45,9 +45,7 @@ import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.datetime.DateTimeUtil;
 import org.apache.tajo.util.datetime.TimeMeta;
 
-import java.util.Set;
-import java.util.Stack;
-import java.util.TimeZone;
+import java.util.*;
 
 import static org.apache.tajo.algebra.WindowSpec.WindowFrameEndBoundType;
 import static org.apache.tajo.algebra.WindowSpec.WindowFrameStartBoundType;
@@ -596,7 +594,9 @@ public class ExprAnnotator extends BaseAlgebraVisitor<ExprAnnotator.Context, Eva
     FunctionDesc funcDesc = catalog.getFunction(expr.getSignature(), paramTypes);
 
     // trying the implicit type conversion between actual parameter types and the definition types.
-    if (CatalogUtil.checkIfVariableLengthParamDefinition(TUtil.newList(funcDesc.getParamTypes()))) {
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList(funcDesc.getParamTypes()));
+    if (CatalogUtil.checkIfVariableLengthParamDefinition(inputList)) {
       DataType lastDataType = funcDesc.getParamTypes()[0];
       for (int i = 0; i < givenArgs.length; i++) {
         if (i < (funcDesc.getParamTypes().length - 1)) { // variable length

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalOptimizer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalOptimizer.java
@@ -260,7 +260,7 @@ public class LogicalOptimizer {
                                    SelectionNode node, Stack<LogicalNode> stack) throws TajoException {
       // all join predicate candidates must be collected before building the join tree except non-equality conditions
       // TODO: non-equality conditions should also be considered as join conditions after TAJO-1554
-      List<EvalNode> candidateJoinQuals = TUtil.newList();
+      List<EvalNode> candidateJoinQuals = new ArrayList<>();
       for (EvalNode eachEval : AlgebraicUtil.toConjunctiveNormalFormArray(node.getQual())) {
         if (EvalTreeUtil.isJoinQual(eachEval, false)) {
           candidateJoinQuals.add(eachEval);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalOptimizer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalOptimizer.java
@@ -41,7 +41,6 @@ import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
 import org.apache.tajo.storage.StorageService;
 import org.apache.tajo.util.ReflectionUtil;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.graph.DirectedGraphCursor;
 
 import java.util.*;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlan.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlan.java
@@ -288,7 +288,7 @@ public class LogicalPlan {
   }
 
   public List<QueryBlock> getChildBlocks(QueryBlock block) {
-    List<QueryBlock> childBlocks = TUtil.newList();
+    List<QueryBlock> childBlocks = new ArrayList<>();
     for (String blockName : queryBlockGraph.getChilds(block.getName())) {
       childBlocks.add(queryBlocks.get(blockName));
     }
@@ -431,7 +431,7 @@ public class LogicalPlan {
     private final Map<String, List<String>> relationAliasMap = new HashMap<>();
     private final Map<String, String> columnAliasMap = new HashMap<>();
     private final Map<OpType, List<Expr>> operatorToExprMap = new HashMap<>();
-    private final List<RelationNode> relationList = TUtil.newList();
+    private final List<RelationNode> relationList = new ArrayList<>();
     private final Map<Integer, List<AccessPathInfo>> relNodePidAccessPathMap = new HashMap<>();
     private boolean hasWindowFunction = false;
     private final Map<String, ConstEval> constantPoolByRef = Maps.newHashMap();

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
@@ -91,7 +91,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     QueryBlock queryBlock;
     EvalTreeOptimizer evalOptimizer;
     TimeZone timeZone;
-    List<Expr> unplannedExprs = TUtil.newList();
+    List<Expr> unplannedExprs = new ArrayList<>();
     boolean debugOrUnitTests;
     Integer noNameSubqueryId = 0;
 
@@ -370,7 +370,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     String [] referenceNames = new String[finalTargetNum];
     ExprNormalizedResult[] normalizedExprList = new ExprNormalizedResult[finalTargetNum];
 
-    List<ExprNormalizer.WindowSpecReferences> windowSpecReferencesList = TUtil.newList();
+    List<ExprNormalizer.WindowSpecReferences> windowSpecReferencesList = new ArrayList<>();
 
     List<Integer> targetsIds = normalize(context, projection, normalizedExprList, new Matcher() {
       @Override
@@ -1030,8 +1030,8 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     ////////////////////////////////////////////////////////
 
     // create EvalNodes and check if each EvalNode can be evaluated here.
-    List<String> aggEvalNames = TUtil.newList();
-    List<AggregationFunctionCallEval> aggEvalNodes = TUtil.newList();
+    List<String> aggEvalNames = new ArrayList<>();
+    List<AggregationFunctionCallEval> aggEvalNodes = new ArrayList<>();
     boolean includeDistinctFunction = false;
     for (Iterator<NamedExpr> iterator = block.namedExprsMgr.getIteratorForUnevaluatedExprs(); iterator.hasNext();) {
       NamedExpr namedExpr = iterator.next();
@@ -1191,7 +1191,8 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     // In this case, this join is the top most one within a query block.
     boolean isTopMostJoin = stack.isEmpty() ? true : stack.peek().getType() != OpType.Join;
     List<String> newlyEvaluatedExprs = getNewlyEvaluatedExprsForJoin(context, joinNode, isTopMostJoin);
-    List<Target> targets = TUtil.newList(PlannerUtil.schemaToTargets(merged));
+    List<Target> targets = new ArrayList<>();
+    targets.addAll(PlannerUtil.schemaToTargets(merged));
 
     for (String newAddedExpr : newlyEvaluatedExprs) {
       targets.add(block.namedExprsMgr.getTarget(newAddedExpr, true));
@@ -1215,7 +1216,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     QueryBlock block = context.queryBlock;
 
     EvalNode evalNode;
-    List<String> newlyEvaluatedExprs = TUtil.newList();
+    List<String> newlyEvaluatedExprs = new ArrayList<>();
     for (Iterator<NamedExpr> it = block.namedExprsMgr.getIteratorForUnevaluatedExprs(); it.hasNext();) {
       NamedExpr namedExpr = it.next();
       try {
@@ -1286,7 +1287,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     block.addJoinType(join.getJoinType());
 
     EvalNode evalNode;
-    List<String> newlyEvaluatedExprs = TUtil.newList();
+    List<String> newlyEvaluatedExprs = new ArrayList<>();
     for (Iterator<NamedExpr> it = block.namedExprsMgr.getIteratorForUnevaluatedExprs(); it.hasNext();) {
       NamedExpr namedExpr = it.next();
       try {
@@ -1299,7 +1300,8 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
       } catch (UndefinedColumnException ve) {}
     }
 
-    List<Target> targets = TUtil.newList(PlannerUtil.schemaToTargets(merged));
+    List<Target> targets = new ArrayList<>();
+    targets.addAll(PlannerUtil.schemaToTargets(merged));
     for (String newAddedExpr : newlyEvaluatedExprs) {
       targets.add(block.namedExprsMgr.getTarget(newAddedExpr, true));
     }
@@ -1730,7 +1732,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
 
       // Modifying projected columns by adding NULL constants
       // It is because that table appender does not support target columns to be written.
-      List<Target> targets = TUtil.newList();
+      List<Target> targets = new ArrayList<>();
 
       for (Column column : tableSchema.getAllColumns()) {
         int idxInProjectionNode = targetColumns.getIndex(column);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
@@ -1191,8 +1191,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     // In this case, this join is the top most one within a query block.
     boolean isTopMostJoin = stack.isEmpty() ? true : stack.peek().getType() != OpType.Join;
     List<String> newlyEvaluatedExprs = getNewlyEvaluatedExprsForJoin(context, joinNode, isTopMostJoin);
-    List<Target> targets = new ArrayList<>();
-    targets.addAll(PlannerUtil.schemaToTargets(merged));
+    List<Target> targets = new ArrayList<>(PlannerUtil.schemaToTargets(merged));
 
     for (String newAddedExpr : newlyEvaluatedExprs) {
       targets.add(block.namedExprsMgr.getTarget(newAddedExpr, true));
@@ -1300,8 +1299,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
       } catch (UndefinedColumnException ve) {}
     }
 
-    List<Target> targets = new ArrayList<>();
-    targets.addAll(PlannerUtil.schemaToTargets(merged));
+    List<Target> targets = new ArrayList<>(PlannerUtil.schemaToTargets(merged));
     for (String newAddedExpr : newlyEvaluatedExprs) {
       targets.add(block.namedExprsMgr.getTarget(newAddedExpr, true));
     }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
@@ -52,7 +52,6 @@ import org.apache.tajo.storage.StorageService;
 import org.apache.tajo.util.KeyValueSet;
 import org.apache.tajo.util.Pair;
 import org.apache.tajo.util.StringUtils;
-import org.apache.tajo.util.TUtil;
 
 import java.net.URI;
 import java.util.*;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/NamedExprsManager.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/NamedExprsManager.java
@@ -349,7 +349,7 @@ public class NamedExprsManager {
     private final Iterator<NamedExpr> iterator;
 
     public UnevaluatedIterator() {
-      List<NamedExpr> unEvaluatedList = TUtil.newList();
+      List<NamedExpr> unEvaluatedList = new ArrayList<>();
       for (Integer refId: idToNamesMap.keySet()) {
         String name = idToNamesMap.get(refId).get(0);
         if (!isEvaluated(name)) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/AlgebraicUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/AlgebraicUtil.java
@@ -543,7 +543,7 @@ public class AlgebraicUtil {
    * @return An array of CNF-formed algebra expressions
    */
   public static Expr[] toConjunctiveNormalFormArray(Expr expr) {
-    List<Expr> list = TUtil.newList();
+    List<Expr> list = new ArrayList<>();
     toConjunctiveNormalFormArrayRecursive(expr, list);
     return list.toArray(new Expr[list.size()]);
   }
@@ -584,7 +584,7 @@ public class AlgebraicUtil {
     Column target;
 
     for (int i = 0; i < partitionColumns.size(); i++) {
-      List<Expr> accumulatedFilters = TUtil.newList();
+      List<Expr> accumulatedFilters = new ArrayList<>();
       target = new Column(partitionColumns.get(i));
       ColumnReferenceExpr columnReference = new ColumnReferenceExpr(tableName, target.getSimpleName());
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/AlgebraicUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/AlgebraicUtil.java
@@ -25,7 +25,6 @@ import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.exception.TajoException;
 import org.apache.tajo.plan.util.ExprFinder;
 import org.apache.tajo.plan.visitor.SimpleAlgebraVisitor;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalTreeUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalTreeUtil.java
@@ -33,7 +33,6 @@ import org.apache.tajo.exception.TajoInternalError;
 import org.apache.tajo.plan.LogicalPlan;
 import org.apache.tajo.plan.Target;
 import org.apache.tajo.plan.util.ExprFinder;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalTreeUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/expr/EvalTreeUtil.java
@@ -523,7 +523,7 @@ public class EvalTreeUtil {
 
   public static class EvalFinder extends BasicEvalNodeVisitor<Object, Object> {
     private EvalType targetType;
-    List<EvalNode> evalNodes = TUtil.newList();
+    List<EvalNode> evalNodes = new ArrayList<>();
 
     public EvalFinder(EvalType targetType) {
       this.targetType = targetType;
@@ -546,7 +546,7 @@ public class EvalTreeUtil {
   }
 
   public static class OuterJoinSensitiveEvalFinder extends BasicEvalNodeVisitor<Object, Object> {
-    private List<EvalNode> evalNodes = TUtil.newList();
+    private List<EvalNode> evalNodes = new ArrayList<>();
 
     @Override
     public Object visit(Object context, EvalNode evalNode, Stack<EvalNode> stack) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/python/PythonScriptEngine.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/python/PythonScriptEngine.java
@@ -45,6 +45,7 @@ import org.apache.tajo.util.TUtil;
 import java.io.*;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -173,7 +174,7 @@ public class PythonScriptEngine extends TajoScriptEngine {
 
   // TODO: python parser must be improved.
   private static List<FunctionInfo> getFunctions(InputStream is) throws IOException {
-    List<FunctionInfo> functions = TUtil.newList();
+    List<FunctionInfo> functions = new ArrayList<>();
     InputStreamReader in = new InputStreamReader(is, Charset.defaultCharset());
     BufferedReader br = new BufferedReader(in);
     String line = br.readLine();

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/python/PythonScriptEngine.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/python/PythonScriptEngine.java
@@ -40,7 +40,6 @@ import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.storage.VTuple;
 import org.apache.tajo.unit.StorageUnit;
 import org.apache.tajo.util.FileUtil;
-import org.apache.tajo.util.TUtil;
 
 import java.io.*;
 import java.net.URI;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/stream/StreamingUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/stream/StreamingUtil.java
@@ -20,7 +20,6 @@ package org.apache.tajo.plan.function.stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.tajo.util.TUtil;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/function/stream/StreamingUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/function/stream/StreamingUtil.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.util.TUtil;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -41,7 +42,7 @@ public class StreamingUtil {
    */
   public static ProcessBuilder createProcess(String[] argv) {
     // Set the actual command to run with 'bash -c exec ...'
-    List<String> cmdArgs = TUtil.newList();
+    List<String> cmdArgs = new ArrayList<>();
 
     StringBuffer argBuffer = new StringBuffer();
     for (String arg : argv) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/NameResolver.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/NameResolver.java
@@ -92,7 +92,7 @@ public abstract class NameResolver {
   public static RelationNode lookupTable(LogicalPlan.QueryBlock block, String tableName)
       throws AmbiguousTableException {
 
-    List<RelationNode> found = TUtil.newList();
+    List<RelationNode> found = new ArrayList<>();
 
     for (RelationNode relation : block.getRelations()) {
 
@@ -245,7 +245,7 @@ public abstract class NameResolver {
                                                String columnName, boolean includeSelfDescTable) throws AmbiguousColumnException {
     Preconditions.checkArgument(CatalogUtil.isSimpleIdentifier(columnName));
 
-    List<Column> candidates = TUtil.newList();
+    List<Column> candidates = new ArrayList<>();
 
     for (RelationNode rel : block.getRelations()) {
       if (rel.isNameResolveBase()) {
@@ -260,7 +260,7 @@ public abstract class NameResolver {
       return ensureUniqueColumn(candidates);
     } else {
       if (includeSelfDescTable) {
-        List<RelationNode> candidateRels = TUtil.newList();
+        List<RelationNode> candidateRels = new ArrayList<>();
         for (RelationNode rel : block.getRelations()) {
           if (describeSchemaByItself(rel)) {
             candidateRels.add(rel);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/NameResolver.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/NameResolver.java
@@ -33,7 +33,6 @@ import org.apache.tajo.plan.logical.RelationNode;
 import org.apache.tajo.plan.logical.ScanNode;
 import org.apache.tajo.util.Pair;
 import org.apache.tajo.util.StringUtils;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/ResolverByLegacy.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/ResolverByLegacy.java
@@ -30,7 +30,6 @@ import org.apache.tajo.plan.logical.LogicalNode;
 import org.apache.tajo.plan.logical.NodeType;
 import org.apache.tajo.plan.logical.RelationNode;
 import org.apache.tajo.util.Pair;
-import org.apache.tajo.util.TUtil;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/ResolverByLegacy.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/nameresolver/ResolverByLegacy.java
@@ -32,6 +32,7 @@ import org.apache.tajo.plan.logical.RelationNode;
 import org.apache.tajo.util.Pair;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ResolverByLegacy extends NameResolver {
@@ -85,7 +86,7 @@ public class ResolverByLegacy extends NameResolver {
 
     if (currentNode != null && !currentNodeSchema.contains(found)
         && currentNode.getType() != NodeType.TABLE_SUBQUERY) {
-      List<Column> candidates = TUtil.newList();
+      List<Column> candidates = new ArrayList<>();
       if (block.getNamedExprsManager().isAliased(qualifiedName)) {
         String alias = block.getNamedExprsManager().getAlias(qualifiedName);
         found = resolve(plan, block, new ColumnReferenceExpr(alias), NameResolvingMode.LEGACY, includeSeflDescTable);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanPreprocessPhaseProvider.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanPreprocessPhaseProvider.java
@@ -20,16 +20,16 @@ package org.apache.tajo.plan.rewrite;
 
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 public class BaseLogicalPlanPreprocessPhaseProvider extends LogicalPlanPreprocessPhaseProvider {
   @Override
   public Collection<Class<? extends LogicalPlanPreprocessPhase>> getPhases() {
-    List phases = TUtil.newList(
-        BaseSchemaBuildPhase.class,
-        SelfDescSchemaBuildPhase.class
-    );
+    List phases = new ArrayList<>();
+    phases.add(BaseSchemaBuildPhase.class);
+    phases.add(SelfDescSchemaBuildPhase.class);
     return phases;
   }
 }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanPreprocessPhaseProvider.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanPreprocessPhaseProvider.java
@@ -18,8 +18,6 @@
 
 package org.apache.tajo.plan.rewrite;
 
-import org.apache.tajo.util.TUtil;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanRewriteRuleProvider.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanRewriteRuleProvider.java
@@ -22,6 +22,7 @@ import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.plan.rewrite.rules.*;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -37,7 +38,7 @@ public class BaseLogicalPlanRewriteRuleProvider extends LogicalPlanRewriteRulePr
 
   @Override
   public Collection<Class<? extends LogicalPlanRewriteRule>> getPreRules() {
-    List<Class<? extends LogicalPlanRewriteRule>> rules = TUtil.newList();
+    List<Class<? extends LogicalPlanRewriteRule>> rules = new ArrayList<>();
 
     rules.add(CommonConditionReduceRule.class);
     // In-subquery rewrite phase must be executed before the filter push down phase.
@@ -55,11 +56,10 @@ public class BaseLogicalPlanRewriteRuleProvider extends LogicalPlanRewriteRulePr
 
   @Override
   public Collection<Class<? extends LogicalPlanRewriteRule>> getPostRules() {
-    List<Class<? extends LogicalPlanRewriteRule>> rules = TUtil.newList(
-        ProjectionPushDownRule.class,
-        PartitionedTableRewriter.class,
-        AccessPathRewriter.class
-    );
+    List<Class<? extends LogicalPlanRewriteRule>> rules = new ArrayList<>();
+    rules.add(ProjectionPushDownRule.class);
+    rules.add(PartitionedTableRewriter.class);
+    rules.add(AccessPathRewriter.class);
     return rules;
   }
 }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanRewriteRuleProvider.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseLogicalPlanRewriteRuleProvider.java
@@ -20,7 +20,6 @@ package org.apache.tajo.plan.rewrite;
 
 import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.plan.rewrite.rules.*;
-import org.apache.tajo.util.TUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseSchemaBuildPhase.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseSchemaBuildPhase.java
@@ -149,7 +149,7 @@ public class BaseSchemaBuildPhase extends LogicalPlanPreprocessPhase {
         // columns of every relation should be resolved.
         Iterator<RelationNode> iterator = block.getRelations().iterator();
         Schema schema;
-        List<Column> resolvedColumns = TUtil.newList();
+        List<Column> resolvedColumns = new ArrayList<>();
 
         while (iterator.hasNext()) {
           relationOp = iterator.next();
@@ -187,7 +187,7 @@ public class BaseSchemaBuildPhase extends LogicalPlanPreprocessPhase {
 
     private static List<NamedExpr> voidResolveAsteriskNamedExpr(LogicalPlanner.PlanContext context,
                                                              List<NamedExpr> namedExprs) throws TajoException {
-      List<NamedExpr> rewrittenTargets = TUtil.newList();
+      List<NamedExpr> rewrittenTargets = new ArrayList<>();
       for (NamedExpr originTarget : namedExprs) {
         if (originTarget.getExpr().getType() == OpType.Asterisk) {
           // rewrite targets

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseSchemaBuildPhase.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/BaseSchemaBuildPhase.java
@@ -36,7 +36,6 @@ import org.apache.tajo.plan.nameresolver.NameResolver;
 import org.apache.tajo.plan.nameresolver.NameResolvingMode;
 import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.plan.visitor.SimpleAlgebraVisitor;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/FilterPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/FilterPushDownRule.java
@@ -74,7 +74,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
 
     public void setToOrigin(Map<EvalNode, EvalNode> evalMap) {
       //evalMap: copy -> origin
-      List<EvalNode> origins = TUtil.newList();
+      List<EvalNode> origins = new ArrayList<>();
       for (EvalNode eval : pushingDownFilters) {
         EvalNode origin = evalMap.get(eval);
         if (origin != null) {
@@ -188,7 +188,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
     LogicalNode left = joinNode.getLeftChild();
     LogicalNode right = joinNode.getRightChild();
 
-    List<EvalNode> notMatched = TUtil.newList();
+    List<EvalNode> notMatched = new ArrayList<>();
     // Join's input schema = right child output columns + left child output columns
     Map<EvalNode, EvalNode> transformedMap = findCanPushdownAndTransform(context, block, joinNode, left, notMatched,
         null, 0);
@@ -210,7 +210,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
 
     notMatched.clear();
     context.pushingDownFilters.addAll(nonPushableQuals);
-    List<EvalNode> matched = TUtil.newList();
+    List<EvalNode> matched = new ArrayList<>();
 
     // If the query involves a subquery, the stack can be empty.
     // In this case, this join is the top most one within a query block.
@@ -414,7 +414,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
   private static List<EvalNode> extractNonEquiThetaJoinQuals(final Set<EvalNode> predicates,
                                                              final LogicalPlan.QueryBlock block,
                                                              final JoinNode joinNode) {
-    List<EvalNode> nonEquiThetaJoinQuals = TUtil.newList();
+    List<EvalNode> nonEquiThetaJoinQuals = new ArrayList<>();
     for (EvalNode eachEval: predicates) {
       if (isNonEquiThetaJoinQual(block, joinNode, eachEval)) {
         nonEquiThetaJoinQuals.add(eachEval);
@@ -534,8 +534,8 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
   @Override
   public LogicalNode visitTableSubQuery(FilterPushDownContext context, LogicalPlan plan, LogicalPlan.QueryBlock block,
                                         TableSubQueryNode node, Stack<LogicalNode> stack) throws TajoException {
-    List<EvalNode> matched = TUtil.newList();
-    List<EvalNode> unmatched = TUtil.newList();
+    List<EvalNode> matched = new ArrayList<>();
+    List<EvalNode> unmatched = new ArrayList<>();
     for (EvalNode eval : context.pushingDownFilters) {
       if (LogicalPlanner.checkIfBeEvaluatedAtRelation(block, eval, node)) {
         matched.add(eval);
@@ -561,7 +561,8 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
                                 Stack<LogicalNode> stack) throws TajoException {
     LogicalNode leftNode = unionNode.getLeftChild();
 
-    List<EvalNode> origins = TUtil.newList(context.pushingDownFilters);
+    List<EvalNode> origins = new ArrayList<>();
+    origins.addAll(context.pushingDownFilters);
 
     // transformed -> pushingDownFilters
     Map<EvalNode, EvalNode> transformedMap = transformEvalsWidthByPassNode(origins, plan, block, unionNode, leftNode);
@@ -594,7 +595,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
                                      Stack<LogicalNode> stack) throws TajoException {
     LogicalNode childNode = projectionNode.getChild();
 
-    List<EvalNode> notMatched = TUtil.newList();
+    List<EvalNode> notMatched = new ArrayList<>();
 
     //copy -> origin
     BiMap<EvalNode, EvalNode> transformedMap = findCanPushdownAndTransform(
@@ -791,8 +792,8 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
       }
     }
 
-    List<EvalNode> aggrEvalOrigins = TUtil.newList();
-    List<EvalNode> aggrEvals = TUtil.newList();
+    List<EvalNode> aggrEvalOrigins = new ArrayList<>();
+    List<EvalNode> aggrEvals = new ArrayList<>();
 
     for (EvalNode eval : context.pushingDownFilters) {
       EvalNode copy = null;
@@ -878,7 +879,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
       context.pushingDownFilters.removeAll(aggrEvals);
     }
 
-    List<EvalNode> notMatched = TUtil.newList();
+    List<EvalNode> notMatched = new ArrayList<>();
     // transform
     Map<EvalNode, EvalNode> transformed =
         findCanPushdownAndTransform(context, block, groupbyNode,groupbyNode.getChild(), notMatched, null, 0);
@@ -896,7 +897,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
   public LogicalNode visitScan(FilterPushDownContext context, LogicalPlan plan,
                                LogicalPlan.QueryBlock block, final ScanNode scanNode,
                                Stack<LogicalNode> stack) throws TajoException {
-    List<EvalNode> matched = TUtil.newList();
+    List<EvalNode> matched = new ArrayList<>();
 
     // find partition column and check matching
     Set<String> partitionColumns = new HashSet<>();
@@ -942,7 +943,7 @@ public class FilterPushDownRule extends BasicLogicalPlanVisitor<FilterPushDownCo
 
     context.pushingDownFilters.removeAll(partitionEvals);
 
-    List<EvalNode> notMatched = TUtil.newList();
+    List<EvalNode> notMatched = new ArrayList<>();
 
     // transform
     Map<EvalNode, EvalNode> transformed =

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/FilterPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/FilterPushDownRule.java
@@ -42,7 +42,6 @@ import org.apache.tajo.plan.rewrite.rules.FilterPushDownRule.FilterPushDownConte
 import org.apache.tajo.plan.rewrite.rules.IndexScanInfo.SimplePredicate;
 import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/InSubqueryRewriteRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/InSubqueryRewriteRule.java
@@ -65,7 +65,7 @@ public class InSubqueryRewriteRule implements LogicalPlanRewriteRule {
   }
 
   static List<InEval> extractInSubquery(EvalNode qual) {
-    List<InEval> inSubqueries = TUtil.newList();
+    List<InEval> inSubqueries = new ArrayList<>();
     for (EvalNode eachQual : EvalTreeUtil.findEvalsByType(qual, EvalType.IN)) {
       InEval inEval = (InEval) eachQual;
       if (inEval.getRightExpr().getType() == EvalType.SUBQUERY) {
@@ -127,7 +127,8 @@ public class InSubqueryRewriteRule implements LogicalPlanRewriteRule {
         joinNode.setInSchema(inSchema);
         joinNode.setOutSchema(node.getOutSchema());
 
-        List<Target> targets = TUtil.newList(PlannerUtil.schemaToTargets(inSchema));
+        List<Target> targets = new ArrayList<>();
+        targets.addAll(PlannerUtil.schemaToTargets(inSchema));
         joinNode.setTargets(targets);
 
         block.addJoinType(joinType);
@@ -140,7 +141,7 @@ public class InSubqueryRewriteRule implements LogicalPlanRewriteRule {
       
       // 4. remove in quals
       EvalNode[] originDnfs = AlgebraicUtil.toDisjunctiveNormalFormArray(node.getQual());
-      List<EvalNode> rewrittenDnfs = TUtil.newList();
+      List<EvalNode> rewrittenDnfs = new ArrayList<>();
       for (EvalNode eachDnf : originDnfs) {
         Set<EvalNode> cnfs = new HashSet<>(Arrays.asList(AlgebraicUtil.toConjunctiveNormalFormArray(eachDnf)));
         cnfs.removeAll(inSubqueries);

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/InSubqueryRewriteRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/InSubqueryRewriteRule.java
@@ -32,7 +32,6 @@ import org.apache.tajo.plan.rewrite.LogicalPlanRewriteRule;
 import org.apache.tajo.plan.rewrite.LogicalPlanRewriteRuleContext;
 import org.apache.tajo.plan.util.PlannerUtil;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
@@ -689,7 +689,7 @@ public class ProjectionPushDownRule extends
     if (node.hasAggFunctions() && aggEvalNames != null) {
       WindowFunctionEval [] aggEvals = new WindowFunctionEval[aggEvalNames.length];
       int i = 0;
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, new ArrayList<>(Arrays.asList(aggEvalNames))); it.hasNext();) {
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, Arrays.asList(aggEvalNames)); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -795,7 +795,7 @@ public class ProjectionPushDownRule extends
     // Getting projected targets
     if (node.hasAggFunctions() && aggEvalNames != null) {
       List<AggregationFunctionCallEval> aggEvals = new ArrayList<>();
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, new ArrayList<>(Arrays.asList(aggEvalNames))); it.hasNext();) {
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, Arrays.asList(aggEvalNames)); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -962,7 +962,7 @@ public class ProjectionPushDownRule extends
   }
 
   static Iterator<String> getFilteredReferences(String [] targetNames, Collection<String> required) {
-    return new FilteredStringsIterator(new ArrayList<>(Arrays.asList(targetNames)), required);
+    return new FilteredStringsIterator(Arrays.asList(targetNames), required);
   }
 
   static class FilteredStringsIterator implements Iterator<String> {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
@@ -689,7 +689,7 @@ public class ProjectionPushDownRule extends
     if (node.hasAggFunctions() && aggEvalNames != null) {
       WindowFunctionEval [] aggEvals = new WindowFunctionEval[aggEvalNames.length];
       int i = 0;
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, Arrays.asList(aggEvalNames)); it.hasNext();) {
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, new ArrayList<>(Arrays.asList(aggEvalNames))); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -795,7 +795,7 @@ public class ProjectionPushDownRule extends
     // Getting projected targets
     if (node.hasAggFunctions() && aggEvalNames != null) {
       List<AggregationFunctionCallEval> aggEvals = new ArrayList<>();
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, Arrays.asList(aggEvalNames)); it.hasNext();) {
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, new ArrayList<>(Arrays.asList(aggEvalNames))); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -962,7 +962,7 @@ public class ProjectionPushDownRule extends
   }
 
   static Iterator<String> getFilteredReferences(String [] targetNames, Collection<String> required) {
-    return new FilteredStringsIterator(Arrays.asList(targetNames), required);
+    return new FilteredStringsIterator(new ArrayList<>(Arrays.asList(targetNames)), required);
   }
 
   static class FilteredStringsIterator implements Iterator<String> {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
@@ -689,9 +689,7 @@ public class ProjectionPushDownRule extends
     if (node.hasAggFunctions() && aggEvalNames != null) {
       WindowFunctionEval [] aggEvals = new WindowFunctionEval[aggEvalNames.length];
       int i = 0;
-      List inputList = new ArrayList<>();
-      inputList.addAll(Arrays.asList(aggEvalNames));
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, inputList); it.hasNext();) {
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, Arrays.asList(aggEvalNames)); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -797,10 +795,7 @@ public class ProjectionPushDownRule extends
     // Getting projected targets
     if (node.hasAggFunctions() && aggEvalNames != null) {
       List<AggregationFunctionCallEval> aggEvals = new ArrayList<>();
-      int i = 0;
-      List inputList = new ArrayList<>();
-      inputList.addAll(Arrays.asList(aggEvalNames));
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, inputList); it.hasNext();) {
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, Arrays.asList(aggEvalNames)); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -967,9 +962,7 @@ public class ProjectionPushDownRule extends
   }
 
   static Iterator<String> getFilteredReferences(String [] targetNames, Collection<String> required) {
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList(targetNames));
-    return new FilteredStringsIterator(inputList, required);
+    return new FilteredStringsIterator(Arrays.asList(targetNames), required);
   }
 
   static class FilteredStringsIterator implements Iterator<String> {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
@@ -363,7 +363,7 @@ public class ProjectionPushDownRule extends
     }
 
     class FilteredTargetIterator implements Iterator<Target> {
-      List<Target> filtered = TUtil.newList();
+      List<Target> filtered = new ArrayList<>();
       Iterator<Target> iterator;
 
       public FilteredTargetIterator(Set<String> required) {
@@ -469,7 +469,7 @@ public class ProjectionPushDownRule extends
     node.setInSchema(child.getOutSchema());
 
     int evaluationCount = 0;
-    List<Target> finalTargets = TUtil.newList();
+    List<Target> finalTargets = new ArrayList<>();
     for (String referenceName : referenceNames) {
       Target target = context.targetListMgr.getTarget(referenceName);
 
@@ -689,7 +689,9 @@ public class ProjectionPushDownRule extends
     if (node.hasAggFunctions() && aggEvalNames != null) {
       WindowFunctionEval [] aggEvals = new WindowFunctionEval[aggEvalNames.length];
       int i = 0;
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, TUtil.newList(aggEvalNames)); it.hasNext();) {
+      List inputList = new ArrayList<>();
+      inputList.addAll(Arrays.asList(aggEvalNames));
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, inputList); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -795,7 +797,10 @@ public class ProjectionPushDownRule extends
     // Getting projected targets
     if (node.hasAggFunctions() && aggEvalNames != null) {
       List<AggregationFunctionCallEval> aggEvals = new ArrayList<>();
-      for (Iterator<String> it = getFilteredReferences(aggEvalNames, TUtil.newList(aggEvalNames)); it.hasNext();) {
+      int i = 0;
+      List inputList = new ArrayList<>();
+      inputList.addAll(Arrays.asList(aggEvalNames));
+      for (Iterator<String> it = getFilteredReferences(aggEvalNames, inputList); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
@@ -962,14 +967,16 @@ public class ProjectionPushDownRule extends
   }
 
   static Iterator<String> getFilteredReferences(String [] targetNames, Collection<String> required) {
-    return new FilteredStringsIterator(targetNames, required);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList(targetNames));
+    return new FilteredStringsIterator(inputList, required);
   }
 
   static class FilteredStringsIterator implements Iterator<String> {
     Iterator<String> iterator;
 
     FilteredStringsIterator(Collection<String> targetNames, Collection<String> required) {
-      List<String> filtered = TUtil.newList();
+      List<String> filtered = new ArrayList<>();
       for (String name : targetNames) {
         if (required.contains(name)) {
           filtered.add(name);
@@ -977,10 +984,6 @@ public class ProjectionPushDownRule extends
       }
 
       iterator = filtered.iterator();
-    }
-
-    FilteredStringsIterator(String [] targetNames, Collection<String> required) {
-      this(TUtil.newList(targetNames), required);
     }
 
     @Override
@@ -1006,7 +1009,7 @@ public class ProjectionPushDownRule extends
     Iterator<Target> iterator;
 
     FilteredIterator(List<Target> targets, Set<String> requiredReferences) {
-      List<Target> filtered = TUtil.newList();
+      List<Target> filtered = new ArrayList<>();
       Map<String, Target> targetSet = new HashMap<>();
       for (Target t : targets) {
         // Only should keep an raw target instead of field reference.

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeDeserializer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeDeserializer.java
@@ -331,7 +331,7 @@ public class LogicalNodeDeserializer {
     }
 
     if (distinctGroupbyProto.getSubPlansCount() > 0) {
-      List<GroupbyNode> subPlans = TUtil.newList();
+      List<GroupbyNode> subPlans = new ArrayList<>();
       for (int i = 0; i < distinctGroupbyProto.getSubPlansCount(); i++) {
         subPlans.add(convertGroupby(context, evalContext, nodeMap, distinctGroupbyProto.getSubPlans(i)));
       }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeSerializer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeSerializer.java
@@ -40,7 +40,6 @@ import org.apache.tajo.plan.serder.PlanProto.AlterTablespaceNode.SetLocation;
 import org.apache.tajo.plan.serder.PlanProto.LogicalNodeTree;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
 import org.apache.tajo.util.ProtoUtil;
-import org.apache.tajo.util.TUtil;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeSerializer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeSerializer.java
@@ -42,6 +42,7 @@ import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
 import org.apache.tajo.util.ProtoUtil;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -478,7 +479,7 @@ public class LogicalNodeSerializer extends BasicLogicalPlanVisitor<LogicalNodeSe
     PlanProto.ScanNode.Builder scanBuilder = buildScanNode(node);
 
     PlanProto.PartitionScanSpec.Builder partitionScan = PlanProto.PartitionScanSpec.newBuilder();
-    List<String> pathStrs = TUtil.newList();
+    List<String> pathStrs = new ArrayList<>();
     if (node.getInputPaths() != null) {
       for (Path p : node.getInputPaths()) {
         pathStrs.add(p.toString());

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/ExprFinder.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/ExprFinder.java
@@ -25,9 +25,12 @@ import org.apache.tajo.algebra.UnaryOperator;
 import org.apache.tajo.exception.TajoException;
 import org.apache.tajo.exception.TajoInternalError;
 import org.apache.tajo.plan.visitor.SimpleAlgebraVisitor;
-import org.apache.tajo.util.TUtil;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Stack;
 
 public class ExprFinder extends SimpleAlgebraVisitor<ExprFinder.Context, Object> {
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/ExprFinder.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/ExprFinder.java
@@ -27,15 +27,12 @@ import org.apache.tajo.exception.TajoInternalError;
 import org.apache.tajo.plan.visitor.SimpleAlgebraVisitor;
 import org.apache.tajo.util.TUtil;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 
 public class ExprFinder extends SimpleAlgebraVisitor<ExprFinder.Context, Object> {
 
   static class Context<T> {
-    List<T> set = TUtil.newList();
+    List<T> set = new ArrayList<>();
     OpType targetType;
 
     Context(OpType type) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
@@ -29,7 +29,6 @@ import org.apache.tajo.exception.UnsupportedException;
 import org.apache.tajo.plan.ExprAnnotator;
 import org.apache.tajo.plan.visitor.SimpleAlgebraVisitor;
 import org.apache.tajo.util.Pair;
-import org.apache.tajo.util.TUtil;
 import org.apache.tajo.util.datetime.DateTimeUtil;
 import org.apache.tajo.util.datetime.TimeMeta;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PartitionFilterAlgebraVisitor.java
@@ -36,6 +36,7 @@ import org.apache.tajo.util.datetime.TimeMeta;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 import java.util.TimeZone;
@@ -51,7 +52,7 @@ public class PartitionFilterAlgebraVisitor extends SimpleAlgebraVisitor<Object, 
   private boolean isHiveCatalog = false;
 
   private Stack<String> queries = new Stack();
-  private List<Pair<Type, Object>> parameters = TUtil.newList();
+  private List<Pair<Type, Object>> parameters = new ArrayList<>();
 
   public String getTableAlias() {
     return tableAlias;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
@@ -38,7 +38,6 @@ import org.apache.tajo.plan.visitor.ExplainLogicalPlanVisitor;
 import org.apache.tajo.plan.visitor.SimpleAlgebraVisitor;
 import org.apache.tajo.util.KeyValueSet;
 import org.apache.tajo.util.StringUtils;
-import org.apache.tajo.util.TUtil;
 
 import java.util.*;
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
@@ -765,7 +765,7 @@ public class PlannerUtil {
   }
 
   public static Collection<String> toQualifiedFieldNames(Collection<String> fieldNames, String qualifier) {
-    List<String> names = TUtil.newList();
+    List<String> names = new ArrayList<>();
     for (String n : fieldNames) {
       String[] parts = n.split("\\.");
       if (parts.length == 1) {
@@ -934,7 +934,7 @@ public class PlannerUtil {
    * @return
    */
   public static List<Expr> extractInSubquery(Expr qual) {
-    List<Expr> inSubqueries = TUtil.newList();
+    List<Expr> inSubqueries = new ArrayList<>();
     for (Expr eachIn : ExprFinder.findsInOrder(qual, OpType.InPredicate)) {
       InPredicate inPredicate = (InPredicate) eachIn;
       if (inPredicate.getInValue().getType() == OpType.SimpleTableSubquery) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/PostLogicalPlanVerifier.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/PostLogicalPlanVerifier.java
@@ -29,6 +29,7 @@ import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
 import org.apache.tajo.unit.StorageUnit;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
@@ -87,7 +88,7 @@ public class PostLogicalPlanVerifier extends BasicLogicalPlanVisitor<Context, Ob
       } else {
 
         boolean crossJoinAllowed = false;
-        List<String> largeRelationNames = TUtil.newList();
+        List<String> largeRelationNames = new ArrayList<>();
 
         if (isSimpleRelationNode(node.getLeftChild())) {
           if (getTableVolume((ScanNode) node.getLeftChild()) <= context.bcastLimitForCrossJoin * StorageUnit.KB) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/PostLogicalPlanVerifier.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/verifier/PostLogicalPlanVerifier.java
@@ -27,7 +27,6 @@ import org.apache.tajo.plan.logical.*;
 import org.apache.tajo.plan.verifier.PostLogicalPlanVerifier.Context;
 import org.apache.tajo.plan.visitor.BasicLogicalPlanVisitor;
 import org.apache.tajo.unit.StorageUnit;
-import org.apache.tajo.util.TUtil;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseTablespace.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HBaseTablespace.java
@@ -73,8 +73,8 @@ public class HBaseTablespace extends Tablespace {
       new StorageProperty("hbase", false, true, false, false);
   public static final FormatProperty HFILE_FORMAT_PROPERTIES = new FormatProperty(true, false, true);
   public static final FormatProperty PUT_MODE_PROPERTIES = new FormatProperty(true, true, false);
-  public static final List<byte []> EMPTY_START_ROW_KEY = TUtil.newList(new byte [0]);
-  public static final List<byte []> EMPTY_END_ROW_KEY   = TUtil.newList(new byte [0]);
+  public static final List<byte []> EMPTY_START_ROW_KEY = Arrays.asList(new byte [0]);
+  public static final List<byte []> EMPTY_END_ROW_KEY   = Arrays.asList(new byte [0]);
 
   private Configuration hbaseConf;
 

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
@@ -226,9 +226,7 @@ public class FileFragment implements Fragment, Comparable<FileFragment>, Cloneab
     }
 
     if(hosts != null) {
-      List inputList = new ArrayList<>();
-      inputList.addAll(Arrays.asList(hosts));
-      builder.addAllHosts(inputList);
+      builder.addAllHosts(Arrays.asList(hosts));
     }
 
     FragmentProto.Builder fragmentBuilder = FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
@@ -226,7 +226,7 @@ public class FileFragment implements Fragment, Comparable<FileFragment>, Cloneab
     }
 
     if(hosts != null) {
-      builder.addAllHosts(Arrays.asList(hosts));
+      builder.addAllHosts(new ArrayList<>(Arrays.asList(hosts)));
     }
 
     FragmentProto.Builder fragmentBuilder = FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
@@ -226,7 +226,9 @@ public class FileFragment implements Fragment, Comparable<FileFragment>, Cloneab
     }
 
     if(hosts != null) {
-      builder.addAllHosts(TUtil.newList(hosts));
+      List inputList = new ArrayList<>();
+      inputList.addAll(Arrays.asList(hosts));
+      builder.addAllHosts(inputList);
     }
 
     FragmentProto.Builder fragmentBuilder = FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/fragment/FileFragment.java
@@ -226,7 +226,7 @@ public class FileFragment implements Fragment, Comparable<FileFragment>, Cloneab
     }
 
     if(hosts != null) {
-      builder.addAllHosts(new ArrayList<>(Arrays.asList(hosts)));
+      builder.addAllHosts(Arrays.asList(hosts));
     }
 
     FragmentProto.Builder fragmentBuilder = FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -164,7 +165,7 @@ public class TestMergeScanner {
     targetSchema.addColumn(schema.getColumn(0));
     targetSchema.addColumn(schema.getColumn(2));
 
-    Scanner scanner = new MergeScanner(conf, schema, meta, Arrays.asList(fragment), targetSchema);
+    Scanner scanner = new MergeScanner(conf, schema, meta, new ArrayList<>(Arrays.asList(fragment)), targetSchema);
     assertEquals(isProjectableStorage(meta.getDataFormat()), scanner.isProjectable());
 
     scanner.init();

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
@@ -165,7 +165,7 @@ public class TestMergeScanner {
     targetSchema.addColumn(schema.getColumn(0));
     targetSchema.addColumn(schema.getColumn(2));
 
-    Scanner scanner = new MergeScanner(conf, schema, meta, new ArrayList<>(Arrays.asList(fragment)), targetSchema);
+    Scanner scanner = new MergeScanner(conf, schema, meta, Arrays.asList(fragment), targetSchema);
     assertEquals(isProjectableStorage(meta.getDataFormat()), scanner.isProjectable());
 
     scanner.init();

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
@@ -167,9 +167,7 @@ public class TestMergeScanner {
     targetSchema.addColumn(schema.getColumn(0));
     targetSchema.addColumn(schema.getColumn(2));
 
-    List inputList = new ArrayList<>();
-    inputList.addAll(Arrays.asList(fragment));
-    Scanner scanner = new MergeScanner(conf, schema, meta, inputList, targetSchema);
+    Scanner scanner = new MergeScanner(conf, schema, meta, Arrays.asList(fragment), targetSchema);
     assertEquals(isProjectableStorage(meta.getDataFormat()), scanner.isProjectable());
 
     scanner.init();

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
@@ -40,7 +40,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
@@ -33,7 +33,6 @@ import org.apache.tajo.storage.fragment.FileFragment;
 import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.util.CommonTestingUtil;
 import org.apache.tajo.util.KeyValueSet;
-import org.apache.tajo.util.TUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,10 +40,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 import static org.junit.Assert.*;
 

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/TestMergeScanner.java
@@ -41,8 +41,10 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -165,7 +167,9 @@ public class TestMergeScanner {
     targetSchema.addColumn(schema.getColumn(0));
     targetSchema.addColumn(schema.getColumn(2));
 
-    Scanner scanner = new MergeScanner(conf, schema, meta, TUtil.newList(fragment), targetSchema);
+    List inputList = new ArrayList<>();
+    inputList.addAll(Arrays.asList(fragment));
+    Scanner scanner = new MergeScanner(conf, schema, meta, inputList, targetSchema);
     assertEquals(isProjectableStorage(meta.getDataFormat()), scanner.isProjectable());
 
     scanner.init();

--- a/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
+++ b/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
@@ -23,11 +23,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.storage.jdbc.JdbcFragmentProtos.JdbcFragmentProto;
-import org.apache.tajo.util.TUtil;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneable {
   String uri;

--- a/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
+++ b/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
@@ -25,6 +25,10 @@ import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.storage.jdbc.JdbcFragmentProtos.JdbcFragmentProto;
 import org.apache.tajo.util.TUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneable {
   String uri;
   String inputSourceId;
@@ -89,7 +93,9 @@ public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneab
     builder.setInputSourceId(this.inputSourceId);
     builder.setUri(this.uri);
     if(hostNames != null) {
-      builder.addAllHosts(TUtil.newList(hostNames));
+      List inputList = new ArrayList<>();
+      inputList.addAll(Arrays.asList(hostNames));
+      builder.addAllHosts(inputList);
     }
 
     CatalogProtos.FragmentProto.Builder fragmentBuilder = CatalogProtos.FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
+++ b/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
@@ -91,7 +91,7 @@ public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneab
     builder.setInputSourceId(this.inputSourceId);
     builder.setUri(this.uri);
     if(hostNames != null) {
-      builder.addAllHosts(new ArrayList<>(Arrays.asList(hostNames)));
+      builder.addAllHosts(Arrays.asList(hostNames));
     }
 
     CatalogProtos.FragmentProto.Builder fragmentBuilder = CatalogProtos.FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
+++ b/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
@@ -93,9 +93,7 @@ public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneab
     builder.setInputSourceId(this.inputSourceId);
     builder.setUri(this.uri);
     if(hostNames != null) {
-      List inputList = new ArrayList<>();
-      inputList.addAll(Arrays.asList(hostNames));
-      builder.addAllHosts(inputList);
+      builder.addAllHosts(Arrays.asList(hostNames));
     }
 
     CatalogProtos.FragmentProto.Builder fragmentBuilder = CatalogProtos.FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
+++ b/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
@@ -24,6 +24,7 @@ import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.storage.jdbc.JdbcFragmentProtos.JdbcFragmentProto;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneable {
@@ -90,7 +91,7 @@ public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneab
     builder.setInputSourceId(this.inputSourceId);
     builder.setUri(this.uri);
     if(hostNames != null) {
-      builder.addAllHosts(Arrays.asList(hostNames));
+      builder.addAllHosts(new ArrayList<>(Arrays.asList(hostNames)));
     }
 
     CatalogProtos.FragmentProto.Builder fragmentBuilder = CatalogProtos.FragmentProto.newBuilder();

--- a/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
+++ b/tajo-storage/tajo-storage-jdbc/src/main/java/org/apache/tajo/storage/jdbc/JdbcFragment.java
@@ -24,7 +24,6 @@ import org.apache.tajo.catalog.proto.CatalogProtos;
 import org.apache.tajo.storage.fragment.Fragment;
 import org.apache.tajo.storage.jdbc.JdbcFragmentProtos.JdbcFragmentProto;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 public class JdbcFragment implements Fragment, Comparable<JdbcFragment>, Cloneable {


### PR DESCRIPTION
We introduced Java 8. We don't need TUtil.newList/newLinkedHashMap utility methods anymore. We need to eliminate them.