### PR TITLE
TAJO-2059: Binary search in BST reader does compare too frequently

### DIFF
--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/index/bst/BSTIndex.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/index/bst/BSTIndex.java
@@ -794,6 +794,7 @@ public class BSTIndex implements IndexMethod {
       int offset = -1;
       int start = startPos;
       int end = endPos;
+      int prevCenter = -1;
 
       //http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6412541
       int centerPos = (start + end) >>> 1;
@@ -803,48 +804,52 @@ public class BSTIndex implements IndexMethod {
 
       correctable = false;
       while (true) {
-        int compareResult = comparator.compare(arr[centerPos], key);
-        int subResult;
+        if (end - start == 1) {
+          int comp;
+          // prevCenter should be either end or start
+          if (end == prevCenter) {
+            comp = comparator.compare(arr[start], key);
 
-        if (compareResult > 0) {
-          if (centerPos == 0) {
+            if (comp == 0) {
+              correctable = true;
+              offset = start;
+            } else if (comp < 0) {
+              offset = start;
+            }
             break;
           } else {
-            subResult = comparator.compare(arr[centerPos - 1], key);
-            if (subResult < 0) {
-              offset = centerPos - 1;
+            if (end == arr.length) {
+              offset = start;
               break;
-            } else if (subResult == 0) {
-              correctable = true;
-              offset = centerPos - 1;
-              break;
-            } else {
-              end = centerPos - 1;
-              centerPos = (start + end) / 2;
             }
-          }
-        } else if (compareResult < 0) {
-          if (centerPos == arr.length - 1) {
-            offset = centerPos;
+
+            comp = comparator.compare(arr[end], key);
+            if (comp == 0) {
+              correctable = true;
+              offset = end;
+            } else if (comp > 0) {
+              offset = start;
+            }
             break;
-          } else {
-            subResult = comparator.compare(arr[centerPos + 1], key);
-            if (subResult > 0) {
-              offset = centerPos;
-              break;
-            } else if (subResult == 0) {
-              correctable = true;
-              offset = centerPos + 1;
-              break;
-            } else {
-              start = centerPos + 1;
-              centerPos = (start + end) / 2;
-            }
           }
-        } else {
+        }
+
+        int compareResult = comparator.compare(arr[centerPos], key);
+
+        if (compareResult == 0) {
           correctable = true;
           offset = centerPos;
           break;
+        } else {
+          prevCenter = centerPos;
+
+          if (compareResult > 0) {
+            end = centerPos;
+          } else {
+            start = centerPos;
+          }
+
+          centerPos = (start + end) / 2;
         }
       }
       return offset;

--- a/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/index/bst/BSTIndex.java
+++ b/tajo-storage/tajo-storage-hdfs/src/main/java/org/apache/tajo/storage/index/bst/BSTIndex.java
@@ -800,31 +800,46 @@ public class BSTIndex implements IndexMethod {
       if (arr.length == 0) {
         LOG.error("arr.length: 0, loadNum: " + loadNum + ", inited: " + inited.get());
       }
+
+      correctable = false;
       while (true) {
-        if (comparator.compare(arr[centerPos], key) > 0) {
+        int compareResult = comparator.compare(arr[centerPos], key);
+        int subResult;
+
+        if (compareResult > 0) {
           if (centerPos == 0) {
-            correctable = false;
-            break;
-          } else if (comparator.compare(arr[centerPos - 1], key) < 0) {
-            correctable = false;
-            offset = centerPos - 1;
             break;
           } else {
-            end = centerPos;
-            centerPos = (start + end) / 2;
+            subResult = comparator.compare(arr[centerPos - 1], key);
+            if (subResult < 0) {
+              offset = centerPos - 1;
+              break;
+            } else if (subResult == 0) {
+              correctable = true;
+              offset = centerPos - 1;
+              break;
+            } else {
+              end = centerPos - 1;
+              centerPos = (start + end) / 2;
+            }
           }
-        } else if (comparator.compare(arr[centerPos], key) < 0) {
+        } else if (compareResult < 0) {
           if (centerPos == arr.length - 1) {
-            correctable = false;
-            offset = centerPos;
-            break;
-          } else if (comparator.compare(arr[centerPos + 1], key) > 0) {
-            correctable = false;
             offset = centerPos;
             break;
           } else {
-            start = centerPos + 1;
-            centerPos = (start + end) / 2;
+            subResult = comparator.compare(arr[centerPos + 1], key);
+            if (subResult > 0) {
+              offset = centerPos;
+              break;
+            } else if (subResult == 0) {
+              correctable = true;
+              offset = centerPos + 1;
+              break;
+            } else {
+              start = centerPos + 1;
+              centerPos = (start + end) / 2;
+            }
           }
         } else {
           correctable = true;

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/index/TestBSTIndex.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/index/TestBSTIndex.java
@@ -49,7 +49,7 @@ public class TestBSTIndex {
   private Schema schema;
   private TableMeta meta;
 
-  private static final int TUPLE_NUM = 1000000;
+  private static final int TUPLE_NUM = 10000;
   private static final int LOAD_NUM = 100;
   private static final String TEST_PATH = "target/test-data/TestIndex";
   private Path testDir;
@@ -130,7 +130,6 @@ public class TestBSTIndex {
 
     Tuple keyTuple;
     long offset;
-    long sum = 0;
     while (true) {
       keyTuple = new VTuple(2);
       offset = scanner.getNextOffset();
@@ -139,12 +138,8 @@ public class TestBSTIndex {
 
       keyTuple.put(0, tuple.asDatum(1));
       keyTuple.put(1, tuple.asDatum(2));
-      long start = System.currentTimeMillis();
       creater.write(keyTuple, offset);
-      long end = System.currentTimeMillis();
-      sum += (end - start);
     }
-    System.out.println("write : "+(sum/1000)+" sec");
 
     creater.flush();
     creater.close();
@@ -160,10 +155,7 @@ public class TestBSTIndex {
     for (int i = 0; i < TUPLE_NUM - 1; i++) {
       tuple.put(0, DatumFactory.createInt8(i));
       tuple.put(1, DatumFactory.createFloat8(i));
-      long start = System.currentTimeMillis();
       long offsets = reader.find(tuple);
-      long end = System.currentTimeMillis();
-      sum += end-start;
       scanner.seek(offsets);
       tuple = scanner.next();
       assertTrue("seek check [" + (i) + " ," + (tuple.getInt8(1)) + "]", (i) == (tuple.getInt8(1)));
@@ -178,7 +170,6 @@ public class TestBSTIndex {
       assertTrue("[seek check " + (i + 1) + " ]", (i + 1) == (tuple.getInt4(0)));
       assertTrue("[seek check " + (i + 1) + " ]", (i + 1) == (tuple.getInt8(1)));
     }
-    System.out.println("find: "+(sum / 1000) + " sec");
     reader.close();
     scanner.close();
   }

--- a/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/index/TestBSTIndex.java
+++ b/tajo-storage/tajo-storage-hdfs/src/test/java/org/apache/tajo/storage/index/TestBSTIndex.java
@@ -49,7 +49,7 @@ public class TestBSTIndex {
   private Schema schema;
   private TableMeta meta;
 
-  private static final int TUPLE_NUM = 10000;
+  private static final int TUPLE_NUM = 1000000;
   private static final int LOAD_NUM = 100;
   private static final String TEST_PATH = "target/test-data/TestIndex";
   private Path testDir;
@@ -130,6 +130,7 @@ public class TestBSTIndex {
 
     Tuple keyTuple;
     long offset;
+    long sum = 0;
     while (true) {
       keyTuple = new VTuple(2);
       offset = scanner.getNextOffset();
@@ -138,8 +139,12 @@ public class TestBSTIndex {
 
       keyTuple.put(0, tuple.asDatum(1));
       keyTuple.put(1, tuple.asDatum(2));
+      long start = System.currentTimeMillis();
       creater.write(keyTuple, offset);
+      long end = System.currentTimeMillis();
+      sum += (end - start);
     }
+    System.out.println("write : "+(sum/1000)+" sec");
 
     creater.flush();
     creater.close();
@@ -155,7 +160,10 @@ public class TestBSTIndex {
     for (int i = 0; i < TUPLE_NUM - 1; i++) {
       tuple.put(0, DatumFactory.createInt8(i));
       tuple.put(1, DatumFactory.createFloat8(i));
+      long start = System.currentTimeMillis();
       long offsets = reader.find(tuple);
+      long end = System.currentTimeMillis();
+      sum += end-start;
       scanner.seek(offsets);
       tuple = scanner.next();
       assertTrue("seek check [" + (i) + " ," + (tuple.getInt8(1)) + "]", (i) == (tuple.getInt8(1)));
@@ -170,6 +178,7 @@ public class TestBSTIndex {
       assertTrue("[seek check " + (i + 1) + " ]", (i + 1) == (tuple.getInt4(0)));
       assertTrue("[seek check " + (i + 1) + " ]", (i + 1) == (tuple.getInt8(1)));
     }
+    System.out.println("find: "+(sum / 1000) + " sec");
     reader.close();
     scanner.close();
   }


### PR DESCRIPTION
Some simple test based on unit test was done with 1M tuples and searching 1M times.
Two columns, which are long and double, are used as sort key.
Count above is a number of invoking compare().

##### Current

find : 44 sec
count : 42001207

##### Patch

find : 43 sec
count : 20141495
