### PR TITLE
TAJO-2025: HBASE_LIB/metrics-core-*.jar should be included in CLASSPATH

### DIFF
--- a/tajo-dist/src/main/bin/tajo
+++ b/tajo-dist/src/main/bin/tajo
@@ -260,6 +260,10 @@ if [ ! -z ${HBASE_HOME} ] && [ -d ${HBASE_HOME} ] && [ -d ${HBASE_LIB} ]; then
     CLASSPATH=${CLASSPATH}:$f;
   done
 
+  for f in ${HBASE_LIB}/metrics-core-*.jar; do
+    CLASSPATH=${CLASSPATH}:$f;
+  done
+
 fi
 
 ##############################################################################


### PR DESCRIPTION
When I try to connect HBase client via TAJO, TAJO cannot connect HBase with below logs.
```
INFO org.apache.hadoop.hbase.client.RpcRetryingCaller: Call exception, tries=10, retries=35, retryTime=68306ms, msg=row 'lineitem,,' on table 'hbase:meta' at region=hbase:meta,,1.1588230740, hostname=<address>,60020,1450062494778, seqNum=0
INFO org.apache.hadoop.hbase.client.RpcRetryingCaller: Call exception, tries=11, retries=35, retryTime=88389ms, msg=row 'lineitem,,' on table 'hbase:meta' at region=hbase:meta,,1.1588230740, hostname=<address>,60020,1450062494778, seqNum=0

...

org.apache.hadoop.hbase.client.RpcRetryingCaller@5b5e2d4c, java.io.IOException: com.google.protobuf.ServiceException: java.lang.NoClassDefFoundError: com/yammer/metrics/core/Gauge
```
But, I can connect HBase using ```TestHBaseTable```.

I found out that tsql can connect hbase client with appending ```HBASE_LIB/HBase-hadoop2-compat-*.jar``` to classpath in ```bin/tajo```.
But, ```HBase-hadoop2-compat-*.jar``` has lots of dependency so I try to find out necessity for TAJO in this jar.

```HBASE_LIB/metrics-core-*.jar``` is answer.
I test hbase 0.98.16.1-hadoop2 version with TAJO, builded with manually-configured Hbase version. 