### PR TITLE
TAJO-2120 Change tajo.master.info-http.address and tajo.master.info-http.address.context.path for tajo-site.xml

### DIFF
--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -137,7 +137,8 @@ public class TajoConf extends Configuration {
         Validators.networkAddr()),
     TAJO_MASTER_CLIENT_RPC_ADDRESS("tajo.master.client-rpc.address", "localhost:26002",
         Validators.networkAddr()),
-    TAJO_MASTER_INFO_ADDRESS("tajo.master.info-http.address", "0.0.0.0:26080", Validators.networkAddr()),
+    TAJO_MASTER_INFO_ADDRESS("tajo.master.info-http.address", "0.0.0.0:26088", Validators.networkAddr()),
+    TAJO_MASTER_INFO_ADDRESS_CONTEXT_PATH("tajo.master.info-http.address.context.path", "/tajo", Validators.javaString()),
 
     // Tajo Rest Service
     REST_SERVICE_ADDRESS("tajo.rest.service.address", "0.0.0.0:26880", Validators.networkAddr()),

--- a/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
+++ b/tajo-common/src/main/java/org/apache/tajo/conf/TajoConf.java
@@ -137,8 +137,8 @@ public class TajoConf extends Configuration {
         Validators.networkAddr()),
     TAJO_MASTER_CLIENT_RPC_ADDRESS("tajo.master.client-rpc.address", "localhost:26002",
         Validators.networkAddr()),
-    TAJO_MASTER_INFO_ADDRESS("tajo.master.info-http.address", "0.0.0.0:26088", Validators.networkAddr()),
-    TAJO_MASTER_INFO_ADDRESS_CONTEXT_PATH("tajo.master.info-http.address.context.path", "/tajo", Validators.javaString()),
+    TAJO_MASTER_INFO_ADDRESS("tajo.master.info-http.address", "0.0.0.0:26080", Validators.networkAddr()),
+    TAJO_MASTER_INFO_ADDRESS_CONTEXT_PATH("tajo.master.info-http.address.context.path", "/", Validators.javaString()),
 
     // Tajo Rest Service
     REST_SERVICE_ADDRESS("tajo.rest.service.address", "0.0.0.0:26880", Validators.networkAddr()),

--- a/tajo-core/src/main/java/org/apache/tajo/webapp/HttpServer.java
+++ b/tajo-core/src/main/java/org/apache/tajo/webapp/HttpServer.java
@@ -22,6 +22,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.tajo.conf.TajoConf;
+import org.apache.tajo.util.TUtil;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Handler;
 import org.mortbay.jetty.Server;
@@ -65,6 +67,8 @@ public class HttpServer {
     this.webServer = new Server();
     this.findPort = findPort;
 
+    TajoConf tajoConf = TUtil.checkTypeAndGet(conf, TajoConf.class);
+
     if (connector == null) {
       listenerStartedExternally = false;
       listener = createBaseListener(conf);
@@ -92,7 +96,7 @@ public class HttpServer {
 
     webAppContext = new WebAppContext();
     webAppContext.setDisplayName(name);
-    webAppContext.setContextPath("/");
+    webAppContext.setContextPath(tajoConf.getVar(TajoConf.ConfVars.TAJO_MASTER_INFO_ADDRESS_CONTEXT_PATH));
     webAppContext.setResourceBase(appDir + "/" + name);
     webAppContext.setDescriptor(appDir + "/" + name + "/WEB-INF/web.xml");
 

--- a/tajo-dist/src/main/bin/start-tajo.sh
+++ b/tajo-dist/src/main/bin/start-tajo.sh
@@ -54,6 +54,7 @@ fi
 # Display WEB UI URL and TajoMaster RPC address.
 # Getting configuration value of http address and rpc address.
 HTTP_ADDRESS=$("$bin"/tajo getconf tajo.master.info-http.address)
+HTTP_ADDRESS_CONTEXT_PATH=$("$bin"/tajo getconf tajo.master.info-http.address.context.path)
 RPC_ADDRESS=$("$bin"/tajo getconf tajo.master.client-rpc.address)
 HTTP_ADDRESS=(${HTTP_ADDRESS//:/ })
 RPC_ADDRESS=(${RPC_ADDRESS//:/ })
@@ -70,5 +71,5 @@ if [ ${RPC_ADDRESS[0]} = "0.0.0.0" ] ||
   RPC_ADDRESS[0]=`hostname`
 fi
 
-echo "Tajo master web UI: http://${HTTP_ADDRESS[0]}:${HTTP_ADDRESS[1]}"
+echo "Tajo master web UI: http://${HTTP_ADDRESS[0]}:${HTTP_ADDRESS[1]}${HTTP_ADDRESS_CONTEXT_PATH}"
 echo "Tajo Client Service: ${RPC_ADDRESS[0]}:${RPC_ADDRESS[1]}"

--- a/tajo-dist/src/main/conf/tajo-site.xml.template
+++ b/tajo-dist/src/main/conf/tajo-site.xml.template
@@ -31,6 +31,18 @@
 </property>
 
 <property>
+    <name>tajo.master.info-http.address</name>
+    <value>hostname:26080</value>
+    <description>TajoMaster info-http binding address.</description>
+</property>
+
+<property>
+    <name>tajo.master.info-http.address.context.path</name>
+    <value>/</value>
+    <description>TajoMaster info-http context-path.</description>
+</property>
+
+<property>
   <name>tajo.master.umbilical-rpc.address</name>
   <value>hostname:26001</value>
   <description>TajoMaster binding address between master and workers.</description>


### PR DESCRIPTION
add tajo.master.info-http.address and tajo.master.info-http.address.context.path with tajo-site.xml.
Because of users want to change tajo-master-webui address, port and context-path.