### PR TITLE
TAJO-1793: result row count unmatched for UNION ALL

### DIFF
--- a/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/cli/tsql/TestTajoCli.java
@@ -501,6 +501,20 @@ public class TestTajoCli {
     }
   }
 
+  @Test
+  public void testResultStatsOfUnionAll() throws Exception {
+    String sql = "select n_nationkey as key_, n_name as name_ from nation where n_nationkey < 3" +
+      " union all select r_regionkey as key_, r_name as name_ from region";
+
+    setVar(tajoCli, SessionVars.CLI_FORMATTER_CLASS, TajoCliOutputTestFormatter.class.getName());
+    tajoCli.executeScript(sql);
+
+    String consoleResult = new String(out.toByteArray());
+    int position = consoleResult.indexOf("rows");
+    assertOutputResult(consoleResult.substring(0, position + 4));
+  }
+
+
   // TODO: This should be removed at TAJO-1891
   @Test
   public void testAddPartitionNotimplementedException() throws Exception {

--- a/tajo-core-tests/src/test/resources/results/TestTajoCli/testResultStatsOfUnionAll.result
+++ b/tajo-core-tests/src/test/resources/results/TestTajoCli/testResultStatsOfUnionAll.result
@@ -1,0 +1,11 @@
+key_,  name_
+-------------------------------
+0,  ALGERIA
+1,  ARGENTINA
+2,  BRAZIL
+0,  AFRICA
+1,  AMERICA
+2,  ASIA
+3,  EUROPE
+4,  MIDDLE EAST
+(8 rows

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
@@ -513,10 +513,8 @@ public class Query implements EventHandler<QueryEvent> {
             Iterator<Stage> iterator = query.getStages().iterator();
             while(iterator.hasNext()) {
               Stage stage = iterator.next();
-              if (stage.getState() == StageState.SUCCEEDED) {
-                totalNumRows += stage.getResultStats().getNumRows();
-                totalNumBytes += stage.getResultStats().getNumBytes();
-              }
+              totalNumRows += stage.getResultStats().getNumRows();
+              totalNumBytes += stage.getResultStats().getNumBytes();
             }
             lastStage.getResultStats().setNumRows(totalNumRows);
             lastStage.getResultStats().setNumBytes(totalNumBytes);

--- a/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
+++ b/tajo-core/src/main/java/org/apache/tajo/querymaster/Query.java
@@ -504,6 +504,25 @@ public class Query implements EventHandler<QueryEvent> {
         QueryHookExecutor hookExecutor = new QueryHookExecutor(query.context.getQueryMasterContext());
         hookExecutor.execute(query.context.getQueryContext(), query, event.getExecutionBlockId(), finalOutputDir);
 
+        // Calculate result stats of Union all query
+        if (rootNode.getChild() instanceof UnionNode) {
+          boolean isDistinct = ((UnionNode) rootNode.getChild()).isDistinct();
+
+          if (!isDistinct) {
+            long totalNumRows = 0L, totalNumBytes = 0L;
+            Iterator<Stage> iterator = query.getStages().iterator();
+            while(iterator.hasNext()) {
+              Stage stage = iterator.next();
+              if (stage.getState() == StageState.SUCCEEDED) {
+                totalNumRows += stage.getResultStats().getNumRows();
+                totalNumBytes += stage.getResultStats().getNumBytes();
+              }
+            }
+            lastStage.getResultStats().setNumRows(totalNumRows);
+            lastStage.getResultStats().setNumBytes(totalNumBytes);
+          }
+        }
+
         // Add dynamic partitions to catalog for partition table.
         if (queryContext.hasOutputTableUri() && queryContext.hasPartition()) {
           List<PartitionDescProto> partitions = query.getPartitions();


### PR DESCRIPTION
When executing an union all query, there isn't TableDesc in ```Query```.  As a result, the result stats of last stage will set output row number and volume. 

To resolve this issue,  I summarized each result stats of all stages in union all query. But I found that the bytes number of stage changes occasionally. So, I just compare row number except bytes number in unit tests.