### PR TITLE
TAJO-2175: Fix some glitches in source code

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogUtil.java
@@ -488,41 +488,39 @@ public class CatalogUtil {
     Collections.addAll(IdentifierUtil.RESERVED_KEYWORDS_SET, IdentifierUtil.RESERVED_KEYWORDS);
   }
 
-  public static AlterTableDesc renameColumn(String tableName, String oldColumName, String newColumName,
-                                            AlterTableType alterTableType) {
+  public static AlterTableDesc renameColumn(String tableName, String oldColumName, String newColumName) {
     final AlterTableDesc alterTableDesc = new AlterTableDesc();
     alterTableDesc.setTableName(tableName);
     alterTableDesc.setColumnName(oldColumName);
     alterTableDesc.setNewColumnName(newColumName);
-    alterTableDesc.setAlterTableType(alterTableType);
+    alterTableDesc.setAlterTableType(AlterTableType.RENAME_COLUMN);
     return alterTableDesc;
   }
 
-  public static AlterTableDesc renameTable(String tableName, String newTableName, AlterTableType alterTableType,
-                                           @Nullable Path newTablePath) {
+  public static AlterTableDesc renameTable(String tableName, String newTableName, @Nullable Path newTablePath) {
     final AlterTableDesc alterTableDesc = new AlterTableDesc();
     alterTableDesc.setTableName(tableName);
     alterTableDesc.setNewTableName(newTableName);
-    alterTableDesc.setAlterTableType(alterTableType);
+    alterTableDesc.setAlterTableType(AlterTableType.RENAME_TABLE);
     if (newTablePath != null) {
       alterTableDesc.setNewTablePath(newTablePath);
     }
     return alterTableDesc;
   }
 
-  public static AlterTableDesc addNewColumn(String tableName, Column column, AlterTableType alterTableType) {
+  public static AlterTableDesc addNewColumn(String tableName, Column column) {
     final AlterTableDesc alterTableDesc = new AlterTableDesc();
     alterTableDesc.setTableName(tableName);
     alterTableDesc.setAddColumn(column);
-    alterTableDesc.setAlterTableType(alterTableType);
+    alterTableDesc.setAlterTableType(AlterTableType.ADD_COLUMN);
     return alterTableDesc;
   }
 
-  public static AlterTableDesc setProperty(String tableName, KeyValueSet params, AlterTableType alterTableType) {
+  public static AlterTableDesc setProperty(String tableName, KeyValueSet params) {
     final AlterTableDesc alterTableDesc = new AlterTableDesc();
     alterTableDesc.setTableName(tableName);
     alterTableDesc.setProperties(params);
-    alterTableDesc.setAlterTableType(alterTableType);
+    alterTableDesc.setAlterTableType(AlterTableType.SET_PROPERTY);
     return alterTableDesc;
   }
 

--- a/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
+++ b/tajo-core/src/main/java/org/apache/tajo/master/exec/DDLExecutor.java
@@ -457,25 +457,23 @@ public class DDLExecutor {
         fs.rename(oldPath, newPath);
       }
       catalog.alterTable(CatalogUtil.renameTable(qualifiedName, alterTable.getNewTableName(),
-          AlterTableType.RENAME_TABLE, newPath));
+          newPath));
       break;
     case RENAME_COLUMN:
       if (ensureColumnExistance(qualifiedName, alterTable.getNewColumnName())) {
         throw new DuplicateColumnException(alterTable.getNewColumnName());
       }
       catalog.alterTable(CatalogUtil.renameColumn(qualifiedName, alterTable.getColumnName(),
-          alterTable.getNewColumnName(), AlterTableType.RENAME_COLUMN));
+          alterTable.getNewColumnName()));
       break;
     case ADD_COLUMN:
       if (ensureColumnExistance(qualifiedName, alterTable.getAddNewColumn().getSimpleName())) {
         throw new DuplicateColumnException(alterTable.getAddNewColumn().getSimpleName());
       }
-      catalog.alterTable(CatalogUtil.addNewColumn(qualifiedName, alterTable.getAddNewColumn(), AlterTableType
-          .ADD_COLUMN));
+      catalog.alterTable(CatalogUtil.addNewColumn(qualifiedName, alterTable.getAddNewColumn()));
       break;
     case SET_PROPERTY:
-      catalog.alterTable(CatalogUtil.setProperty(qualifiedName, alterTable.getProperties(), AlterTableType
-          .SET_PROPERTY));
+      catalog.alterTable(CatalogUtil.setProperty(qualifiedName, alterTable.getProperties()));
       break;
     case UNSET_PROPERTY:
       catalog.alterTable(CatalogUtil.unsetProperty(qualifiedName, alterTable.getUnsetPropertyKeys()));

--- a/tajo-plan/src/main/java/org/apache/tajo/plan/logical/AlterTableNode.java
+++ b/tajo-plan/src/main/java/org/apache/tajo/plan/logical/AlterTableNode.java
@@ -209,17 +209,6 @@ public class AlterTableNode extends LogicalNode {
     }
   }
 
-    /*@Override
-    public Object clone() throws CloneNotSupportedException {
-        AlterTableNode alterTableNode = (AlterTableNode) super.clone();
-        alterTableNode.tableName = tableName;
-        alterTableNode.newTableName = newTableName;
-        alterTableNode.columnName = columnName;
-        alterTableNode.newColumnName=newColumnName;
-        alterTableNode.addNewColumn =(Column) addNewColumn.clone();
-        return alterTableNode;
-    }*/
-
   @Override
   public String toString() {
     return "AlterTable (table=" + tableName + ")";


### PR DESCRIPTION
Fix some glitches found working on TAJO-2165:

1. Refine method signiture: CatalogUtil#renameColumn, renameTable, addNewColumn and setProperty. 2. Remove AlterTableNode#clone.