### PR TITLE
TAJO-2019: Replace manual array copy with System.arraycopy()

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/util/StringUtils.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/StringUtils.java
@@ -310,15 +310,11 @@ public class StringUtils {
     padded[0] = new char[max];
     padded[1] = new char[max];
 
-    for (int i = 0; i < startChars.length; i++) {
-      padded[0][i] = startChars[i];
-    }
+    System.arraycopy(startChars, 0, padded[0], 0, startChars.length);
     for (int i = startChars.length; i < max; i++) {
       padded[0][i] = 0;
     }
-    for (int i = 0; i < endChars.length; i++) {
-      padded[1][i] = endChars[i];
-    }
+    System.arraycopy(endChars, 0, padded[1], 0, endChars.length);
     for (int i = endChars.length; i < max; i++) {
       padded[1][i] = 0;
     }

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/DistinctGroupbyNode.java
@@ -117,9 +117,7 @@ public class DistinctGroupbyNode extends UnaryNode implements Projectable, Clone
 
     if (groupingColumns != null) {
       cloneNode.groupingColumns = new Column[groupingColumns.length];
-      for (int i = 0; i < groupingColumns.length; i++) {
-        cloneNode.groupingColumns[i] = groupingColumns[i];
-      }
+      System.arraycopy(groupingColumns, 0, cloneNode.groupingColumns, 0, groupingColumns.length);
     }
 
     if (subGroupbyPlan != null) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/GroupbyNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/GroupbyNode.java
@@ -166,9 +166,7 @@ public class GroupbyNode extends UnaryNode implements Projectable, Cloneable {
     GroupbyNode grp = (GroupbyNode) super.clone();
     if (groupingKeys != null) {
       grp.groupingKeys = new Column[groupingKeys.length];
-      for (int i = 0; i < groupingKeys.length; i++) {
-        grp.groupingKeys[i] = groupingKeys[i];
-      }
+      System.arraycopy(groupingKeys, 0, grp.groupingKeys, 0, groupingKeys.length);
     }
 
     if (aggrFunctions != null) {

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/WindowAggNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/WindowAggNode.java
@@ -157,9 +157,7 @@ public class WindowAggNode extends UnaryNode implements Projectable, Cloneable {
     WindowAggNode grp = (WindowAggNode) super.clone();
     if (partitionKeys != null) {
       grp.partitionKeys = new Column[partitionKeys.length];
-      for (int i = 0; i < partitionKeys.length; i++) {
-        grp.partitionKeys[i] = partitionKeys[i];
-      }
+      System.arraycopy(partitionKeys, 0, grp.partitionKeys, 0, partitionKeys.length);
     }
 
     if (windowFuncs != null) {


### PR DESCRIPTION
Manual copying of array contents can be replaced by calls to System.arraycopy(). It makes code line lighten.
