### PR TITLE
TAJO-2029: Showing query progress percentage in TAJO JDBC

### DIFF
--- a/tajo-client/src/main/java/org/apache/tajo/client/TajoClientUtil.java
+++ b/tajo-client/src/main/java/org/apache/tajo/client/TajoClientUtil.java
@@ -18,6 +18,8 @@
 
 package org.apache.tajo.client;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.tajo.QueryId;
 import org.apache.tajo.QueryIdFactory;
 import org.apache.tajo.SessionVars;
@@ -35,6 +37,8 @@ import java.io.IOException;
 import java.sql.ResultSet;
 
 public class TajoClientUtil {
+
+  private static final Log PROGRESS_LOG = LogFactory.getLog(TajoClientUtil.class.getName() + ".PROGRESS");
 
   /* query submit */
   public static boolean isQueryWaitingForSchedule(TajoProtos.QueryState state) {
@@ -69,6 +73,10 @@ public class TajoClientUtil {
       }
 
       status = client.getQueryStatus(queryId);
+      if (PROGRESS_LOG.isDebugEnabled()) {
+	PROGRESS_LOG.debug("Progress: " + (int) (status.getProgress() * 100.0f) + "%, response time: "
+	    + ((float) ((status.getFinishTime() - status.getSubmitTime()) / 1000.0)) + " sec");
+      }
     }
     return status;
   }

--- a/tajo-storage/tajo-storage-s3/src/main/java/org/apache/tajo/storage/s3/S3TableSpace.java
+++ b/tajo-storage/tajo-storage-s3/src/main/java/org/apache/tajo/storage/s3/S3TableSpace.java
@@ -18,39 +18,11 @@
 
 package org.apache.tajo.storage.s3;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import net.minidev.json.JSONObject;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.*;
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hdfs.DFSConfigKeys;
-import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.tajo.*;
-import org.apache.tajo.catalog.*;
-import org.apache.tajo.catalog.statistics.TableStats;
-import org.apache.tajo.conf.TajoConf;
-import org.apache.tajo.exception.TajoInternalError;
-import org.apache.tajo.exception.UnsupportedException;
-import org.apache.tajo.plan.LogicalPlan;
-import org.apache.tajo.plan.expr.EvalNode;
-import org.apache.tajo.plan.logical.LogicalNode;
-import org.apache.tajo.plan.logical.NodeType;
-import org.apache.tajo.storage.*;
-import org.apache.tajo.storage.Scanner;
-import org.apache.tajo.storage.fragment.FileFragment;
-import org.apache.tajo.storage.fragment.Fragment;
-import org.apache.tajo.util.Bytes;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
 import java.net.URI;
-import java.text.NumberFormat;
-import java.util.*;
+
+import org.apache.tajo.storage.FileTablespace;
+
+import net.minidev.json.JSONObject;
 
 public class S3TableSpace extends FileTablespace {
   public S3TableSpace(String spaceName, URI uri, JSONObject config) {


### PR DESCRIPTION
It would be nice to check out query progress percentage in TAJO JDBC like TAJO CLI already did. The purpose is simple. I want to verify whether query is in block or not by monitoring query progress percentage.