### PR TITLE
TAJO-2170: Disable unsetting timezone property

### DIFF
--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -21,7 +21,9 @@
  */
 package org.apache.tajo.catalog.store;
 
+import com.google.common.collect.Sets;
 import com.google.protobuf.InvalidProtocolBufferException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -62,6 +64,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   protected final String connectionPassword;
   protected final String catalogUri;
 
+  protected final Set<String> unremovablePropertySet = Sets.newHashSet("timezone");
   protected final String insertPartitionSql = "INSERT INTO " + TB_PARTTIONS
     + "(" + COL_TABLES_PK + ", PARTITION_NAME, PATH, " + COL_PARTITION_BYTES
     + ") VALUES (?, ? , ?, ?)";
@@ -978,7 +981,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   public void alterTable(CatalogProtos.AlterTableDescProto alterTableDescProto)
       throws UndefinedDatabaseException, DuplicateTableException, DuplicateColumnException,
       DuplicatePartitionException, UndefinedPartitionException, UndefinedColumnException, UndefinedTableException,
-      UndefinedPartitionMethodException, AmbiguousTableException {
+      UndefinedPartitionMethodException, AmbiguousTableException, UnremovableTablePropertyException {
 
     String[] splitted = IdentifierUtil.splitTableName(alterTableDescProto.getTableName());
     if (splitted.length == 1) {
@@ -1110,11 +1113,19 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     }
   }
 
-  private void unsetProperties(final int tableId, final PrimitiveProtos.StringListProto propertyKeys) {
+  private void unsetProperties(final int tableId, final PrimitiveProtos.StringListProto propertyKeys)
+      throws UnremovableTablePropertyException {
     final String deleteSql = "DELETE FROM " + TB_OPTIONS + " WHERE TID=? AND KEY_=?";
 
     Connection conn;
     PreparedStatement pstmt = null;
+
+	  Set<String> keys = Sets.newHashSet(propertyKeys.getValuesList());
+	  Set<String> violations = Sets.intersection(keys, unremovablePropertySet);
+
+	  if (!violations.isEmpty()) {
+			throw new UnremovableTablePropertyException(violations.toArray(new String[0]));
+	  }
 
     Map<String, String> oldProperties = getTableOptions(tableId);
 

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -1120,12 +1120,12 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     Connection conn;
     PreparedStatement pstmt = null;
 
-	  Set<String> keys = Sets.newHashSet(propertyKeys.getValuesList());
-	  Set<String> violations = Sets.intersection(keys, unremovablePropertySet);
+    Set<String> keys = Sets.newHashSet(propertyKeys.getValuesList());
+    Set<String> violations = Sets.intersection(keys, unremovablePropertySet);
 
-	  if (!violations.isEmpty()) {
-			throw new UnremovableTablePropertyException(violations.toArray(new String[0]));
-	  }
+    if (!violations.isEmpty()) {
+      throw new UnremovableTablePropertyException(violations.toArray(new String[0]));
+    }
 
     Map<String, String> oldProperties = getTableOptions(tableId);
 

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/CatalogStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/CatalogStore.java
@@ -71,7 +71,8 @@ public interface CatalogStore extends Closeable {
 
   void alterTable(CatalogProtos.AlterTableDescProto alterTableDescProto) throws UndefinedDatabaseException,
       DuplicateTableException, DuplicateColumnException, DuplicatePartitionException, UndefinedPartitionException,
-      UndefinedTableException, UndefinedColumnException, UndefinedPartitionMethodException, AmbiguousTableException;
+      UndefinedTableException, UndefinedColumnException, UndefinedPartitionMethodException, AmbiguousTableException,
+      UnremovableTablePropertyException;
 
   List<TableDescriptorProto> getAllTables();
 

--- a/tajo-catalog/tajo-catalog-server/src/test/java/org/apache/tajo/catalog/TestCatalog.java
+++ b/tajo-catalog/tajo-catalog-server/src/test/java/org/apache/tajo/catalog/TestCatalog.java
@@ -1003,9 +1003,9 @@ public class TestCatalog {
     assertEquals(newTimeZone, setPropertyDesc.getMeta().getProperty("timezone"));
 
     //UNSET_PROPERTY
-    catalog.alterTable(createMockAlterTableUnsetProperty(Sets.newHashSet("timezone", "dummy")));
+    catalog.alterTable(createMockAlterTableUnsetProperty(Sets.newHashSet("dummy")));
     setPropertyDesc = catalog.getTableDesc("default","mynewcooltable");
-    assertFalse(setPropertyDesc.getMeta().getPropertySet().containsKey("timezone"));
+    assertTrue(setPropertyDesc.getMeta().getPropertySet().containsKey("timezone"));
     assertFalse(setPropertyDesc.getMeta().getPropertySet().containsKey("dummy"));
   }
 

--- a/tajo-common/src/main/java/org/apache/tajo/exception/ErrorMessages.java
+++ b/tajo-common/src/main/java/org/apache/tajo/exception/ErrorMessages.java
@@ -113,6 +113,7 @@ public class ErrorMessages {
     ADD_MESSAGE(INVALID_TABLE_PROPERTY, "invalid table property '%s': '%s'", 2);
     ADD_MESSAGE(MISSING_TABLE_PROPERTY, "table property '%s' required for '%s'", 2);
     ADD_MESSAGE(INVALID_TABLESPACE_URI, "Invalid tablespace '%s' for table '%s'", 2);
+    ADD_MESSAGE(UNREMOVABLE_TABLE_PROPERTY, "Removing following properties is disabled: %s", 1);
 
     ADD_MESSAGE(AMBIGUOUS_PARTITION_DIRECTORY, "There is a directory which is assumed to be a partitioned directory" +
       " : '%s'", 1);

--- a/tajo-common/src/main/java/org/apache/tajo/exception/UnremovableTablePropertyException.java
+++ b/tajo-common/src/main/java/org/apache/tajo/exception/UnremovableTablePropertyException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tajo.exception;
+
+import org.apache.tajo.error.Errors.ResultCode;
+import org.apache.tajo.rpc.protocolrecords.PrimitiveProtos.ReturnState;
+
+public class UnremovableTablePropertyException extends TajoException {
+
+  public UnremovableTablePropertyException(ReturnState e) {
+    super(e);
+  }
+
+  public UnremovableTablePropertyException(String...keys) {
+    super(ResultCode.UNREMOVABLE_TABLE_PROPERTY, ErrorMessages.concat(keys));
+  }
+}

--- a/tajo-common/src/main/java/org/apache/tajo/exception/UnremovableTablePropertyException.java
+++ b/tajo-common/src/main/java/org/apache/tajo/exception/UnremovableTablePropertyException.java
@@ -27,7 +27,7 @@ public class UnremovableTablePropertyException extends TajoException {
     super(e);
   }
 
-  public UnremovableTablePropertyException(String...keys) {
+  public UnremovableTablePropertyException(String... keys) {
     super(ResultCode.UNREMOVABLE_TABLE_PROPERTY, ErrorMessages.concat(keys));
   }
 }

--- a/tajo-common/src/main/proto/errors.proto
+++ b/tajo-common/src/main/proto/errors.proto
@@ -173,6 +173,7 @@ enum ResultCode {
   INVALID_TABLE_PROPERTY                = 1004; // SQLState: ? - Invalid Table Property
   MISSING_TABLE_PROPERTY                = 1005; // SQLState: ? - Missing table property
   INVALID_TABLESPACE_URI                = 1006;
+  UNREMOVABLE_TABLE_PROPERTY            = 1007;
 
   // Client Connection
   CLIENT_CONNECTION_EXCEPTION           = 1101; // SQLState: 08000 - Client connection error


### PR DESCRIPTION
@jihoonson Hello. I just completed [TAJO-2170, Disable unsetting timezone property](https://issues.apache.org/jira/browse/TAJO-2170). However, It would be good to explain my decisions made on this issue. In short, it became a little bit different from our initial expectation.

A little bit different from [your comment in TAJO-2165](https://github.com/apache/tajo/pull/1036#issuecomment-230673810), which became the starting point of this feature, I didn't move the timezone property from KeyValueSet to TableMeta or TableDesc. Here is why:

- Our goal is to disable the removal of the timezone property from the catalog. So, it is sufficient to keep this property from removal by raising Error when the user attempts to remove it from the catalog storage; However, KeyValueSet, TableMeta and TableDesc are all components in alter table message, not storage. So, they don't need to be modified.
- If we modify KeyValueSet, TableMeta or TableDesc, we have to reconduct similar task every time some new unremovable properties are added. This repetitive task does not worth.

With above reasons, I decided not to modify KeyValueSet, TableMeta or TableDesc.