### PR TITLE
TAJO-2017: Replace manual array copy with Collection

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
@@ -765,9 +765,7 @@ public class CatalogUtil {
   };
 
   static {
-    for (String keyword : RESERVED_KEYWORDS) {
-      RESERVED_KEYWORDS_SET.add(keyword);
-    }
+    Collections.addAll(RESERVED_KEYWORDS_SET, RESERVED_KEYWORDS);
   }
 
   public static AlterTableDesc renameColumn(String tableName, String oldColumName, String newColumName,

--- a/tajo-core-tests/src/test/java/org/apache/tajo/master/TestRepartitioner.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/master/TestRepartitioner.java
@@ -500,9 +500,7 @@ public class TestRepartitioner {
   private static void assertFetchProto(FetchProto [] expected, Map<String, List<FetchProto>>[] result) {
     Set<FetchProto> expectedURLs = Sets.newHashSet();
 
-    for (FetchProto f : expected) {
-      expectedURLs.add(f);
-    }
+    Collections.addAll(expectedURLs, expected);
 
     Set<FetchProto> resultURLs = Sets.newHashSet();
 

--- a/tajo-core-tests/src/test/java/org/apache/tajo/storage/TestFileFragment.java
+++ b/tajo-core-tests/src/test/java/org/apache/tajo/storage/TestFileFragment.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.SortedSet;
 
 import static org.junit.Assert.assertEquals;
@@ -85,9 +86,7 @@ public class TestFileFragment {
     }
 
     SortedSet sortedSet = Sets.newTreeSet();
-    for (FileFragment frag : tablets) {
-      sortedSet.add(frag);
-    }
+    Collections.addAll(sortedSet, tablets);
     assertEquals(num, sortedSet.size());
   }
 }

--- a/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
+++ b/tajo-core/src/main/java/org/apache/tajo/engine/planner/physical/DistinctGroupbyThirdAggregationExec.java
@@ -104,9 +104,7 @@ public class DistinctGroupbyThirdAggregationExec extends UnaryPhysicalExec {
     }
     for (GroupbyNode eachGroupby : groupbyNodes) {
       Set<Column> groupingColumnSet = new HashSet<>();
-      for (Column column: eachGroupby.getGroupingColumns()) {
-        groupingColumnSet.add(column);
-      }
+      Collections.addAll(groupingColumnSet, eachGroupby.getGroupingColumns());
       for (Target eachTarget: eachGroupby.getTargets()) {
         if (!groupingColumnSet.contains(eachTarget.getNamedColumn())) {
           //aggr function

--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HFileAppender.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/HFileAppender.java
@@ -43,6 +43,7 @@ import org.apache.tajo.storage.Tuple;
 import org.apache.tajo.util.Bytes;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.TreeSet;
 
 public class HFileAppender extends AbstractHBaseAppender {
@@ -118,9 +119,7 @@ public class HFileAppender extends AbstractHBaseAppender {
 
     readKeyValues(tuple, rowkey);
     if (keyValues != null) {
-      for (KeyValue eachKeyVal: keyValues) {
-        kvSet.add(eachKeyVal);
-      }
+      Collections.addAll(kvSet, keyValues);
     }
   }
 

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/FileTablespace.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/FileTablespace.java
@@ -330,9 +330,7 @@ public class FileTablespace extends Tablespace {
       } else {
         for (FileStatus globStat : matches) {
           if (globStat.isDirectory()) {
-            for (FileStatus stat : fs.listStatus(globStat.getPath(), inputFilter)) {
-              result.add(stat);
-            }
+            Collections.addAll(result, fs.listStatus(globStat.getPath(), inputFilter));
           } else {
             result.add(globStat);
           }

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckMethodAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckMethodAdapter.java
@@ -32,12 +32,7 @@ package org.apache.tajo.org.objectweb.asm.util;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.tajo.org.objectweb.asm.tree.MethodNode;
 import org.apache.tajo.org.objectweb.asm.tree.analysis.Analyzer;
@@ -744,9 +739,7 @@ public class CheckMethodAdapter extends MethodVisitor {
             checkNonDebugLabel(labels[i]);
         }
         super.visitTableSwitchInsn(min, max, dflt, labels);
-        for (Label label : labels) {
-            usedLabels.add(label);
-        }
+        Collections.addAll(usedLabels, labels);
         ++insnCount;
     }
 
@@ -767,9 +760,7 @@ public class CheckMethodAdapter extends MethodVisitor {
         }
         super.visitLookupSwitchInsn(dflt, keys, labels);
         usedLabels.add(dflt);
-        for (Label label : labels) {
-            usedLabels.add(label);
-        }
+        Collections.addAll(usedLabels, labels);
         ++insnCount;
     }
 

--- a/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckMethodAdapter.java
+++ b/tajo-thirdparty/asm/src/main/java/org/apache/tajo/org/objectweb/asm/util/CheckMethodAdapter.java
@@ -32,7 +32,13 @@ package org.apache.tajo.org.objectweb.asm.util;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.tajo.org.objectweb.asm.tree.MethodNode;
 import org.apache.tajo.org.objectweb.asm.tree.analysis.Analyzer;


### PR DESCRIPTION
Copying of array contents to a collection where each element is added individually using a for loop. Such constructs may be replaced by a call to Collection.addAll(Arrays.asList()) or Collections.addAll().