### PR TITLE
TAJO-2055: Handling unsigned large integer in LiteralValue

### DIFF
--- a/tajo-algebra/src/main/java/org/apache/tajo/algebra/LiteralValue.java
+++ b/tajo-algebra/src/main/java/org/apache/tajo/algebra/LiteralValue.java
@@ -82,7 +82,10 @@ public class LiteralValue extends Expr {
         return LiteralType.Unsigned_Float;
       } catch (NumberFormatException e) {}
 
-      // TODO: handle unsigned_large_integer
+      try {
+        Long.parseUnsignedLong(value);
+        return LiteralType.Unsigned_Large_Integer;
+      } catch (NumberFormatException e) {}
 
       return LiteralType.String;
     }


### PR DESCRIPTION
Currently, LiteralType.Unsigned_Large_Integer is not returned in LiteralValue::getLiteralType.
