### PR TITLE
TAJO-1948: Change GroupbyNode::setAggFunctions and getAggFunctions to set and get List

### DIFF
--- a/tajo-core-tests/src/test/java/org/apache/tajo/engine/eval/TestEvalTreeUtil.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/engine/eval/TestEvalTreeUtil.java
@@ -345,11 +345,11 @@ public class TestEvalTreeUtil {
     Expr expr = analyzer.parse(query);
     LogicalPlan plan = planner.createPlan(defaultContext, expr);
     GroupbyNode groupByNode = plan.getRootBlock().getNode(NodeType.GROUP_BY);
-    EvalNode [] aggEvals = groupByNode.getAggFunctions();
+    List aggEvals = groupByNode.getAggFunctions();
 
     List<AggregationFunctionCallEval> list = new ArrayList<>();
-    for (int i = 0; i < aggEvals.length; i++) {
-      list.addAll(EvalTreeUtil.findDistinctAggFunction(aggEvals[i]));
+    for (int i = 0; i < aggEvals.size(); i++) {
+      list.addAll(EvalTreeUtil.findDistinctAggFunction((EvalNode) aggEvals.get(i)));
     }
     assertEquals(2, list.size());
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/AggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/AggregationExec.java
@@ -25,12 +25,14 @@ import org.apache.tajo.plan.logical.GroupbyNode;
 import org.apache.tajo.worker.TaskAttemptContext;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class AggregationExec extends UnaryPhysicalExec {
 
   protected final int groupingKeyNum;
   protected final int aggFunctionsNum;
-  protected final AggregationFunctionCallEval aggFunctions[];
+  protected final List<AggregationFunctionCallEval> aggFunctions;
 
   public AggregationExec(final TaskAttemptContext context, GroupbyNode plan,
                          PhysicalExec child) throws IOException {
@@ -41,9 +43,9 @@ public abstract class AggregationExec extends UnaryPhysicalExec {
 
     if (plan.hasAggFunctions()) {
       aggFunctions = plan.getAggFunctions();
-      aggFunctionsNum = aggFunctions.length;
+      aggFunctionsNum = aggFunctions.size();
     } else {
-      aggFunctions = new AggregationFunctionCallEval[0];
+      aggFunctions = new ArrayList<>();
       aggFunctionsNum = 0;
     }
   }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySecondAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySecondAggregationExec.java
@@ -81,7 +81,7 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
   private int numGroupingColumns;
   private int[][] distinctKeyIndexes;
   private FunctionContext[] nonDistinctAggrContexts;
-  private AggregationFunctionCallEval[] nonDistinctAggrFunctions;
+  private List<AggregationFunctionCallEval> nonDistinctAggrFunctions;
   private int nonDistinctAggrTupleStartIndex = -1;
 
   // Key tuples may have various lengths. The below two maps are used to cache key tuple instances.
@@ -131,7 +131,7 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
             eachFunction.bind(context.getEvalContext(), inSchema);
             eachFunction.setIntermediatePhase();
           }
-          nonDistinctAggrContexts = new FunctionContext[nonDistinctAggrFunctions.length];
+          nonDistinctAggrContexts = new FunctionContext[nonDistinctAggrFunctions.size()];
         }
       }
     }
@@ -163,7 +163,7 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
       }
     }
     if (nonDistinctAggrFunctions != null) {
-      nonDistinctAggrTupleStartIndex = inSchema.size() - nonDistinctAggrFunctions.length;
+      nonDistinctAggrTupleStartIndex = inSchema.size() - nonDistinctAggrFunctions.size();
     }
   }
 
@@ -235,9 +235,9 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
 
   private void initNonDistinctAggrContext() {
     if (nonDistinctAggrFunctions != null) {
-      nonDistinctAggrContexts = new FunctionContext[nonDistinctAggrFunctions.length];
-      for (int i = 0; i < nonDistinctAggrFunctions.length; i++) {
-        nonDistinctAggrContexts[i] = nonDistinctAggrFunctions[i].newContext();
+      nonDistinctAggrContexts = new FunctionContext[nonDistinctAggrFunctions.size()];
+      for (int i = 0; i < nonDistinctAggrFunctions.size(); i++) {
+        nonDistinctAggrContexts[i] = nonDistinctAggrFunctions.get(i).newContext();
       }
     }
   }
@@ -246,8 +246,8 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
     if (nonDistinctAggrFunctions == null) {
       return;
     }
-    for (int i = 0; i < nonDistinctAggrFunctions.length; i++) {
-      nonDistinctAggrFunctions[i].merge(nonDistinctAggrContexts[i], tuple);
+    for (int i = 0; i < nonDistinctAggrFunctions.size(); i++) {
+      nonDistinctAggrFunctions.get(i).merge(nonDistinctAggrContexts[i], tuple);
     }
   }
 
@@ -255,8 +255,8 @@ public class DistinctGroupbySecondAggregationExec extends UnaryPhysicalExec {
     if (nonDistinctAggrFunctions == null) {
       return;
     }
-    for (int i = 0; i < nonDistinctAggrFunctions.length; i++) {
-      tuple.put(nonDistinctAggrTupleStartIndex + i, nonDistinctAggrFunctions[i].terminate(nonDistinctAggrContexts[i]));
+    for (int i = 0; i < nonDistinctAggrFunctions.size(); i++) {
+      tuple.put(nonDistinctAggrTupleStartIndex + i, nonDistinctAggrFunctions.get(i).terminate(nonDistinctAggrContexts[i]));
     }
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySortAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbySortAggregationExec.java
@@ -127,7 +127,7 @@ public class DistinctGroupbySortAggregationExec extends PhysicalExec {
     int tupleIndex = 0;
     for (SortAggregateExec aggExec: aggregateExecs) {
       for (int i = 0; i < aggExec.aggFunctionsNum; i++, tupleIndex++) {
-        String funcName = aggExec.aggFunctions[i].getName();
+        String funcName = aggExec.aggFunctions.get(i).getName();
         if ("min".equals(funcName) || "max".equals(funcName) || "avg".equals(funcName) || "sum".equals(funcName)) {
           outTuple.put(resultColumnIdIndexes[tupleIndex], DatumFactory.createNullDatum());
         }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
@@ -84,12 +84,12 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
 
         Column[] distinctGroupingColumns = eachGroupby.getGroupingColumns();
         inTupleIndex += distinctGroupingColumns.length;
-        outTupleIndex += eachGroupby.getAggFunctions().length;
+        outTupleIndex += eachGroupby.getAggFunctions().size();
       } else {
         nonDistinctAggr = new DistinctFinalAggregator(-1, inTupleIndex, outTupleIndex, eachGroupby);
-        outTupleIndex += eachGroupby.getAggFunctions().length;
+        outTupleIndex += eachGroupby.getAggFunctions().size();
       }
-      resultTupleLength += eachGroupby.getAggFunctions().length;
+      resultTupleLength += eachGroupby.getAggFunctions().size();
     }
     aggregators = aggregatorList.toArray(new DistinctFinalAggregator[aggregatorList.size()]);
     outTuple = new VTuple(resultTupleLength);
@@ -234,7 +234,7 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
 
   class DistinctFinalAggregator {
     private FunctionContext[] functionContexts;
-    private AggregationFunctionCallEval[] aggrFunctions;
+    private List<AggregationFunctionCallEval> aggrFunctions;
     private int seq;
     private int inTupleIndex;
     private int outTupleIndex;
@@ -254,15 +254,15 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
     }
 
     private void newFunctionContext() {
-      functionContexts = new FunctionContext[aggrFunctions.length];
-      for (int i = 0; i < aggrFunctions.length; i++) {
-        functionContexts[i] = aggrFunctions[i].newContext();
+      functionContexts = new FunctionContext[aggrFunctions.size()];
+      for (int i = 0; i < aggrFunctions.size(); i++) {
+        functionContexts[i] = aggrFunctions.get(i).newContext();
       }
     }
 
     public void merge(Tuple tuple) {
-      for (int i = 0; i < aggrFunctions.length; i++) {
-        aggrFunctions[i].merge(functionContexts[i], tuple);
+      for (int i = 0; i < aggrFunctions.size(); i++) {
+        aggrFunctions.get(i).merge(functionContexts[i], tuple);
       }
 
       if (seq == 0 && nonDistinctAggr != null) {
@@ -273,8 +273,8 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
     }
 
     public void terminate(Tuple resultTuple) {
-      for (int i = 0; i < aggrFunctions.length; i++) {
-        resultTuple.put(resultTupleIndexes[outTupleIndex + i], aggrFunctions[i].terminate(functionContexts[i]));
+      for (int i = 0; i < aggrFunctions.size(); i++) {
+        resultTuple.put(resultTupleIndexes[outTupleIndex + i], aggrFunctions.get(i).terminate(functionContexts[i]));
       }
       newFunctionContext();
 
@@ -285,8 +285,8 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
 
     public void terminateEmpty(Tuple resultTuple) {
       newFunctionContext();
-      for (int i = 0; i < aggrFunctions.length; i++) {
-        resultTuple.put(resultTupleIndexes[outTupleIndex + i], aggrFunctions[i].terminate(functionContexts[i]));
+      for (int i = 0; i < aggrFunctions.size(); i++) {
+        resultTuple.put(resultTupleIndexes[outTupleIndex + i], aggrFunctions.get(i).terminate(functionContexts[i]));
       }
       if (seq == 0 && nonDistinctAggr != null) {
         nonDistinctAggr.terminateEmpty(resultTuple);

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashAggregateExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/HashAggregateExec.java
@@ -55,14 +55,14 @@ public class HashAggregateExec extends AggregationExec {
 
       FunctionContext [] contexts = hashTable.get(keyTuple);
       if(contexts != null) {
-        for(int i = 0; i < aggFunctions.length; i++) {
-          aggFunctions[i].merge(contexts[i], tuple);
+        for(int i = 0; i < aggFunctions.size(); i++) {
+          aggFunctions.get(i).merge(contexts[i], tuple);
         }
       } else { // if the key occurs firstly
         contexts = new FunctionContext[aggFunctionsNum];
         for(int i = 0; i < aggFunctionsNum; i++) {
-          contexts[i] = aggFunctions[i].newContext();
-          aggFunctions[i].merge(contexts[i], tuple);
+          contexts[i] = aggFunctions.get(i).newContext();
+          aggFunctions.get(i).merge(contexts[i], tuple);
         }
         hashTable.put(keyTuple, contexts);
       }
@@ -73,7 +73,7 @@ public class HashAggregateExec extends AggregationExec {
     if (groupingKeyNum == 0 && aggFunctionsNum > 0 && hashTable.entrySet().size() == 0) {
       FunctionContext[] contexts = new FunctionContext[aggFunctionsNum];
       for(int i = 0; i < aggFunctionsNum; i++) {
-        contexts[i] = aggFunctions[i].newContext();
+        contexts[i] = aggFunctions.get(i).newContext();
       }
       hashTable.put(null, contexts);
     }
@@ -99,7 +99,7 @@ public class HashAggregateExec extends AggregationExec {
         tuple.put(tupleIdx, keyTuple.asDatum(tupleIdx));
       }
       for (int funcIdx = 0; funcIdx < aggFunctionsNum; funcIdx++, tupleIdx++) {
-        tuple.put(tupleIdx, aggFunctions[funcIdx].terminate(contexts[funcIdx]));
+        tuple.put(tupleIdx, aggFunctions.get(funcIdx).terminate(contexts[funcIdx]));
       }
 
       return tuple;

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/LogicalPlanner.java
@@ -534,7 +534,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
       }
 
       if (groupbyNode.hasAggFunctions()) {
-        verifyIfEvalNodesCanBeEvaluated(projectable, groupbyNode.getAggFunctions());
+        verifyIfEvalNodesCanBeEvaluated(projectable, (List<EvalNode>)(List<?>) groupbyNode.getAggFunctions());
       }
 
     } else if (projectable instanceof WindowAggNode) {
@@ -545,7 +545,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
       }
 
       if (windowAggNode.hasAggFunctions()) {
-        verifyIfEvalNodesCanBeEvaluated(projectable, windowAggNode.getWindowFunctions());
+        verifyIfEvalNodesCanBeEvaluated(projectable, Arrays.asList(windowAggNode.getWindowFunctions()));
       }
 
       if (windowAggNode.hasSortSpecs()) {
@@ -584,7 +584,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     }
   }
 
-  public static void verifyIfEvalNodesCanBeEvaluated(Projectable projectable, EvalNode[] evalNodes)
+  public static void verifyIfEvalNodesCanBeEvaluated(Projectable projectable, List<EvalNode> evalNodes)
       throws TajoException {
     for (EvalNode e : evalNodes) {
       Set<Column> columns = EvalTreeUtil.findUniqueColumns(e);
@@ -804,7 +804,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     }
 
     groupbyNode.setDistinct(includeDistinctFunction);
-    groupbyNode.setAggFunctions(aggEvals.toArray(new AggregationFunctionCallEval[aggEvals.size()]));
+    groupbyNode.setAggFunctions(new ArrayList<>(aggEvals));
     List<Target> targets = ProjectionPushDownRule.buildGroupByTarget(groupbyNode, null,
         aggEvalNames.toArray(new String[aggEvalNames.size()]));
     groupbyNode.setTargets(targets);
@@ -1049,7 +1049,7 @@ public class LogicalPlanner extends BaseAlgebraVisitor<LogicalPlanner.PlanContex
     }
     // if there is at least one distinct aggregation function
     groupingNode.setDistinct(includeDistinctFunction);
-    groupingNode.setAggFunctions(aggEvalNodes.toArray(new AggregationFunctionCallEval[aggEvalNodes.size()]));
+    groupingNode.setAggFunctions(aggEvalNodes);
 
     List<Target> targets = new ArrayList<>();
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
@@ -49,7 +49,7 @@ public class DistinctGroupbyNode extends UnaryNode implements Projectable, Clone
   private int[] resultColumnIds = new int[]{};
 
   /** Aggregation Functions */
-  @Expose private AggregationFunctionCallEval[] aggrFunctions = PlannerUtil.EMPTY_AGG_FUNCS;
+  @Expose private List<AggregationFunctionCallEval> aggrFunctions = PlannerUtil.EMPTY_AGG_FUNCS;
 
   public DistinctGroupbyNode(int pid) {
     super(pid, NodeType.DISTINCT_GROUP_BY);
@@ -99,11 +99,11 @@ public class DistinctGroupbyNode extends UnaryNode implements Projectable, Clone
     this.resultColumnIds = resultColumnIds;
   }
 
-  public AggregationFunctionCallEval [] getAggFunctions() {
+  public List<AggregationFunctionCallEval> getAggFunctions() {
     return this.aggrFunctions;
   }
 
-  public void setAggFunctions(AggregationFunctionCallEval[] evals) {
+  public void setAggFunctions(List<AggregationFunctionCallEval> evals) {
     this.aggrFunctions = evals;
   }
 
@@ -165,7 +165,7 @@ public class DistinctGroupbyNode extends UnaryNode implements Projectable, Clone
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + Arrays.hashCode(aggrFunctions);
+    result = prime * result + Objects.hashCode(aggrFunctions);
     result = prime * result + ((groupbyPlan == null) ? 0 : groupbyPlan.hashCode());
     result = prime * result + Arrays.hashCode(groupingColumns);
     result = prime * result + Arrays.hashCode(resultColumnIds);
@@ -213,9 +213,9 @@ public class DistinctGroupbyNode extends UnaryNode implements Projectable, Clone
     String prefix = "";
     for (GroupbyNode eachNode: subGroupbyPlan) {
       if (eachNode.hasAggFunctions()) {
-        AggregationFunctionCallEval[] aggrFunctions = eachNode.getAggFunctions();
-        for (int j = 0; j < aggrFunctions.length; j++) {
-          sb.append(prefix).append(aggrFunctions[j]);
+        List<AggregationFunctionCallEval> aggrFunctions = eachNode.getAggFunctions();
+        for (int j = 0; j < aggrFunctions.size(); j++) {
+          sb.append(prefix).append(aggrFunctions.get(j));
           prefix = ",";
         }
       }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/GroupbyNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/GroupbyNode.java
@@ -37,7 +37,7 @@ public class GroupbyNode extends UnaryNode implements Projectable, Cloneable {
   /** Grouping key sets */
   @Expose private Column [] groupingKeys = PlannerUtil.EMPTY_COLUMNS;
   /** Aggregation Functions */
-  @Expose private AggregationFunctionCallEval [] aggrFunctions = PlannerUtil.EMPTY_AGG_FUNCS;
+  @Expose private List<AggregationFunctionCallEval> aggrFunctions = PlannerUtil.EMPTY_AGG_FUNCS;
   /**
    * It's a list of targets. The grouping columns should be followed by aggregation functions.
    * aggrFunctions keep actual aggregation functions, but it only contains field references.
@@ -86,18 +86,18 @@ public class GroupbyNode extends UnaryNode implements Projectable, Cloneable {
   }
 
   public boolean hasAggFunctions() {
-    return aggrFunctions.length > 0;
+    return aggrFunctions.size() > 0;
   }
 
   public int aggregationFunctionNum() {
-    return this.aggrFunctions.length;
+    return this.aggrFunctions.size();
   }
 
-  public AggregationFunctionCallEval[] getAggFunctions() {
+  public List<AggregationFunctionCallEval> getAggFunctions() {
     return this.aggrFunctions;
   }
 
-  public void setAggFunctions(AggregationFunctionCallEval[] evals) {
+  public void setAggFunctions(List<AggregationFunctionCallEval> evals) {
     Preconditions.checkNotNull(evals);
     this.aggrFunctions = evals;
   }
@@ -139,7 +139,7 @@ public class GroupbyNode extends UnaryNode implements Projectable, Cloneable {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + Arrays.hashCode(aggrFunctions);
+    result = prime * result + Objects.hashCode(aggrFunctions);
     result = prime * result + Arrays.hashCode(groupingKeys);
     result = prime * result + (hasDistinct ? 1231 : 1237);
     result = prime * result + Objects.hashCode(targets);
@@ -172,9 +172,9 @@ public class GroupbyNode extends UnaryNode implements Projectable, Cloneable {
     }
 
     if (aggrFunctions != null) {
-      grp.aggrFunctions = new AggregationFunctionCallEval[aggrFunctions.length];
-      for (int i = 0; i < aggrFunctions.length; i++) {
-        grp.aggrFunctions[i] = (AggregationFunctionCallEval) aggrFunctions[i].clone();
+      grp.aggrFunctions = new ArrayList<>();
+      for (int i = 0; i < aggrFunctions.size(); i++) {
+        grp.aggrFunctions.add((AggregationFunctionCallEval) aggrFunctions.get(i).clone());
       }
     }
 
@@ -205,9 +205,9 @@ public class GroupbyNode extends UnaryNode implements Projectable, Cloneable {
     if (hasAggFunctions()) {
       sb.append(", exprs: (");
 
-      for (int j = 0; j < aggrFunctions.length; j++) {
-        sb.append(aggrFunctions[j]);
-        if(j < aggrFunctions.length - 1) {
+      for (int j = 0; j < aggrFunctions.size(); j++) {
+        sb.append(aggrFunctions.get(j));
+        if(j < aggrFunctions.size() - 1) {
           sb.append(",");
         }
       }
@@ -253,9 +253,9 @@ public class GroupbyNode extends UnaryNode implements Projectable, Cloneable {
       sb = new StringBuilder();
       sb.append("(");
 
-      for (int j = 0; j < aggrFunctions.length; j++) {
-        sb.append(aggrFunctions[j]);
-        if(j < aggrFunctions.length - 1) {
+      for (int j = 0; j < aggrFunctions.size(); j++) {
+        sb.append(aggrFunctions.get(j));
+        if(j < aggrFunctions.size() - 1) {
           sb.append(",");
         }
       }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/rewrite/rules/ProjectionPushDownRule.java
@@ -732,12 +732,12 @@ public class ProjectionPushDownRule extends
 
       // Getting eval names
       if (node.hasAggFunctions()) {
-        final int evalNum = node.getAggFunctions().length;
+        final int evalNum = node.getAggFunctions().size();
         aggEvalNames = new String[evalNum];
         for (int evalIdx = 0, targetIdx = node.getGroupingColumns().length; targetIdx < node.getTargets().size();
              evalIdx++, targetIdx++) {
           Target target = node.getTargets().get(targetIdx);
-          EvalNode evalNode = node.getAggFunctions()[evalIdx];
+          EvalNode evalNode = node.getAggFunctions().get(evalIdx);
           aggEvalNames[evalIdx] = newContext.addExpr(new Target(evalNode, target.getCanonicalName()));
         }
       }
@@ -794,19 +794,18 @@ public class ProjectionPushDownRule extends
 
     // Getting projected targets
     if (node.hasAggFunctions() && aggEvalNames != null) {
-      AggregationFunctionCallEval [] aggEvals = new AggregationFunctionCallEval[aggEvalNames.length];
-      int i = 0;
+      List<AggregationFunctionCallEval> aggEvals = new ArrayList<>();
       for (Iterator<String> it = getFilteredReferences(aggEvalNames, TUtil.newList(aggEvalNames)); it.hasNext();) {
 
         String referenceName = it.next();
         Target target = context.targetListMgr.getTarget(referenceName);
 
         if (LogicalPlanner.checkIfBeEvaluatedAtGroupBy(target.getEvalTree(), node)) {
-          aggEvals[i++] = target.getEvalTree();
+          aggEvals.add(target.getEvalTree());
           context.targetListMgr.markAsEvaluated(target);
         }
       }
-      if (aggEvals.length > 0) {
+      if (aggEvals.size() > 0) {
         node.setAggFunctions(aggEvals);
       }
     }
@@ -823,7 +822,7 @@ public class ProjectionPushDownRule extends
     final int groupingKeyNum =
         groupingKeyTargets == null ? groupbyNode.getGroupingColumns().length : groupingKeyTargets.size();
     final int aggrFuncNum = aggEvalNames != null ? aggEvalNames.length : 0;
-    EvalNode [] aggEvalNodes = groupbyNode.getAggFunctions();
+    List<EvalNode> aggEvalNodes = (List<EvalNode>)(List<?>) groupbyNode.getAggFunctions();
     List<Target> targets = new ArrayList<>();
 
     if (groupingKeyTargets != null) {
@@ -838,7 +837,7 @@ public class ProjectionPushDownRule extends
 
     if (aggEvalNames != null) {
       for (int aggrFuncIdx = 0, targetIdx = groupingKeyNum; aggrFuncIdx < aggrFuncNum; aggrFuncIdx++, targetIdx++) {
-        targets.add(new Target(new FieldEval(aggEvalNames[aggrFuncIdx], aggEvalNodes[aggrFuncIdx].getValueType())));
+        targets.add(new Target(new FieldEval(aggEvalNames[aggrFuncIdx], aggEvalNodes.get(aggrFuncIdx).getValueType())));
       }
     }
 

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeDeserializer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeDeserializer.java
@@ -710,12 +710,12 @@ public class LogicalNodeDeserializer {
     return dropIndex;
   }
 
-  private static AggregationFunctionCallEval [] convertAggFuncCallEvals(OverridableConf context, EvalContext evalContext,
+  private static List<AggregationFunctionCallEval> convertAggFuncCallEvals(OverridableConf context, EvalContext evalContext,
                                                                        List<PlanProto.EvalNodeTree> evalTrees) {
-    AggregationFunctionCallEval [] aggFuncs = new AggregationFunctionCallEval[evalTrees.size()];
-    for (int i = 0; i < aggFuncs.length; i++) {
-      aggFuncs[i] = (AggregationFunctionCallEval) EvalNodeDeserializer.deserialize(context, evalContext,
-          evalTrees.get(i));
+    List<AggregationFunctionCallEval> aggFuncs = new ArrayList<>();
+    for (int i = 0; i < evalTrees.size(); i++) {
+      aggFuncs.add((AggregationFunctionCallEval) EvalNodeDeserializer.deserialize(context, evalContext,
+          evalTrees.get(i)));
     }
     return aggFuncs;
   }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeSerializer.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/serder/LogicalNodeSerializer.java
@@ -30,6 +30,7 @@ import org.apache.tajo.exception.NotImplementedException;
 import org.apache.tajo.exception.TajoRuntimeException;
 import org.apache.tajo.plan.LogicalPlan;
 import org.apache.tajo.plan.Target;
+import org.apache.tajo.plan.expr.EvalNode;
 import org.apache.tajo.plan.logical.*;
 import org.apache.tajo.plan.rewrite.rules.IndexScanInfo.SimplePredicate;
 import org.apache.tajo.plan.serder.PlanProto.AlterTableNode.AddColumn;
@@ -295,7 +296,7 @@ public class LogicalNodeSerializer extends BasicLogicalPlanVisitor<LogicalNodeSe
     }
     if (node.hasAggFunctions()) {
       groupbyBuilder.addAllAggFunctions(
-          ProtoUtil.<PlanProto.EvalNodeTree>toProtoObjects(node.getAggFunctions()));
+          ProtoUtil.<PlanProto.EvalNodeTree>toProtoObjects(node.getAggFunctions().toArray(new ProtoObject[node.getAggFunctions().size()])));
     }
     if (node.hasTargets()) {
       groupbyBuilder.addAllTargets(ProtoUtil.<PlanProto.Target>toProtoObjects(node.getTargets().toArray(new ProtoObject[node.getTargets().size()])));
@@ -328,9 +329,9 @@ public class LogicalNodeSerializer extends BasicLogicalPlanVisitor<LogicalNodeSe
       distGroupbyBuilder.addAllGroupingKeys(
           ProtoUtil.<CatalogProtos.ColumnProto>toProtoObjects(node.getGroupingColumns()));
     }
-    if (node.getAggFunctions().length > 0) {
+    if (node.getAggFunctions().size() > 0) {
       distGroupbyBuilder.addAllAggFunctions(
-          ProtoUtil.<PlanProto.EvalNodeTree>toProtoObjects(node.getAggFunctions()));
+          ProtoUtil.<PlanProto.EvalNodeTree>toProtoObjects(node.getAggFunctions().toArray(new ProtoObject[node.getAggFunctions().size()])));
     }
     if (node.hasTargets()) {
       distGroupbyBuilder.addAllTargets(ProtoUtil.<PlanProto.Target>toProtoObjects(node.getTargets().toArray(new ProtoObject[node.getTargets().size()])));
@@ -830,7 +831,7 @@ public class LogicalNodeSerializer extends BasicLogicalPlanVisitor<LogicalNodeSe
 
   public static PlanProto.Target convertTarget(Target target) {
     PlanProto.Target.Builder targetBuilder = PlanProto.Target.newBuilder();
-    targetBuilder.setExpr(EvalNodeSerializer.serialize(target.getEvalTree()));
+    targetBuilder.setExpr(EvalNodeSerializer.serialize((EvalNode) target.getEvalTree()));
     if (target.hasAlias()) {
       targetBuilder.setAlias(target.getAlias());
     }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/util/PlannerUtil.java
@@ -45,7 +45,7 @@ import java.util.*;
 public class PlannerUtil {
 
   public static final Column [] EMPTY_COLUMNS = new Column[] {};
-  public static final AggregationFunctionCallEval [] EMPTY_AGG_FUNCS = new AggregationFunctionCallEval[] {};
+  public static final List<AggregationFunctionCallEval> EMPTY_AGG_FUNCS = new ArrayList<>();
 
   public static boolean checkIfSetSession(LogicalNode node) {
     LogicalNode baseNode = node;


### PR DESCRIPTION
See TAJO-1938. It would simplify lots of codes for 'for-loop' on Targets if we Change GroupbyNode::setAggFunctions and getAggFunctions to set and get List.