### PR TITLE
TAJO-2050: Adopt TAJO logo in CLI

### DIFF
--- a/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/TajoCli.java
+++ b/tajo-cli/src/main/java/org/apache/tajo/cli/tsql/TajoCli.java
@@ -43,6 +43,7 @@ import org.apache.tajo.service.ServiceTrackerFactory;
 import org.apache.tajo.util.FileUtil;
 import org.apache.tajo.util.KeyValueSet;
 import org.apache.tajo.util.ShutdownHookManager;
+import org.apache.tajo.util.VersionInfo;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
@@ -409,6 +410,11 @@ public class TajoCli implements Closeable {
     int exitCode;
     ParsingState latestState = SimpleParser.START_STATE;
 
+    sout.write("welcome to \n" +
+      "   _____ ___  _____ ___\n" +
+      "  /_  _/ _  |/_  _/   /\n" +
+      "   / // /_| |_/ // / /\n" +
+      "  /_//_/ /_/___/ \\__/  " + VersionInfo.getVersion() + "\n\n");
     sout.write("Try \\? for help.\n");
 
     SimpleParser parser = new SimpleParser();


### PR DESCRIPTION
Adopt TAJO logo in tsql. When TSQL running start, TAJO logo using word-art and version will print in CLI.
