### PR TITLE
TAJO-2117: Add some missing index to MariaDBStore

### DIFF
--- a/tajo-catalog/tajo-catalog-server/src/main/resources/schemas/mariadb/mariadb.xml
+++ b/tajo-catalog/tajo-catalog-server/src/main/resources/schemas/mariadb/mariadb.xml
@@ -19,7 +19,7 @@
 <tns:store xmlns:tns="http://tajo.apache.org/catalogstore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tajo.apache.org/catalogstore ../DBMSSchemaDefinition.xsd ">
   <!--
       Catalog base version history
-      * 13 - 2016-05-07: Added general index consist of DB_ID, TID, COLUMN_NAMES (TAJO-2117)
+      * 13 - 2016-05-07: Add some missing index to MariaDBStore (TAJO-2117)
       * 12 - 2015-09-28: Change the variable name storeType to dataFormat (TAJO-1663)
       * 11 - 2015-09-23: Add contents length and file count for partition directory (TAJO-1493)
       * 10 - 2015-09-22: Well support for self-describing data formats (TAJO-1832)

--- a/tajo-catalog/tajo-catalog-server/src/main/resources/schemas/mariadb/mariadb.xml
+++ b/tajo-catalog/tajo-catalog-server/src/main/resources/schemas/mariadb/mariadb.xml
@@ -19,6 +19,7 @@
 <tns:store xmlns:tns="http://tajo.apache.org/catalogstore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tajo.apache.org/catalogstore ../DBMSSchemaDefinition.xsd ">
   <!--
       Catalog base version history
+      * 13 - 2016-05-07: Added general index consist of DB_ID, TID, COLUMN_NAMES (TAJO-2117)
       * 12 - 2015-09-28: Change the variable name storeType to dataFormat (TAJO-1663)
       * 11 - 2015-09-23: Add contents length and file count for partition directory (TAJO-1493)
       * 10 - 2015-09-22: Well support for self-describing data formats (TAJO-1832)
@@ -32,7 +33,7 @@
       * 2 - 2014-06-09: First versioning
       * 1-  Before 2013-03-20
     -->
-  <tns:base version="12">
+  <tns:base version="13">
     <tns:objects>
       <tns:Object order="0" type="table" name="META">
         <tns:sql><![CDATA[CREATE TABLE META (VERSION INT NOT NULL)]]></tns:sql>
@@ -126,7 +127,10 @@
         )]]>
         </tns:sql>
       </tns:Object>
-      <tns:Object order="7" type="table" name="STATS">
+      <tns:Object order="7" type="index" name="INDEXES_IDX_TID_COLUMN_NAME" dependsOn="INDEXES">
+        <tns:sql><![CDATA[CREATE INDEX INDEXES_IDX_TID_COLUMN_NAME on INDEXES (DB_ID, TID, COLUMN_NAMES)]]></tns:sql>
+      </tns:Object>
+      <tns:Object order="8" type="table" name="STATS">
         <tns:sql><![CDATA[
         CREATE TABLE STATS (
           TID INT NOT NULL PRIMARY KEY,
@@ -136,7 +140,7 @@
         )]]>
         </tns:sql>
       </tns:Object>
-      <tns:Object order="8" type="table" name="PARTITION_METHODS">
+      <tns:Object order="9" type="table" name="PARTITION_METHODS">
         <tns:sql><![CDATA[
         CREATE TABLE PARTITION_METHODS (
           TID INT NOT NULL PRIMARY KEY,
@@ -147,7 +151,7 @@
         )]]>
         </tns:sql>
       </tns:Object>
-      <tns:Object order="9" type="table" name="PARTITIONS">
+      <tns:Object order="10" type="table" name="PARTITIONS">
         <tns:sql><![CDATA[
         CREATE TABLE PARTITIONS (
           PARTITION_ID INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -160,7 +164,7 @@
         )]]>
         </tns:sql>
       </tns:Object>
-      <tns:Object order="10" type="table" name="PARTITION_KEYS">
+      <tns:Object order="11" type="table" name="PARTITION_KEYS">
         <tns:sql><![CDATA[
         CREATE TABLE PARTITION_KEYS (
           PARTITION_ID INT NOT NULL,


### PR DESCRIPTION
Added General Index : Consists of DB_ID and TID and COLUMN_NAMES
Issue: https://issues.apache.org/jira/browse/TAJO-2117