### PR TITLE
Change the git repo to the Aapche Tajo Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and its optimizer.
 ## Project
 
 * [Project Home](http://tajo.apache.org/)
-* [Source Repository](https://git-wip-us.apache.org/repos/asf/tajo.git)
+* [Source Repository](https://github.com/apache/tajo.git)
 * [Issue Tracking](https://issues.apache.org/jira/browse/TAJO)
 
 ## License

--- a/doap_Tajo.rdf
+++ b/doap_Tajo.rdf
@@ -49,7 +49,7 @@
     <category rdf:resource="http://projects.apache.org/category/big-data" />
     <repository>
       <SVNRepository>
-        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/tajo.git"/>
+        <location rdf:resource="https://github.com/apache/tajo.git"/>
         <browse rdf:resource="https://git-wip-us.apache.org/repos/asf?p=tajo.git"/>
       </SVNRepository>
     </repository>

--- a/doap_Tajo.rdf
+++ b/doap_Tajo.rdf
@@ -50,7 +50,7 @@
     <repository>
       <SVNRepository>
         <location rdf:resource="https://github.com/apache/tajo.git"/>
-        <browse rdf:resource="https://git-wip-us.apache.org/repos/asf?p=tajo.git"/>
+        <browse rdf:resource="https://github.com/apache/tajo"/>
       </SVNRepository>
     </repository>
     <maintainer>

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
   </ciManagement>
 
   <scm>
-    <url>https://git-wip-us.apache.org/repos/asf/tajo.git</url>
-    <connection>scm:git:https://git-wip-us.apache.org/repos/asf/tajo.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/tajo.git</developerConnection>
+    <url>https://github.com/apache/tajo.git</url>
+    <connection>scm:git:https://github.com/apache/tajo.git</connection>
+    <developerConnection>scm:git:https://github.com/apache/tajo.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 

--- a/tajo-docs/src/main/sphinx/configuration/catalog_configuration.rst
+++ b/tajo-docs/src/main/sphinx/configuration/catalog_configuration.rst
@@ -157,7 +157,7 @@ First, you must compile source code and get a binary archive as follows:
 
 .. code-block:: sh
 
-  $ git clone https://git-wip-us.apache.org/repos/asf/tajo.git tajo
+  $ git clone https://github.com/apache/tajo.git tajo
   $ mvn clean install -DskipTests -Pdist -Dtar
   $ ls tajo-dist/target/tajo-x.y.z-SNAPSHOT.tar.gz
 

--- a/tajo-docs/src/main/sphinx/getting_started.rst
+++ b/tajo-docs/src/main/sphinx/getting_started.rst
@@ -33,9 +33,9 @@ Decompress and untar your downloaded file and then change into the unpacked dire
 Check out the source code via Git
 -----------------------------------
 
-The development codebase can also be downloaded from `the Apache git repository <https://git-wip-us.apache.org/repos/asf/tajo.git>`_ as follows: ::
+The development codebase can also be downloaded from `the Apache git repository <https://github.com/apache/tajo.git>`_ as follows: ::
 
-  git clone https://git-wip-us.apache.org/repos/asf/tajo.git
+  git clone https://github.com/apache/tajo.git
 
 A read-only git repository is also mirrored on `Github <https://github.com/apache/tajo>`_.
 

--- a/tajo-project/pom.xml
+++ b/tajo-project/pom.xml
@@ -361,9 +361,9 @@
   </issueManagement>
 
   <scm>
-    <url>https://git-wip-us.apache.org/repos/asf/tajo.git</url>
-    <connection>scm:git:https://git-wip-us.apache.org/repos/asf/tajo.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/tajo.git</developerConnection>
+    <url>https://github.com/apache/tajo.git</url>
+    <connection>scm:git:https://github.com/apache/tajo.git</connection>
+    <developerConnection>scm:git:https://github.com/apache/tajo.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 

--- a/tajo-project/src/site/markdown/downloads.md
+++ b/tajo-project/src/site/markdown/downloads.md
@@ -93,10 +93,10 @@ For developers, Tajo maintains nightly builds and SNAPSHOT artifacts. More infor
 
 ## Getting the source code via Git
 
-The development codebase can also be downloaded from [the Apache git repository](https://git-wip-us.apache.org/repos/asf/tajo.git) as follows:
+The development codebase can also be downloaded from [the Apache git repository](https://github.com/apache/tajo.git) as follows:
 
 ```
-git clone https://git-wip-us.apache.org/repos/asf/tajo.git
+git clone https://github.com/apache/tajo.git
 ```
 
 A read-only git repository is also mirrored on [Github](https://github.com/apache/tajo).

--- a/tajo-project/src/site/markdown/source-code.md
+++ b/tajo-project/src/site/markdown/source-code.md
@@ -19,17 +19,17 @@
 
 ## Apache Git Repository
 
-The development codebase can also be downloaded from the [Apache git repository](https://git-wip-us.apache.org/repos/asf/tajo.git) at:
+The development codebase can also be downloaded from the [Apache git repository](https://github.com/apache/tajo.git) at:
 
 ```
-git clone https://git-wip-us.apache.org/repos/asf/tajo.git
+git clone https://github.com/apache/tajo.git
 ```
 
 ### Getting a Specific Branch or Tag
 If you want to get a specific branch or tagged source code, just add an option -b *branch or tag name* as follow:
 
 ```
-git clone -b [branch or tag name] https://git-wip-us.apache.org/repos/asf/tajo.git
+git clone -b [branch or tag name] https://github.com/apache/tajo.git
 ```
 
 You can see all available branch or tag lists at [here](https://git-wip-us.apache.org/repos/asf?p=tajo.git;a=tags).

--- a/tajo-project/src/site/markdown/source-code.md
+++ b/tajo-project/src/site/markdown/source-code.md
@@ -32,7 +32,8 @@ If you want to get a specific branch or tagged source code, just add an option -
 git clone -b [branch or tag name] https://github.com/apache/tajo.git
 ```
 
-You can see all available branch or tag lists at [here](https://git-wip-us.apache.org/repos/asf?p=tajo.git;a=tags).
+You can see all available [releases](https://github.com/apache/tajo/releases), 
+[branches](https://github.com/apache/tajo/branches), and [tags](https://github.com/apache/tajo/tags).
 
 ## Github
 

--- a/tajo-project/src/site/markdown/tajo-0.2.0-doc.md
+++ b/tajo-project/src/site/markdown/tajo-0.2.0-doc.md
@@ -98,7 +98,7 @@ Download the source code from http://tajo.apache.org/downloads.html.
 Download the source code and build Tajo as follows:
 
 ```
-$ git clone https://git-wip-us.apache.org/repos/asf/tajo.git tajo
+$ git clone https://github.com/apache/tajo.git tajo
 ```
 
 ## <a name="BuildSourceCode"></a>Build Source Code

--- a/tajo-project/src/site/markdown/tajo-0.8.0-doc.md
+++ b/tajo-project/src/site/markdown/tajo-0.8.0-doc.md
@@ -100,7 +100,7 @@ Download the source code from http://tajo.apache.org/downloads.html.
 Download the source code and build Tajo as follows:
 
 ```
-$ git clone https://git-wip-us.apache.org/repos/asf/tajo.git tajo
+$ git clone https://github.com/apache/tajo.git tajo
 ```
 
 ## <a name="BuildSourceCode"></a>Build Source Code
@@ -460,7 +460,7 @@ Tajo support HCatalogStore to integrate with hive. If you want to use HCatalogSt
 First, you must compile source code and get a binary archive as follows:
 
 ```
-$ git clone https://git-wip-us.apache.org/repos/asf/tajo.git tajo
+$ git clone https://github.com/apache/tajo.git tajo
 $ mvn clean package -DskipTests -Pdist -Dtar -Phcatalog-0.1x.0
 $ ls tajo-dist/target/tajo-0.8.0-SNAPSHOT.tar.gz
 ```

--- a/tajo-project/src/site/site.xml
+++ b/tajo-project/src/site/site.xml
@@ -173,7 +173,7 @@ window.onload = ga_event_load;
     </head>
 
     <links>
-      <item name="GIT" href="https://git-wip-us.apache.org/repos/asf/tajo.git" />
+      <item name="GIT" href="https://github.com/apache/tajo.git" />
     </links>
 
     <breadcrumbs>


### PR DESCRIPTION
This patch changes all git repositories URL to Apache Tajo Github repository. Since we started using the gitbox, the github repo can be used as the primary repository. For most of users, the github repo is one which has more accessibility.

This patch is also necessary to release the next version through Github branches.