### PR TITLE
TAJO-2002: Change log4j log level for aws

### DIFF
--- a/tajo-dist/src/main/conf/log4j.properties
+++ b/tajo-dist/src/main/conf/log4j.properties
@@ -74,3 +74,11 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+
+
+# AWS SDK & S3A FileSystem
+log4j.logger.com.amazonaws=ERROR
+log4j.logger.com.amazonaws.http.AmazonHttpClient=ERROR
+log4j.logger.org.apache.hadoop.fs.s3a.S3AFileSystem=WARN
+log4j.logger.com.amazon.ws.emr=WARN
+log4j.logger.amazon.emr=WARN


### PR DESCRIPTION
I found that the patch ran as expected on emr cluster.