### PR TITLE
[TAJO-2085] Add parseDateTime method with TimeZone in DateTimeFormat class

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeFormat.java
+++ b/tajo-common/src/main/java/org/apache/tajo/util/datetime/DateTimeFormat.java
@@ -592,7 +592,10 @@ public class DateTimeFormat {
   public static TimeMeta parseDateTime(String dateText, String formatText) {
     TimeMeta tm = new TimeMeta();
 
-    //TODO consider TimeZone
+    return parseDateTime(dateText, formatText, tm);
+  }
+
+  public static TimeMeta parseDateTime(String dateText, String formatText, TimeMeta tm) {
     doToTimestamp(dateText, formatText, tm);
 
     // when we parse some date without day like '2014-04', we should set day to 1.


### PR DESCRIPTION
I added the UDF for my application like below.

TimeMeta tm = DateTimeFormat.parseDateTime(pastDateText, "YYYYMMDD");
DateTimeUtil.toUserTimezone(tm, timezone);

I expected to return the date to apply a time zone but It wasn't working.
So I hope to add parseDateTime method with TimeZone.
Thanks.