### PR TITLE
TAJO-2065: Increase default heap size.

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -168,7 +168,7 @@ public class TajoConf extends Configuration {
     QUERYMASTER_MINIMUM_MEMORY("tajo.qm.resource.min.memory-mb", 500, Validators.min("64")),
 
     // Worker task resource
-    TASK_RESOURCE_MINIMUM_MEMORY("tajo.task.resource.min.memory-mb", 500, Validators.min("64")),
+    TASK_RESOURCE_MINIMUM_MEMORY("tajo.task.resource.min.memory-mb", 1000, Validators.min("64")),
 
     // Tajo Worker Service Addresses
     WORKER_INFO_ADDRESS("tajo.worker.info-http.address", "0.0.0.0:28080", Validators.networkAddr()),
@@ -186,7 +186,7 @@ public class TajoConf extends Configuration {
         Runtime.getRuntime().availableProcessors(), Validators.min("2")), // 1qm + 1task
     WORKER_RESOURCE_AVAILABLE_MEMORY_MB("tajo.worker.resource.memory-mb", 1000, Validators.min("64")),
 
-    WORKER_RESOURCE_AVAILABLE_DISKS("tajo.worker.resource.disks", 1, Validators.min("1")),
+    WORKER_RESOURCE_AVAILABLE_DISKS("tajo.worker.resource.disks", 2, Validators.min("1")),
 
     WORKER_RESOURCE_AVAILABLE_DISK_PARALLEL_NUM("tajo.worker.resource.disk.parallel-execution.num", 2,
         Validators.min("1")),

--- a/tajo-dist/src/main/bin/tajo
+++ b/tajo-dist/src/main/bin/tajo
@@ -35,7 +35,7 @@
 #                         Default is 1000.
 #
 #   TAJO_WORKER_HEAPSIZE  The maximum amount of heap to use, in MB. 
-#                         Default is 1000.
+#                         Default is 5000.
 #
 #   TAJO_OPTS      Extra Java runtime options.
 
@@ -118,7 +118,7 @@ fi
 
 JAVA=$JAVA_HOME/bin/java
 JAVA_TAJO_MASTER_HEAP_MAX=-Xmx1000m 
-JAVA_WORKER_HEAP_MAX=-Xmx1000m
+JAVA_WORKER_HEAP_MAX=-Xmx5000m
 JAVA_QUERYMASTER_HEAP_MAX=-Xmx1000m
 JAVA_PULLSERVER_HEAP_MAX=-Xmx1000m
 

--- a/tajo-dist/src/main/conf/tajo-env.sh
+++ b/tajo-dist/src/main/conf/tajo-env.sh
@@ -33,8 +33,8 @@
 # The maximum amount of heap to use, in MB. Default is 1000.
 # export TAJO_MASTER_HEAPSIZE=1000
 
-# The maximum amount of heap to use, in MB. Default is 1000.
-# export TAJO_WORKER_HEAPSIZE=1000
+# The maximum amount of heap to use, in MB. Default is 5000.
+# export TAJO_WORKER_HEAPSIZE=5000
 
 # The maximum amount of heap to use, in MB. Default is 1000.
 # export TAJO_PULLSERVER_HEAPSIZE=1000
@@ -48,8 +48,8 @@
 # Extra TajoMaster's java runtime options for TajoMaster. Empty by default
 # export TAJO_MASTER_OPTS=
 
-# Extra TajoWorker's java runtime options. Empty by default
-# export TAJO_WORKER_OPTS=
+# Extra TajoWorker's java runtime options.
+export TAJO_WORKER_OPTS='-XX:+UseParallelOldGC'
 
 # Extra TajoPullServer's java runtime options. Empty by default
 # export TAJO_PULLSERVER_OPTS=

--- a/tajo-dist/src/main/conf/tajo-site.xml.template
+++ b/tajo-dist/src/main/conf/tajo-site.xml.template
@@ -60,19 +60,19 @@
 <!--
 <property>
   <name>tajo.worker.resource.cpu-cores</name>
-  <value>1</value>
+  <value>4</value>
   <description>Number of CPU cores</description>
 </property>
 
 <property>
-  <name>tajo.worker.resource.memory-mb</name>
-  <value>1024</value>
-  <description>Available memory size (MB)</description>
+  <name>tajo.task.resource.min.memory-mb</name>
+  <value>2000</value>
+  <description>Minimum allocatable memory per task</description>
 </property>
 
 <property>
   <name>tajo.worker.resource.disks</name>
-  <value>1</value>
+  <value>2</value>
   <description>Available disk capacity (usually number of disks)</description>
 </property>
 

--- a/tajo-docs/src/main/sphinx/configuration/worker_configuration.rst
+++ b/tajo-docs/src/main/sphinx/configuration/worker_configuration.rst
@@ -14,7 +14,7 @@ If you want to adjust heap memory size, set ``TAJO_WORKER_HEAPSIZE`` variable in
 
   TAJO_WORKER_HEAPSIZE=8000
 
-The default size is 1000 (1GB).
+The default size is 5000 (5GB).
 
 ========================
 Temporary Data Directory
@@ -54,8 +54,8 @@ In order to specify the resource capacity of each worker, you should add the fol
 ===================================  =============   ======================   =================================
   tajo.worker.resource.cpu-cores       Integer         available cpu-cores      the number of cpu cores
   tajo.worker.resource.memory-mb       Integer         available jvm heap       memory size (MB)
-  tajo.worker.resource.disks           Integer         1                        the number of disks
-  tajo.task.resource.min.memory-mb     Integer         500                      minimum allocatable memory per task
+  tajo.worker.resource.disks           Integer         2                        the number of disks
+  tajo.task.resource.min.memory-mb     Integer         1000                     minimum allocatable memory per task
   tajo.qm.resource.min.memory-mb       Integer         500                      minimum allocatable memory per query
 ===================================  =============   ======================   =================================
 
@@ -73,7 +73,7 @@ In order to specify the resource capacity of each worker, you should add the fol
  Example
 ------------
 
-Assume that you want to give 15GB Jvm heap, 1GB memory per task, 4 disks, and 12 cores on each worker. The example configuration is as follows:
+Assume that you want to give 15GB Jvm heap, 2GB memory per task, 4 disks, and 12 cores on each worker. The example configuration is as follows:
 
 ``tajo-env.sh``
 
@@ -93,7 +93,7 @@ Assume that you want to give 15GB Jvm heap, 1GB memory per task, 4 disks, and 12
   
    <property>
     <name>tajo.task.resource.min.memory-mb</name>
-    <value>1000</value>
+    <value>2000</value>
   </property>
   
   <property>
@@ -117,7 +117,7 @@ Assume that you want to give 15GB Jvm heap, 1GB memory per task, 4 disks, and 12
 
    <property>
     <name>tajo.task.resource.min.memory-mb</name>
-    <value>1000</value>
+    <value>2000</value>
   </property>
 
   <property>
@@ -141,7 +141,7 @@ Assume that you want to give 15GB Jvm heap, 1GB memory per task, 4 disks, and 12
 
    <property>
     <name>tajo.task.resource.min.memory-mb</name>
-    <value>1000</value>
+    <value>2000</value>
   </property>
 
   <property>


### PR DESCRIPTION
I've change the default value to following:
`Default Xmx: 1G -> 5G`
`tajo.task.resource.min.memory-mb: 500 -> 1000`
`tajo.worker.resource.disks: 1 -> 2`
`Default GC: -XX:+UseParallelOldGC`
This configuration can execute 4 task simultaneously.
