### PR TITLE
TAJO-2035: Rewrite README file using Markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ and its optimizer.
 * commits@tajo.apache.org - To monitor commits to the source repository.
 
 To subscribe to the mailing lists, please send an email to:
-${listname}-subscribe@tajo.apache.org. For example, to subscribe to
-dev, send an email from your desired subscription address to:
-dev-subscribe@tajo.apache.org and follow the instructions from there.
+
+    ${listname}-subscribe@tajo.apache.org
+
+For example, to subscribe to dev, send an email from your desired subscription address to:
+
+    dev-subscribe@tajo.apache.org
+
+and follow the instructions from there.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,9 @@ and its optimizer.
 ## Mailing lists
 
 * dev@tajo.apache.org     - To discuss and ask general development issues.
-
 * user@tajo.apache.org    - To discuss and ask end-user questions/issues.
-
 * issues@tajo.apache.org  - To see notifications made in the Tajo issue
                             tracking system, review board, and Jenkins CI.
-
 * commits@tajo.apache.org - To monitor commits to the source repository.
 
 To subscribe to the mailing lists, please send an email to:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Apache Tajo
-========================
+# Apache Tajo
+
 Tajo is a relational and distributed data warehouse system for Hadoop.
 Tajo is designed for low-latency and scalable ad-hoc queries, online
 aggregation and ETL on large-data sets by leveraging advanced database
@@ -9,33 +9,33 @@ Tajo has a variety of query evaluation strategies and more optimization
 opportunities. In addition, Tajo will have a native columnar execution and
 and its optimizer.
 
-Project
-=======
-* Project Home (http://tajo.apache.org/)
-* Source Repository (https://git-wip-us.apache.org/repos/asf/tajo.git)
-* Issue Tracking (https://issues.apache.org/jira/browse/TAJO)
+## Project
 
-License
-=======
-* Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.html)
+* [Project Home](http://tajo.apache.org/)
+* [Source Repository](https://git-wip-us.apache.org/repos/asf/tajo.git)
+* [Issue Tracking](https://issues.apache.org/jira/browse/TAJO)
 
-Documents
-=========
-* Tajo Wiki (https://cwiki.apache.org/confluence/display/TAJO)
-* Getting Started (http://tajo.apache.org/docs/current/getting_started.html)
-* Query Language (http://tajo.apache.org/docs/current/sql_language.html)
-* Configuration Guide (http://tajo.apache.org/docs/current/configuration.html)
-* Backup and Restore Guide (http://tajo.apache.org/docs/current/backup_and_restore.html)
-* Functions (http://tajo.apache.org/docs/current/functions.html)
-* Tajo Interactive Shell (http://tajo.apache.org/docs/current/tsql.html)
+## License
 
-Requirements
-============
+* [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
+
+## Documents
+
+* [Tajo Wiki](https://cwiki.apache.org/confluence/display/TAJO)
+* [Getting Started](http://tajo.apache.org/docs/current/getting_started.html)
+* [Query Language](http://tajo.apache.org/docs/current/sql_language.html)
+* [Configuration Guide](http://tajo.apache.org/docs/current/configuration.html)
+* [Backup and Restore Guide](http://tajo.apache.org/docs/current/backup_and_restore.html)
+* [Functions](http://tajo.apache.org/docs/current/functions.html)
+* [Tajo Interactive Shell](http://tajo.apache.org/docs/current/tsql.html)
+
+## Requirements
+
 * Java 1.8 or higher
 * Hadoop 2.3.0 or higher
 
-Mailing lists
-=============
+## Mailing lists
+
 * dev@tajo.apache.org     - To discuss and ask general development issues.
 
 * user@tajo.apache.org    - To discuss and ask end-user questions/issues.


### PR DESCRIPTION
Currently, README file is written with text only. To enhance information expressive power and readability, Rewrite this file using Markdown format is needed.