### PR TITLE
[TAJO-2072] The constructor of RegionSizeCalculator changes for HBase 1.0.0 compatibility.

### DIFF
--- a/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/RegionSizeCalculator.java
+++ b/tajo-storage/tajo-storage-hbase/src/main/java/org/apache/tajo/storage/hbase/RegionSizeCalculator.java
@@ -73,7 +73,7 @@ public class RegionSizeCalculator {
   public RegionSizeCalculator(HTable table) throws IOException {
     HBaseAdmin admin = new HBaseAdmin(table.getConfiguration());
     try {
-      init(table.getRegionLocator(), admin);
+      init(table, admin);
     } finally {
       admin.close();
     }


### PR DESCRIPTION
I wish getRegionLocator() method to remove for HBase 1.0.0 compatibility. HTable already implements RegionLocator interface.

Thank you.