### PR TITLE
TAJO-2180: Disable unsetting timezone property in HiveCatalogStore

### DIFF
--- a/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogConstants.java
+++ b/tajo-catalog/tajo-catalog-common/src/main/java/org/apache/tajo/catalog/CatalogConstants.java
@@ -18,6 +18,10 @@
 
 package org.apache.tajo.catalog;
 
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
 public class CatalogConstants {
   // Linux and BSD's max username length is 32. For compatibility with other systems, we should follow it.
   public final static int MAX_USERNAME_LENGTH = 32;
@@ -58,4 +62,5 @@ public class CatalogConstants {
   public static final String COL_PARTITION_BYTES = "NUM_BYTES";
 
   public static final String INFORMATION_SCHEMA_DB_NAME = "information_schema";
+  protected static final Set<String> UNREMOVABLE_PROPERTY_SET = Sets.newHashSet("timezone");
 }

--- a/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
+++ b/tajo-catalog/tajo-catalog-server/src/main/java/org/apache/tajo/catalog/store/AbstractDBStore.java
@@ -64,7 +64,6 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
   protected final String connectionPassword;
   protected final String catalogUri;
 
-  protected final Set<String> unremovablePropertySet = Sets.newHashSet("timezone");
   protected final String insertPartitionSql = "INSERT INTO " + TB_PARTTIONS
     + "(" + COL_TABLES_PK + ", PARTITION_NAME, PATH, " + COL_PARTITION_BYTES
     + ") VALUES (?, ? , ?, ?)";
@@ -1121,7 +1120,7 @@ public abstract class AbstractDBStore extends CatalogConstants implements Catalo
     PreparedStatement pstmt = null;
 
     Set<String> keys = Sets.newHashSet(propertyKeys.getValuesList());
-    Set<String> violations = Sets.intersection(keys, unremovablePropertySet);
+    Set<String> violations = Sets.intersection(keys, UNREMOVABLE_PROPERTY_SET);
 
     if (!violations.isEmpty()) {
       throw new UnremovableTablePropertyException(violations.toArray(new String[0]));


### PR DESCRIPTION
1. Move AbstractDBStore#unremovablePropertySet -> CatalogConstants#UNREMOVABLE_PROPERTY_SET.
2. update HiveCatalogStore#unsetProperties.