### PR TITLE
[TAJO-2185] Eliminate protoc binary dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,7 @@ before_install:
   # http://docs.travis-ci.com/user/database-setup/#MySQL
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop
-  - sudo sh -c "ulimit -n 64000 && exec su $LOGNAME"
-  - sudo sh -c "sudo ulimit -a"
+  - sudo sh -c "ulimit -u 10000 && ulimit -n 64000 ulimit -t unlimited && ulimit -a && exec su $LOGNAME"
   - free -m
   - df -h
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,6 @@ install:
   - mvn clean install -q -ff -Dsurefire.useFile=false $HADOOP_FLAG -Pdist -DskipTests -Dtar
 
 script: 
-  - mvn $HADOOP_FLAG $TEST_FLAG
+  - travis_wait 30 mvn $HADOOP_FLAG $TEST_FLAG
   - sh -c "dmesg | grep -i OOM || exit 0"
   - free -m

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+dist: trusty
+sudo: required
+
 language: java
 
 git:
@@ -63,8 +66,8 @@ before_install:
   # http://docs.travis-ci.com/user/database-setup/#MySQL
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop
-  - sudo sh -c "ulimit -t unlimited -u 10000 -n 64000"
-  - sudo sh -c "ulimit -a"
+  - sudo ulimit -t unlimited -u 10000 -n 64000
+  - sudo ulimit -a
   - free -m
   - df -h
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ before_install:
   # http://docs.travis-ci.com/user/database-setup/#MySQL
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop
-  - ulimit -t unlimited -u 10000 -n 64000
-  - ulimit -a
+  - sudo sh -c "ulimit -t unlimited -u 10000 -n 64000"
+  - sudo sh -c "ulimit -a"
   - free -m
   - df -h
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   # http://docs.travis-ci.com/user/database-setup/#MySQL
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop
-  - sudo sh -c "ulimit -u 10000 && ulimit -n 64000 ulimit -t unlimited && ulimit -a && exec su $LOGNAME"
+  - sudo sh -c "ulimit -p 10000 && ulimit -n 64000 ulimit -t unlimited && ulimit -a && exec su $LOGNAME"
   - free -m
   - df -h
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ before_install:
   - df -h
 
 install:
-  - sh dev-support/travis-install-dependencies.sh
   - mvn clean install -q -ff -Dsurefire.useFile=false $HADOOP_FLAG -Pdist -DskipTests -Dtar
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   # http://docs.travis-ci.com/user/database-setup/#MySQL
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop
-  - sudo sh -c "ulimit -p 10000 && ulimit -n 64000 && ulimit -t unlimited && ulimit -a && exec su $LOGNAME"
+  - sudo sh -c "ulimit -p 10000 && ulimit -n 64000 && ulimit -t unlimited && ulimit -a"
   - free -m
   - df -h
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dist: trusty
 sudo: required
-
+dist: trusty
 language: java
 
 git:
@@ -66,8 +65,8 @@ before_install:
   # http://docs.travis-ci.com/user/database-setup/#MySQL
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop
-  - sudo ulimit -t unlimited -u 10000 -n 64000
-  - sudo ulimit -a
+  - sudo sh -c "ulimit -n 64000 && exec su $LOGNAME"
+  - sudo sh -c "sudo ulimit -a"
   - free -m
   - df -h
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   # http://docs.travis-ci.com/user/database-setup/#MySQL
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop
-  - sudo sh -c "ulimit -p 10000 && ulimit -n 64000 ulimit -t unlimited && ulimit -a && exec su $LOGNAME"
+  - sudo sh -c "ulimit -p 10000 && ulimit -n 64000 && ulimit -t unlimited && ulimit -a && exec su $LOGNAME"
   - free -m
   - df -h
 

--- a/BUILDING
+++ b/BUILDING
@@ -6,7 +6,6 @@ Requirements:
 * Unix System
 * JDK 1.8 or higher
 * Maven 3.0 or higher
-* Protocol Buffers 2.5.0
 * Internet connection for first build (to fetch all Maven and Tajo dependencies)
 
 --------------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -152,41 +152,7 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.5</version>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.6</version>
-          <executions>
-            <execution>
-              <phase>validate</phase>
-              <goals>
-                <goal>run</goal>
-              </goals>
-              <configuration>
-                <target>
-                  <echo file="${project.build.directory}/verify-protocbuf.sh">
-                    PROTOC_VERSION=`protoc --version`
-                    if [ "${PROTOC_VERSION}" == "" ]; then
-                    echo
-                    echo "Protocol buffer is not installed or protocol buffer path did not add to your PATH variable."
-                    echo
-                    exit -1
-                    fi
-                    if [ "${PROTOC_VERSION}" != "libprotoc 2.5.0" ]; then
-                    echo
-                    echo "Tajo requires protocol buffer version 2.5.0, another versions is not supported."
-                    echo
-                    exit -1
-                    fi
-                  </echo>
-                  <exec executable="bash" dir="${project.build.directory}" failonerror="true">
-                    <arg line="./verify-protocbuf.sh" />
-                  </exec>
-                </target>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
+
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>

--- a/tajo-catalog/tajo-catalog-client/pom.xml
+++ b/tajo-catalog/tajo-catalog-client/pom.xml
@@ -70,26 +70,27 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/CatalogProtocol.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-catalog/tajo-catalog-common/pom.xml
+++ b/tajo-catalog/tajo-catalog-common/pom.xml
@@ -75,25 +75,27 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../../tajo-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/CatalogProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-catalog/tajo-catalog-common/pom.xml
+++ b/tajo-catalog/tajo-catalog-common/pom.xml
@@ -92,7 +92,6 @@
               </inputDirectories>
               <includeDirectories>
                 <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
-                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
               </includeDirectories>
               <outputDirectory>target/generated-sources/proto</outputDirectory>
             </configuration>

--- a/tajo-client/pom.xml
+++ b/tajo-client/pom.xml
@@ -110,29 +110,28 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--proto_path=../tajo-core/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/ClientProtos.proto</argument>
-                <argument>src/main/proto/TajoMasterClientProtocol.proto</argument>
-                <argument>src/main/proto/QueryMasterClientProtocol.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-core/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-common/pom.xml
+++ b/tajo-common/pom.xml
@@ -134,30 +134,23 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/TestProtos.proto</argument>
-                <argument>src/main/proto/TajoIdProtos.proto</argument>
-                <argument>src/main/proto/DataTypes.proto</argument>
-                <argument>src/main/proto/PrimitiveProtos.proto</argument>
-                <argument>src/main/proto/tajo_protos.proto</argument>
-                <argument>src/main/proto/stacktrace.proto</argument>
-                <argument>src/main/proto/errors.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-core/pom.xml
+++ b/tajo-core/pom.xml
@@ -111,7 +111,6 @@
               <includeDirectories>
                 <includeDirectory>../tajo-common/src/main/proto</includeDirectory>
                 <includeDirectory>../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
-                <includeDirectory>../tajo-core/src/main/proto</includeDirectory>
                 <includeDirectory>../tajo-plan/src/main/proto</includeDirectory>
               </includeDirectories>
               <outputDirectory>target/generated-sources/proto</outputDirectory>

--- a/tajo-core/pom.xml
+++ b/tajo-core/pom.xml
@@ -93,33 +93,29 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--proto_path=../tajo-client/src/main/proto</argument>
-                <argument>--proto_path=../tajo-plan/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/ResourceTrackerProtocol.proto</argument>
-                <argument>src/main/proto/QueryMasterProtocol.proto</argument>
-                <argument>src/main/proto/QueryCoordinatorProtocol.proto</argument>
-                <argument>src/main/proto/TajoWorkerProtocol.proto</argument>
-                <argument>src/main/proto/InternalTypes.proto</argument>
-                <argument>src/main/proto/ResourceProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-core/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-plan/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-docs/src/main/sphinx/getting_started.rst
+++ b/tajo-docs/src/main/sphinx/getting_started.rst
@@ -10,7 +10,6 @@ Prerequisites
 
  * Hadoop 2.3.0 or higher (up to 2.6.0)
  * Java 1.8 or higher
- * Protocol buffer 2.5.0
 
 ===================================
 Dowload and unpack the source code

--- a/tajo-jdbc/src/test/java/org/apache/tajo/jdbc/TestResultSet.java
+++ b/tajo-jdbc/src/test/java/org/apache/tajo/jdbc/TestResultSet.java
@@ -232,7 +232,7 @@ public class TestResultSet {
       assertEquals(res.getTimestamp(3), res.getTimestamp("col3"));
 
       // assert with timezone
-      //Current timezone + 1 hour
+      // Current timezone + 1 hour
       TimeZone tz = TimeZone.getDefault();
       tz.setRawOffset(tz.getRawOffset() + (int) TimeUnit.HOURS.toMillis(1));
 
@@ -240,7 +240,8 @@ public class TestResultSet {
       assertEquals(tz.getRawOffset(), cal.getTimeZone().getRawOffset());
 
       assertEquals(Date.valueOf("2013-12-31"), res.getDate(1, cal));
-      assertEquals(Time.valueOf("23:00:00"), res.getTime(1, cal));
+      // TODO - See https://issues.apache.org/jira/browse/TAJO-2186
+      assertEquals(Time.valueOf("23:00:00").toString(), res.getTime(1, cal).toString());
       assertEquals(Timestamp.valueOf("2013-12-31 23:00:00.0"), res.getTimestamp(1, cal));
       assertEquals(res.getDate(1, cal), res.getDate("col1", cal));
 

--- a/tajo-metrics/pom.xml
+++ b/tajo-metrics/pom.xml
@@ -71,25 +71,23 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>src/main/proto/master_metrics.proto</argument>
-                <argument>src/main/proto/node_metrics.proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-plan/pom.xml
+++ b/tajo-plan/pom.xml
@@ -71,27 +71,28 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--proto_path=../tajo-client/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/Plan.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-client/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-rpc/tajo-rpc-protobuf/pom.xml
+++ b/tajo-rpc/tajo-rpc-protobuf/pom.xml
@@ -84,27 +84,23 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/DummyProtos.proto</argument>
-                <argument>src/main/proto/RpcProtos.proto</argument>
-                <argument>src/main/proto/TestProtos.proto</argument>
-                <argument>src/main/proto/TestProtocol.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-storage/tajo-storage-common/pom.xml
+++ b/tajo-storage/tajo-storage-common/pom.xml
@@ -109,26 +109,27 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/IndexProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-storage/tajo-storage-hbase/pom.xml
+++ b/tajo-storage/tajo-storage-hbase/pom.xml
@@ -112,26 +112,28 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/StorageFragmentProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-core/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-storage/tajo-storage-hbase/pom.xml
+++ b/tajo-storage/tajo-storage-hbase/pom.xml
@@ -130,7 +130,6 @@
               <includeDirectories>
                 <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
                 <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
-                <includeDirectory>../../tajo-core/src/main/proto</includeDirectory>
               </includeDirectories>
               <outputDirectory>target/generated-sources/proto</outputDirectory>
             </configuration>

--- a/tajo-storage/tajo-storage-hdfs/pom.xml
+++ b/tajo-storage/tajo-storage-hdfs/pom.xml
@@ -113,26 +113,27 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/StorageFragmentProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-storage/tajo-storage-jdbc/pom.xml
+++ b/tajo-storage/tajo-storage-jdbc/pom.xml
@@ -111,26 +111,27 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/JdbcFragmentProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-storage/tajo-storage-kafka/pom.xml
+++ b/tajo-storage/tajo-storage-kafka/pom.xml
@@ -100,26 +100,27 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/StorageFragmentProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/tajo-tablespace-example/pom.xml
+++ b/tajo-tablespace-example/pom.xml
@@ -87,26 +87,27 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
             <phase>generate-sources</phase>
-            <configuration>
-              <executable>protoc</executable>
-              <arguments>
-                <argument>-Isrc/main/proto/</argument>
-                <argument>--proto_path=../tajo-common/src/main/proto</argument>
-                <argument>--proto_path=../tajo-catalog/tajo-catalog-common/src/main/proto</argument>
-                <argument>--java_out=target/generated-sources/proto</argument>
-                <argument>src/main/proto/ExampleHttpFragmentProtos.proto</argument>
-              </arguments>
-            </configuration>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>2.5.0</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+              <inputDirectories>
+                <include>src/main/proto/</include>
+              </inputDirectories>
+              <includeDirectories>
+                <includeDirectory>../tajo-common/src/main/proto</includeDirectory>
+                <includeDirectory>../tajo-catalog/tajo-catalog-common/src/main/proto</includeDirectory>
+              </includeDirectories>
+              <outputDirectory>target/generated-sources/proto</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/TAJO-2185.

Building Tajo project depends on protoc binary installed on a local machine. It is very inconvenient because users must install protoc in their local machine. It would be great if we eliminate this dependency. This patch uses [1] to replace the dependency of local binary by protoc-jar.